### PR TITLE
sc2: Fixing some incorrect unlocks for Blood Hunter, Energizer, and Protoss Air Upgrades

### DIFF
--- a/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
@@ -4495,7 +4495,7 @@ void libABFE498B_gf_AP_Triggers_Protoss_unlockEnergizer (int lp_player) {
     // Implementation
     libABFE498B_gf_AP_Triggers_Protoss_unlockGateway(lp_player);
     TechTreeUnitAllow(lp_player, "AP_CyberneticsCore", true);
-    TechTreeUnitAllow(lp_player, "AP_SentryAiur", true);
+    TechTreeUnitAllow(lp_player, "AP_SentryPurifier", true);
     libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_GatewayFactionPurifier", 1);
 }
 
@@ -4558,7 +4558,7 @@ void libABFE498B_gf_AP_Triggers_Protoss_unlockBloodHunter (int lp_player) {
     // Implementation
     libABFE498B_gf_AP_Triggers_Protoss_unlockGateway(lp_player);
     TechTreeUnitAllow(lp_player, "AP_DarkShrine", true);
-    TechTreeUnitAllow(lp_player, "AP_DarkTemplarAiur", true);
+    TechTreeUnitAllow(lp_player, "AP_DarkTemplarTaldarim", true);
     libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_GatewayFactionTaldarim", 1);
 }
 
@@ -5033,7 +5033,6 @@ void libABFE498B_gf_AP_Triggers_Protoss_unlockAirWeapons (int lp_player, int lp_
     }
     else {
         if ((lp_level >= 1)) {
-            libABFE498B_gf_AP_Triggers_Protoss_unlockStargate(lp_player);
             TechTreeUnitAllow(lp_player, "AP_CyberneticsCore", true);
             TechTreeUpgradeAllow(lp_player, "AP_ProtossAirWeaponsLevel1", true);
             if ((lp_level >= 2)) {
@@ -5068,7 +5067,6 @@ void libABFE498B_gf_AP_Triggers_Protoss_unlockAirArmor (int lp_player, int lp_le
     }
     else {
         if ((lp_level >= 1)) {
-            libABFE498B_gf_AP_Triggers_Protoss_unlockStargate(lp_player);
             TechTreeUnitAllow(lp_player, "AP_CyberneticsCore", true);
             TechTreeUpgradeAllow(lp_player, "AP_ProtossAirArmorsLevel1", true);
             if ((lp_level >= 2)) {


### PR DESCRIPTION
See issues on the main AP repo, [#90 - energizer](https://github.com/Ziktofel/Archipelago/issues/90), [#95 - Blood Hunter](https://github.com/Ziktofel/Archipelago/issues/95), and [#88 - stargate unlock from air upgrades](https://github.com/Ziktofel/Archipelago/issues/88).

I tested the fixes by manually re-applying them to the triggers file after I did a `/download_data`, and checking I could build energizers and blood hunters with the items in my inventory. I did _not_ do extra checking for the stargate, though I still tested things loaded with the stargate changes applied to the trigger file.

I noticed when I copy-pasted the whole file that the triggers failed to initialize; I'm not sure why, I think it's related to other issues that are in the repo but aren't in the published triggers file.