### PR TITLE
Resource Efficiency Sentinel Upgrade added!

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -21307,9 +21307,9 @@
         <StationaryTurningRate value="999.8437"/>
         <TurningRate value="999.8437"/>
         <Sight value="9"/>
-        <Food value="-2"/>
+        <Food value="-3"/>
         <CostCategory value="Army"/>
-        <CostResource index="Minerals" value="100"/>
+        <CostResource index="Minerals" value="160"/>
         <AttackTargetPriority value="20"/>
         <DamageDealtXP value="1"/>
         <DamageTakenXP value="1"/>
@@ -21399,9 +21399,9 @@
         <StationaryTurningRate value="999.8437"/>
         <TurningRate value="999.8437"/>
         <Sight value="9"/>
-        <Food value="-2"/>
+        <Food value="-3"/>
         <CostCategory value="Army"/>
-        <CostResource index="Minerals" value="100"/>
+        <CostResource index="Minerals" value="160"/>
         <AttackTargetPriority value="20"/>
         <DamageDealtXP value="1"/>
         <DamageTakenXP value="1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -9126,5 +9126,12 @@
         <AffectedUnitArray value="AP_ValkyrieSCBW"/>
         <AffectedUnitArray value="AP_BrynhildFighter"/>
         <AffectedUnitArray value="AP_BrynhildAssault"/>
+    <CUpgrade id="AP_ResourceEfficiencySentinel">
+        <EffectArray Operation="Subtract" Reference="Unit,AP_ZealotPurifier,CostResource[Minerals]" Value="60"/>
+        <EffectArray Reference="Unit,AP_ZealotPurifier,Food" Value="1"/>
+        <EffectArray Operation="Subtract" Reference="Unit,AP_ZealotPurifierReviveCorpse,CostResource[Minerals]" Value="60"/>
+        <EffectArray Reference="Unit,AP_ZealotPurifierReviveCorpse,Food" Value="1"/>
+        <AffectedUnitArray value="AP_ZealotPurifier"/>
+        <AffectedUnitArray value="AP_ZealotPurifierReviveCorpse"/>
     </CUpgrade>
 </Catalog>

--- a/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
@@ -5266,6 +5266,7 @@ void libABFE498B_gf_AP_Triggers_giveProtossDefaultTech (int lp_player) {
     libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_AlarakStalkerPhasingArmor", 1);
     libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_VoidZealotWhirlwind", 1);
     libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_ResourceEfficiencyCenturion", 1);
+    libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_ResourceEfficiencySentinel", 1);
 }
 
 void libABFE498B_gf_AP_Triggers_replaceUpgrade (int lp_player, string lp_oldUpgrade, string lp_newUpgrade) {

--- a/Mods/ArchipelagoTriggers.SC2Mod/Triggers
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Triggers
@@ -45097,6 +45097,7 @@
             <FunctionCall Type="Comment" Library="ABFE498B" Id="CDAE262D"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="45EB03F1"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="99354651"/>
+            <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="F3AE087F"/>
         </Element>
         <Element Type="ParamDef" Id="56209DEA">
             <ParameterType>
@@ -45236,6 +45237,27 @@
         <Element Type="Param" Id="825EBAB0">
             <ParameterDef Type="ParamDef" Library="Ntve" Id="7E5035EE"/>
             <Value>AP_ResourceEfficiencyCenturion</Value>
+            <ValueType Type="gamelink"/>
+            <ValueGameType Type="Upgrade"/>
+        </Element>
+        <Element Type="FunctionCall" Id="F3AE087F">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="9F8EF8FB"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="69953D06"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="0461CF71"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="4427BD35"/>
+        </Element>
+        <Element Type="Param" Id="69953D06">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="C7188352"/>
+            <Parameter Type="ParamDef" Library="ABFE498B" Id="56209DEA"/>
+        </Element>
+        <Element Type="Param" Id="0461CF71">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="3BFEECBB"/>
+            <Value>1</Value>
+            <ValueType Type="int"/>
+        </Element>
+        <Element Type="Param" Id="4427BD35">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="7E5035EE"/>
+            <Value>AP_ResourceEfficiencySentinel</Value>
             <ValueType Type="gamelink"/>
             <ValueGameType Type="Upgrade"/>
         </Element>


### PR DESCRIPTION
Changes base Sentinel to 160 minerals and 3 supply! upgrade changes the cost and supply to 100 minerals and 2 supply. Is on by default.