### PR TITLE
Update unit selection priorities

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -168,7 +168,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="30"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkSentry"/>
@@ -249,7 +249,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Marine"/>
@@ -351,7 +351,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="125"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="4"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -480,7 +480,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="150"/>
         <ScoreKill value="225"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="15"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
         <GlossaryPriority value="40"/>
@@ -578,7 +578,7 @@
         <ScoreMake value="125"/>
         <ScoreKill value="125"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="15"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Marauder"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -723,7 +723,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="7"/>
+        <SubgroupPriority value="20"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Reaper"/>
@@ -969,7 +969,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TechAliasArray value="Alias_Hellion"/>
@@ -1140,7 +1140,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="75"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAIThink value="AIThinkVulture"/>
@@ -1229,7 +1229,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="200"/>
         <ScoreKill value="400"/>
-        <SubgroupPriority value="1"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.65"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -1322,7 +1322,7 @@
         <CargoSize value="4"/>
         <ScoreMake value="375"/>
         <ScoreKill value="750"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="15"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
         <GlossaryPriority value="120"/>
@@ -1414,7 +1414,7 @@
         <ScoreMake value="275"/>
         <ScoreKill value="275"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="SiegeTank"/>
@@ -1512,7 +1512,7 @@
         <InnerRadius value="0.875"/>
         <Footprint value="AP_FootprintSieged"/>
         <ScoreKill value="275"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="SiegeTankSieged"/>
@@ -1721,7 +1721,7 @@
         <SeparationRadius value="0.625"/>
         <ScoreMake value="400"/>
         <ScoreKill value="800"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="21"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -1816,7 +1816,7 @@
         <InnerRadius value="0.375"/>
         <CargoSize value="2"/>
         <ScoreKill value="225"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkVikingAssault"/>
@@ -1897,7 +1897,7 @@
         <ScoreMake value="225"/>
         <ScoreKill value="225"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkVikingFighter"/>
@@ -2012,7 +2012,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="11"/>
+        <SubgroupPriority value="30"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Banshee"/>
@@ -2106,7 +2106,7 @@
         <ScoreMake value="700"/>
         <ScoreKill value="700"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="40"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkBattleCruiser"/>
@@ -2236,7 +2236,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Ghost"/>
@@ -2426,7 +2426,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="500"/>
         <ScoreKill value="1000"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="SpecterUnit"/>
@@ -2536,7 +2536,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="10"/>
+        <SubgroupPriority value="35"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkThor"/>
@@ -2646,7 +2646,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="10"/>
+        <SubgroupPriority value="35"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkThor"/>
@@ -2993,7 +2993,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkRaven"/>
@@ -3079,7 +3079,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value=""/>
@@ -3157,7 +3157,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="21"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value=""/>
@@ -3289,7 +3289,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkLiberator"/>
@@ -3362,7 +3362,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkLiberatorAG"/>
@@ -3466,7 +3466,7 @@
         <SeparationRadius value="0.625"/>
         <ScoreMake value="400"/>
         <ScoreKill value="800"/>
-        <SubgroupPriority value="3"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -3528,7 +3528,7 @@
         <SeparationRadius value="0.625"/>
         <ScoreMake value="400"/>
         <ScoreKill value="800"/>
-        <SubgroupPriority value="3"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <SelectAlias value="AP_ValkyrieSCBW"/>
@@ -3607,7 +3607,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="200"/>
         <ScoreKill value="400"/>
-        <SubgroupPriority value="3"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.65"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <LeaderAlias value="AP_BrynhildFighter"/>
@@ -3843,7 +3843,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="19"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="SiegeTank"/>
@@ -3943,7 +3943,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="50"/>
         <ScoreKill value="100"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Marine"/>
@@ -4052,7 +4052,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="150"/>
         <ScoreKill value="225"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="15"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Firebat"/>
         <SelectAlias value="AP_Firebat"/>
@@ -4142,7 +4142,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="75"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="15"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Marauder"/>
         <SelectAlias value="AP_Marauder"/>
@@ -4228,7 +4228,7 @@
         <Radius value="0.6875"/>
         <SeparationRadius value="0.65"/>
         <CargoSize value="2"/>
-        <SubgroupPriority value="1"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.65"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <SelectAlias value="AP_Goliath"/>
@@ -4323,7 +4323,7 @@
         <CargoSize value="4"/>
         <ScoreMake value="350"/>
         <ScoreKill value="700"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="SiegeTank"/>
@@ -4415,7 +4415,7 @@
         <InnerRadius value="0.875"/>
         <Footprint value="AP_FootprintSieged"/>
         <ScoreKill value="700"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="SiegeTankSieged"/>
@@ -4518,7 +4518,7 @@
         <InnerRadius value="0.375"/>
         <CargoSize value="2"/>
         <ScoreKill value="400"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="WreckingCrewAssault"/>
@@ -4596,7 +4596,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="400"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="WreckingCrewFighter"/>
@@ -4702,7 +4702,7 @@
         <SeparationRadius value="0.75"/>
         <ScoreMake value="350"/>
         <ScoreKill value="700"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="30"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Banshee"/>
@@ -4811,7 +4811,7 @@
         <SeparationRadius value="1.25"/>
         <ScoreMake value="1200"/>
         <ScoreKill value="2400"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="40"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Battlecruiser"/>
@@ -8251,7 +8251,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="41"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Hero,ObjectFamily:Campaign"/>
         <TacticalAIThink value="AIThinkLeviathan"/>
@@ -8329,7 +8329,7 @@
         <ScoreMake value="175"/>
         <ScoreKill value="175"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
@@ -8579,7 +8579,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="500"/>
         <ScoreKill value="1000"/>
-        <SubgroupPriority value="99"/>
+        <SubgroupPriority value="98"/>
         <EditorCategories value="ObjectType:Hero,ObjectFamily:Campaign"/>
         <TechAliasArray value="Alias_Kerrigan"/>
         <GlossaryCategory value="Unit/Category/ZergCharacter"/>
@@ -8691,7 +8691,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="500"/>
         <ScoreKill value="1000"/>
-        <SubgroupPriority value="99"/>
+        <SubgroupPriority value="98"/>
         <EditorCategories value="ObjectType:Hero,ObjectFamily:Campaign"/>
         <HotkeyAlias value="K5Kerrigan"/>
         <TechAliasArray value="Alias_Kerrigan"/>
@@ -8799,7 +8799,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="500"/>
         <ScoreKill value="1000"/>
-        <SubgroupPriority value="99"/>
+        <SubgroupPriority value="98"/>
         <EditorCategories value="ObjectType:Hero,ObjectFamily:Campaign"/>
         <TechAliasArray value="Alias_Kerrigan"/>
         <KillDisplay value="Always"/>
@@ -8946,7 +8946,7 @@
         </CardLayouts>
         <Radius value="0.375"/>
         <InnerRadius value="0.375"/>
-        <SubgroupPriority value="66"/>
+        <SubgroupPriority value="20"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryPriority value="219"/>
         <GlossaryStrongArray value="VikingFighter"/>
@@ -8991,7 +8991,7 @@
         </CardLayouts>
         <Radius value="0.375"/>
         <InnerRadius value="0.375"/>
-        <SubgroupPriority value="66"/>
+        <SubgroupPriority value="20"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="InfestorTerran"/>
         <HotkeyAlias value="InfestorTerran"/>
@@ -9591,7 +9591,7 @@
         <CargoSize value="4"/>
         <ScoreMake value="400"/>
         <ScoreKill value="800"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
@@ -9646,7 +9646,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.75"/>
         <ScoreKill value="1600"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <LeaderAlias value="AP_InfestedAbomination"/>
@@ -9772,7 +9772,7 @@
         <ScoreMake value="75"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <GlossaryPriority value="170"/>
@@ -9844,7 +9844,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.625"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="AP_Impaler"/>
         <HotkeyAlias value="AP_Impaler"/>
@@ -9997,7 +9997,7 @@
         <ScoreMake value="450"/>
         <ScoreKill value="900"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Lurker"/>
@@ -10067,7 +10067,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.25"/>
         <ScoreKill value="900"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="LurkerBurrowed"/>
@@ -10355,7 +10355,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkHellionTank"/>
@@ -10940,7 +10940,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Infestor"/>
@@ -11021,7 +11021,7 @@
         <InnerRadius value="0.5"/>
         <CargoSize value="2"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="InfestorBurrowed"/>
@@ -11107,7 +11107,7 @@
         <ScoreMake value="600"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Carrier"/>
@@ -11190,7 +11190,7 @@
         <ScoreMake value="600"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="11"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Carrier"/>
@@ -11401,7 +11401,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="19"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Phoenix"/>
@@ -11486,7 +11486,7 @@
         <SeparationRadius value="0.75"/>
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="19"/>
         <MinimapRadius value="0.75"/>
         <LeaderAlias value="Phoenix"/>
         <SelectAlias value="Phoenix"/>
@@ -11827,7 +11827,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="15"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <GlossaryPriority value="130"/>
@@ -11902,7 +11902,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="84"/>
+        <SubgroupPriority value="21"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkCorruptor"/>
@@ -11960,7 +11960,7 @@
         </CardLayouts>
         <Radius value="0.375"/>
         <SeparationRadius value="0.375"/>
-        <SubgroupPriority value="108"/>
+        <SubgroupPriority value="8"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectFamily:Campaign,ObjectType:Unit"/>
         <TacticalAI value=""/>
@@ -12042,7 +12042,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="7"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.625"/>
         <SelectAlias value="Immortal"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
@@ -12133,7 +12133,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Immortal"/>
@@ -12220,7 +12220,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="35"/>
+        <SubgroupPriority value="40"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Immortal"/>
@@ -12317,7 +12317,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Immortal"/>
@@ -12408,7 +12408,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="10"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1"/>
         <SelectAlias value="Colossus"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
@@ -12491,7 +12491,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Colossus"/>
@@ -12582,7 +12582,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Colossus"/>
@@ -12733,7 +12733,7 @@
         <CargoSize value="4"/>
         <ScoreKill value="450"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
@@ -12827,7 +12827,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="6"/>
+        <SubgroupPriority value="25"/>
         <MinimapRadius value="0.375"/>
         <SelectAlias value="DarkTemplar"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
@@ -12914,7 +12914,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="25"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="DarkTemplar"/>
@@ -13009,7 +13009,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="25"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="DarkTemplar"/>
@@ -13100,7 +13100,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="25"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="DarkTemplar"/>
@@ -13647,7 +13647,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="75"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="14"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Baneling"/>
@@ -13731,7 +13731,7 @@
         <SeparationRadius value="0.375"/>
         <InnerRadius value="0.375"/>
         <ScoreKill value="75"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="14"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="BanelingBurrowed"/>
@@ -13876,7 +13876,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="13"/>
         <MinimapRadius value="0.3125"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAIThink value="AIThinkBaneling"/>
@@ -13957,7 +13957,7 @@
         <SeparationRadius value="0.3125"/>
         <InnerRadius value="0.3125"/>
         <ScoreKill value="300"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="13"/>
         <MinimapRadius value="0.3125"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAIThink value="AIThinkBaneling"/>
@@ -14561,7 +14561,7 @@
         </CardLayouts>
         <Radius value="1"/>
         <SeparationRadius value="1"/>
-        <SubgroupPriority value="30"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsAir"/>
@@ -14823,7 +14823,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkOracle"/>
@@ -14945,7 +14945,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="40"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkDisruptor"/>
@@ -15024,7 +15024,7 @@
         <CargoSize value="4"/>
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="40"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkDisruptorPhased"/>
@@ -15107,7 +15107,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="23"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkAdept"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
@@ -15176,7 +15176,7 @@
         <CargoSize value="2"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="22"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="Adept"/>
         <HotkeyAlias value="Adept"/>
@@ -15327,7 +15327,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="30"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <AIEvalFactor value="0"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
@@ -16991,7 +16991,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="19"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Queen"/>
@@ -17068,7 +17068,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.5"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="19"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="QueenBurrowed"/>
@@ -17855,7 +17855,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="6"/>
+        <SubgroupPriority value="4"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkSCV"/>
@@ -18146,7 +18146,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="119"/>
+        <SubgroupPriority value="40"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkRavager"/>
@@ -18201,7 +18201,7 @@
         <InnerRadius value="0.5"/>
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="119"/>
+        <SubgroupPriority value="40"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="AP_Ravager"/>
@@ -18583,7 +18583,7 @@
         <SeparationRadius value="1"/>
         <InnerRadius value="1"/>
         <CargoSize value="4"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <Mass value="0.6"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
@@ -18662,7 +18662,7 @@
         <Radius value="0.8125"/>
         <SeparationRadius value="0"/>
         <InnerRadius value="0.5"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="AP_SwarmHost"/>
         <HotkeyAlias value="AP_SwarmHost"/>
@@ -18740,7 +18740,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.5"/>
         <Footprint value="AP_FootprintSiegedSmall"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="AP_SwarmHost"/>
         <HotkeyAlias value="AP_SwarmHost"/>
@@ -18828,7 +18828,7 @@
         <ScoreMake value="175"/>
         <ScoreKill value="175"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="40"/>
+        <SubgroupPriority value="25"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
@@ -18913,7 +18913,7 @@
         <ScoreMake value="175"/>
         <ScoreKill value="175"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="25"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
@@ -19011,7 +19011,7 @@
         <ScoreMake value="175"/>
         <ScoreKill value="175"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="40"/>
+        <SubgroupPriority value="25"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
@@ -19281,7 +19281,7 @@
         </CardLayouts>
         <Radius value="0.75"/>
         <SeparationRadius value="0.75"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryStrongArray value="Battlecruiser"/>
@@ -19364,7 +19364,7 @@
         <InnerRadius value="0.5"/>
         <CargoSize value="2"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="140"/>
+        <SubgroupPriority value="25"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
@@ -19539,7 +19539,7 @@
         <ScoreMake value="600"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <Mass value="0.6"/>
@@ -19665,7 +19665,7 @@
         <InnerRadius value="0.375"/>
         <CargoSize value="2"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="104"/>
+        <SubgroupPriority value="5"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:FactionTaldarim"/>
         <TacticalAI value="Adept"/>
         <TacticalAIThink value="AIThinkAdept"/>
@@ -19802,7 +19802,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="30"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Sentry"/>
@@ -20652,7 +20652,7 @@
         </CardLayouts>
         <Radius value="0.75"/>
         <SeparationRadius value="0.75"/>
-        <SubgroupPriority value="121"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:FactionInfested"/>
         <TacticalAIThink value="AIThinkQueenClassic"/>
@@ -20842,7 +20842,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Ultralisk"/>
@@ -20941,7 +20941,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.75"/>
         <ScoreKill value="500"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="UltraliskBurrowed"/>
@@ -21078,7 +21078,7 @@
             <LayoutButtons Face="AP_VoidRayPrismaticAlignmentBase" Type="Passive" AbilCmd="AP_VoidRayVoidDamageBoost,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_VoidRayVoidPrismaticRange" Type="Passive" Row="2" Column="1"/>
         </CardLayouts>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="15"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <SelectAlias value="VoidRay"/>
         <HotkeyCategory value="Unit/Category/ProtossStory"/>
@@ -21089,7 +21089,7 @@
             <LayoutButtons Face="AP_VoidVoidRayBeamBounce" Type="Passive" Row="2" Column="0"/>
             <LayoutButtons Face="AP_DestroyerChargingBeam" Type="Passive" Requirements="AP_HaveDestroyerChargingBeam" Row="2" Column="1"/>
         </CardLayouts>
-        <SubgroupPriority value="10"/>
+        <SubgroupPriority value="15"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <SelectAlias value="VoidRay"/>
         <HotkeyCategory value="Unit/Category/ProtossStory"/>
@@ -21163,7 +21163,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkViper"/>
@@ -21408,7 +21408,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="40"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <Mass value="0.6"/>
@@ -22368,7 +22368,7 @@
         </CardLayouts>
         <Radius value="0.875"/>
         <SeparationRadius value="0.875"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.75"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
@@ -22661,7 +22661,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkDefilerSCBW"/>
@@ -22721,7 +22721,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="45"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="1.8"/>
@@ -22785,7 +22785,7 @@
         <CargoSize value="4"/>
         <ScoreMake value="225"/>
         <ScoreKill value="225"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectFamily:Campaign,ObjectType:Unit"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -1641,7 +1641,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="6"/>
+        <SubgroupPriority value="8"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="0.2"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -22,7 +22,7 @@
         <Radius value="0.375"/>
         <SeparationRadius value="0.375"/>
         <InnerRadius value="0.375"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Broodling"/>
@@ -351,7 +351,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="125"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -1025,7 +1025,7 @@
         </CardLayouts>
         <Radius value="0.125"/>
         <SeparationRadius value="0"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="0.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="SpiderMineVulture"/>
@@ -1075,7 +1075,7 @@
         </CardLayouts>
         <Radius value="0.125"/>
         <SeparationRadius value="0"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="0.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="SpiderMineVultureBurrowed"/>
@@ -4811,7 +4811,7 @@
         <SeparationRadius value="1.25"/>
         <ScoreMake value="1200"/>
         <ScoreKill value="2400"/>
-        <SubgroupPriority value="42"/>
+        <SubgroupPriority value="41"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Battlecruiser"/>
@@ -6432,7 +6432,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -9195,7 +9195,7 @@
         <InnerRadius value="0.375"/>
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -11557,7 +11557,7 @@
         <ScoreMake value="550"/>
         <ScoreKill value="550"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="1.5"/>
@@ -15327,7 +15327,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="31"/>
+        <SubgroupPriority value="30"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <AIEvalFactor value="0"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
@@ -16534,7 +16534,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="3"/>
+        <SubgroupPriority value="4"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
@@ -16596,7 +16596,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="4"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="0"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -6485,7 +6485,7 @@
         <SeparationRadius value="0.75"/>
         <ScoreMake value="50"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="12"/>
+        <SubgroupPriority value="3"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Campaign"/>
         <SelectAlias value="PerditionTurret"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -11401,7 +11401,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="7"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Phoenix"/>
@@ -11486,7 +11486,7 @@
         <SeparationRadius value="0.75"/>
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="7"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.75"/>
         <LeaderAlias value="Phoenix"/>
         <SelectAlias value="Phoenix"/>
@@ -20941,7 +20941,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.75"/>
         <ScoreKill value="500"/>
-        <SubgroupPriority value="6"/>
+        <SubgroupPriority value="8"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="UltraliskBurrowed"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -88,7 +88,7 @@
         <ScoreMake value="400"/>
         <ScoreKill value="400"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsAir"/>
@@ -249,7 +249,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="50"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Marine"/>
@@ -351,7 +351,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="125"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -480,7 +480,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="150"/>
         <ScoreKill value="225"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="18"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
         <GlossaryPriority value="40"/>
@@ -578,7 +578,7 @@
         <ScoreMake value="125"/>
         <ScoreKill value="125"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="18"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Marauder"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -723,7 +723,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Reaper"/>
@@ -969,7 +969,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TechAliasArray value="Alias_Hellion"/>
@@ -1140,7 +1140,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="75"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="15"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAIThink value="AIThinkVulture"/>
@@ -1229,7 +1229,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="200"/>
         <ScoreKill value="400"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="0.65"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -1322,7 +1322,7 @@
         <CargoSize value="4"/>
         <ScoreMake value="375"/>
         <ScoreKill value="750"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
         <GlossaryPriority value="120"/>
@@ -1414,7 +1414,7 @@
         <ScoreMake value="275"/>
         <ScoreKill value="275"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="SiegeTank"/>
@@ -1512,7 +1512,7 @@
         <InnerRadius value="0.875"/>
         <Footprint value="AP_FootprintSieged"/>
         <ScoreKill value="275"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="SiegeTankSieged"/>
@@ -1641,7 +1641,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="9"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="0.2"/>
@@ -1816,7 +1816,7 @@
         <InnerRadius value="0.375"/>
         <CargoSize value="2"/>
         <ScoreKill value="225"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkVikingAssault"/>
@@ -1897,7 +1897,7 @@
         <ScoreMake value="225"/>
         <ScoreKill value="225"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkVikingFighter"/>
@@ -2012,7 +2012,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="30"/>
+        <SubgroupPriority value="22"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Banshee"/>
@@ -2106,7 +2106,7 @@
         <ScoreMake value="700"/>
         <ScoreKill value="700"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="40"/>
+        <SubgroupPriority value="41"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkBattleCruiser"/>
@@ -3157,7 +3157,7 @@
         <ScoreMake value="300"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="21"/>
+        <SubgroupPriority value="22"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value=""/>
@@ -3222,7 +3222,7 @@
         <SeparationRadius value="1.5"/>
         <ScoreMake value="900"/>
         <ScoreKill value="1800"/>
-        <SubgroupPriority value="11"/>
+        <SubgroupPriority value="4"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -3289,7 +3289,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="23"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkLiberator"/>
@@ -3362,7 +3362,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="23"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkLiberatorAG"/>
@@ -3466,7 +3466,7 @@
         <SeparationRadius value="0.625"/>
         <ScoreMake value="400"/>
         <ScoreKill value="800"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="20"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -3528,7 +3528,7 @@
         <SeparationRadius value="0.625"/>
         <ScoreMake value="400"/>
         <ScoreKill value="800"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="20"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <SelectAlias value="AP_ValkyrieSCBW"/>
@@ -3607,7 +3607,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="200"/>
         <ScoreKill value="400"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="20"/>
         <MinimapRadius value="0.65"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <LeaderAlias value="AP_BrynhildFighter"/>
@@ -3684,7 +3684,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="4"/>
+        <SubgroupPriority value="7"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAIThink value="AIThinkWidowMine"/>
         <TechAliasArray value="Alias_WidowMine"/>
@@ -3755,7 +3755,7 @@
             <LayoutButtons Face="AP_HHWidowMineDeathBlossom" Type="Passive" Requirements="AP_HaveHHWidowMineDeathBlossom" Row="1" Column="3"/>
         </CardLayouts>
         <ScoreKill value="100"/>
-        <SubgroupPriority value="4"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAIThink value="AIThinkWidowMineBurrowed"/>
@@ -3843,7 +3843,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="SiegeTank"/>
@@ -3943,7 +3943,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="50"/>
         <ScoreKill value="100"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="18"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Marine"/>
@@ -4052,7 +4052,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="150"/>
         <ScoreKill value="225"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="18"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Firebat"/>
         <SelectAlias value="AP_Firebat"/>
@@ -4142,7 +4142,7 @@
         <CargoSize value="2"/>
         <ScoreMake value="75"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="18"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Marauder"/>
         <SelectAlias value="AP_Marauder"/>
@@ -4228,7 +4228,7 @@
         <Radius value="0.6875"/>
         <SeparationRadius value="0.65"/>
         <CargoSize value="2"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="0.65"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <SelectAlias value="AP_Goliath"/>
@@ -4323,7 +4323,7 @@
         <CargoSize value="4"/>
         <ScoreMake value="350"/>
         <ScoreKill value="700"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="SiegeTank"/>
@@ -4415,7 +4415,7 @@
         <InnerRadius value="0.875"/>
         <Footprint value="AP_FootprintSieged"/>
         <ScoreKill value="700"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="SiegeTankSieged"/>
@@ -4518,7 +4518,7 @@
         <InnerRadius value="0.375"/>
         <CargoSize value="2"/>
         <ScoreKill value="400"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="WreckingCrewAssault"/>
@@ -4596,7 +4596,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="400"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="18"/>
+        <SubgroupPriority value="17"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="WreckingCrewFighter"/>
@@ -4702,7 +4702,7 @@
         <SeparationRadius value="0.75"/>
         <ScoreMake value="350"/>
         <ScoreKill value="700"/>
-        <SubgroupPriority value="30"/>
+        <SubgroupPriority value="22"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Banshee"/>
@@ -4811,7 +4811,7 @@
         <SeparationRadius value="1.25"/>
         <ScoreMake value="1200"/>
         <ScoreKill value="2400"/>
-        <SubgroupPriority value="40"/>
+        <SubgroupPriority value="42"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Battlecruiser"/>
@@ -8329,7 +8329,7 @@
         <ScoreMake value="175"/>
         <ScoreKill value="175"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
@@ -8946,7 +8946,7 @@
         </CardLayouts>
         <Radius value="0.375"/>
         <InnerRadius value="0.375"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="7"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryPriority value="219"/>
         <GlossaryStrongArray value="VikingFighter"/>
@@ -8991,7 +8991,7 @@
         </CardLayouts>
         <Radius value="0.375"/>
         <InnerRadius value="0.375"/>
-        <SubgroupPriority value="20"/>
+        <SubgroupPriority value="7"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="InfestorTerran"/>
         <HotkeyAlias value="InfestorTerran"/>
@@ -9055,7 +9055,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.6875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>
@@ -9114,7 +9114,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.6875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="AP_HERC"/>
@@ -9591,7 +9591,7 @@
         <CargoSize value="4"/>
         <ScoreMake value="400"/>
         <ScoreKill value="800"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
@@ -9646,7 +9646,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.75"/>
         <ScoreKill value="1600"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <LeaderAlias value="AP_InfestedAbomination"/>
@@ -9772,7 +9772,7 @@
         <ScoreMake value="75"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="19"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <GlossaryPriority value="170"/>
@@ -9844,7 +9844,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.625"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="19"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="AP_Impaler"/>
         <HotkeyAlias value="AP_Impaler"/>
@@ -9997,7 +9997,7 @@
         <ScoreMake value="450"/>
         <ScoreKill value="900"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="19"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Lurker"/>
@@ -10067,7 +10067,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.25"/>
         <ScoreKill value="900"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="19"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="LurkerBurrowed"/>
@@ -10143,7 +10143,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="8"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Hydralisk"/>
         <AIEvalFactor value="2"/>
@@ -10209,7 +10209,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.375"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="16"/>
+        <SubgroupPriority value="8"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="HydraliskBurrowed"/>
         <LeaderAlias value="AP_Hydralisk"/>
@@ -10355,7 +10355,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="17"/>
+        <SubgroupPriority value="16"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkHellionTank"/>
@@ -10940,7 +10940,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="45"/>
+        <SubgroupPriority value="46"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Infestor"/>
@@ -11021,7 +11021,7 @@
         <InnerRadius value="0.5"/>
         <CargoSize value="2"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="45"/>
+        <SubgroupPriority value="46"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="InfestorBurrowed"/>
@@ -11107,7 +11107,7 @@
         <ScoreMake value="600"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Carrier"/>
@@ -11190,7 +11190,7 @@
         <ScoreMake value="600"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="1.25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Carrier"/>
@@ -11401,7 +11401,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Phoenix"/>
@@ -11486,7 +11486,7 @@
         <SeparationRadius value="0.75"/>
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="0.75"/>
         <LeaderAlias value="Phoenix"/>
         <SelectAlias value="Phoenix"/>
@@ -11827,7 +11827,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="10"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <GlossaryPriority value="130"/>
@@ -11960,7 +11960,7 @@
         </CardLayouts>
         <Radius value="0.375"/>
         <SeparationRadius value="0.375"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectFamily:Campaign,ObjectType:Unit"/>
         <TacticalAI value=""/>
@@ -12042,7 +12042,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.625"/>
         <SelectAlias value="Immortal"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
@@ -12133,7 +12133,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Immortal"/>
@@ -12220,7 +12220,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="40"/>
+        <SubgroupPriority value="34"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Immortal"/>
@@ -12317,7 +12317,7 @@
         <ScoreMake value="350"/>
         <ScoreKill value="350"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Immortal"/>
@@ -12408,7 +12408,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="1"/>
         <SelectAlias value="Colossus"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
@@ -12491,7 +12491,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Colossus"/>
@@ -12582,7 +12582,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Colossus"/>
@@ -12733,7 +12733,7 @@
         <CargoSize value="4"/>
         <ScoreKill value="450"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="33"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
@@ -12914,7 +12914,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="24"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="DarkTemplar"/>
@@ -13009,7 +13009,7 @@
         <ScoreMake value="250"/>
         <ScoreKill value="250"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="26"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="DarkTemplar"/>
@@ -13647,7 +13647,7 @@
         <ScoreMake value="50"/>
         <ScoreKill value="75"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Baneling"/>
@@ -13731,7 +13731,7 @@
         <SeparationRadius value="0.375"/>
         <InnerRadius value="0.375"/>
         <ScoreKill value="75"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="BanelingBurrowed"/>
@@ -13876,7 +13876,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="300"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.3125"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAIThink value="AIThinkBaneling"/>
@@ -13957,7 +13957,7 @@
         <SeparationRadius value="0.3125"/>
         <InnerRadius value="0.3125"/>
         <ScoreKill value="300"/>
-        <SubgroupPriority value="13"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.3125"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAIThink value="AIThinkBaneling"/>
@@ -14561,7 +14561,7 @@
         </CardLayouts>
         <Radius value="1"/>
         <SeparationRadius value="1"/>
-        <SubgroupPriority value="45"/>
+        <SubgroupPriority value="44"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsAir"/>
@@ -15327,7 +15327,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="30"/>
+        <SubgroupPriority value="31"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <AIEvalFactor value="0"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
@@ -16596,7 +16596,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="10"/>
+        <SubgroupPriority value="4"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="0"/>
@@ -16991,7 +16991,7 @@
         <ScoreMake value="150"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="30"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Queen"/>
@@ -17068,7 +17068,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.5"/>
         <ScoreKill value="150"/>
-        <SubgroupPriority value="19"/>
+        <SubgroupPriority value="30"/>
         <MinimapRadius value="0.875"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="QueenBurrowed"/>
@@ -17127,7 +17127,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="25"/>
         <ScoreKill value="50"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="7"/>
         <EditorCategories value="ObjectFamily:Campaign,ObjectType:Unit"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <GlossaryPriority value="450"/>
@@ -17178,7 +17178,7 @@
         <CargoSize value="1"/>
         <ScoreMake value="25"/>
         <ScoreKill value="50"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="7"/>
         <EditorCategories value="ObjectFamily:Campaign,ObjectType:Unit"/>
         <LeaderAlias value="PrimalZergling"/>
         <HotkeyAlias value="PrimalZergling"/>
@@ -17346,7 +17346,7 @@
         <ScoreMake value="75"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="7"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <GlossaryPriority value="465"/>
@@ -17414,7 +17414,7 @@
         <ScoreMake value="75"/>
         <ScoreKill value="150"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="7"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <LeaderAlias value="PrimalRoach"/>
         <HotkeyAlias value="PrimalRoach"/>
@@ -17941,7 +17941,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="7"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Roach"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
@@ -18025,7 +18025,7 @@
         <InnerRadius value="0.625"/>
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="7"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="RoachBurrowed"/>
         <LeaderAlias value="Roach"/>
@@ -18828,7 +18828,7 @@
         <ScoreMake value="175"/>
         <ScoreKill value="175"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="28"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
@@ -18913,7 +18913,7 @@
         <ScoreMake value="175"/>
         <ScoreKill value="175"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="28"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
@@ -19011,7 +19011,7 @@
         <ScoreMake value="175"/>
         <ScoreKill value="175"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="28"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
@@ -19281,7 +19281,7 @@
         </CardLayouts>
         <Radius value="0.75"/>
         <SeparationRadius value="0.75"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryStrongArray value="Battlecruiser"/>
@@ -19364,7 +19364,7 @@
         <InnerRadius value="0.5"/>
         <CargoSize value="2"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="25"/>
+        <SubgroupPriority value="28"/>
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
@@ -19539,7 +19539,7 @@
         <ScoreMake value="600"/>
         <ScoreKill value="600"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <Mass value="0.6"/>
@@ -20842,7 +20842,7 @@
         <ScoreMake value="500"/>
         <ScoreKill value="500"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="8"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Ultralisk"/>
@@ -20941,7 +20941,7 @@
         <SeparationRadius value="0"/>
         <InnerRadius value="0.75"/>
         <ScoreKill value="500"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="UltraliskBurrowed"/>
@@ -21078,7 +21078,7 @@
             <LayoutButtons Face="AP_VoidRayPrismaticAlignmentBase" Type="Passive" AbilCmd="AP_VoidRayVoidDamageBoost,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_VoidRayVoidPrismaticRange" Type="Passive" Row="2" Column="1"/>
         </CardLayouts>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <SelectAlias value="VoidRay"/>
         <HotkeyCategory value="Unit/Category/ProtossStory"/>
@@ -21089,7 +21089,7 @@
             <LayoutButtons Face="AP_VoidVoidRayBeamBounce" Type="Passive" Row="2" Column="0"/>
             <LayoutButtons Face="AP_DestroyerChargingBeam" Type="Passive" Requirements="AP_HaveDestroyerChargingBeam" Row="2" Column="1"/>
         </CardLayouts>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <SelectAlias value="VoidRay"/>
         <HotkeyCategory value="Unit/Category/ProtossStory"/>
@@ -21703,7 +21703,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Zealot"/>
@@ -21792,7 +21792,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Zealot"/>
@@ -21975,7 +21975,7 @@
         <ScoreMake value="25"/>
         <ScoreKill value="25"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Zergling"/>
@@ -22045,7 +22045,7 @@
         <Radius value="0.375"/>
         <SeparationRadius value="0"/>
         <ScoreKill value="25"/>
-        <SubgroupPriority value="8"/>
+        <SubgroupPriority value="7"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="ZerglingBurrowed"/>
@@ -22188,7 +22188,7 @@
         <ScoreMake value="100"/>
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="5"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Zealot"/>
@@ -22368,7 +22368,7 @@
         </CardLayouts>
         <Radius value="0.875"/>
         <SeparationRadius value="0.875"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="0.75"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
@@ -22464,7 +22464,7 @@
         </CardLayouts>
         <Radius value="1"/>
         <SeparationRadius value="1"/>
-        <SubgroupPriority value="14"/>
+        <SubgroupPriority value="5"/>
         <MinimapRadius value="1"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
@@ -22661,7 +22661,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="45"/>
+        <SubgroupPriority value="46"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkDefilerSCBW"/>
@@ -22721,7 +22721,7 @@
         <ScoreMake value="200"/>
         <ScoreKill value="200"/>
         <ScoreResult value="BuildOrder"/>
-        <SubgroupPriority value="45"/>
+        <SubgroupPriority value="46"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="1.8"/>
@@ -22785,7 +22785,7 @@
         <CargoSize value="4"/>
         <ScoreMake value="225"/>
         <ScoreKill value="225"/>
-        <SubgroupPriority value="15"/>
+        <SubgroupPriority value="6"/>
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectFamily:Campaign,ObjectType:Unit"/>
         <GlossaryCategory value="Unit/Category/AP_TerranUnits"/>


### PR DESCRIPTION
Changes to subgroup selection, in order to have the units more used higher and to remove oddities. Heroes->casters->damage abilties->utility->blink->form changes->rest.

https://docs.google.com/spreadsheets/d/1hObgY0_T7O94AOJ6wVCElEex-sE6JKQmIMsQO2oshpA/edit#gid=1122573492