### PR TITLE
Various Hotkey fixes

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -2706,8 +2706,11 @@
     </CAbilMorph>
     <CAbilAugment id="AP_Charge">
         <Alignment value="Negative"/>
+        <AbilSetId value="AP_Charge"/>
         <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
-        <CmdButtonArray index="Execute" DefaultButtonFace="Charge"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="Charge">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
         <Flags index="AutoCast" value="1"/>
         <Flags index="AutoCastOn" value="1"/>
         <AbilCmd value="attack,Execute"/>
@@ -3308,6 +3311,7 @@
         <CmdButtonArray index="Execute" DefaultButtonFace="AP_VoidStasis"/>
     </CAbilEffectTarget>
     <CAbilEffectTarget id="AP_DarkTemplarBlink">
+        <AbilSetId value="Blnk"/>
         <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
         <Range value="500"/>
         <!--Blink like Zeratul, Instead of Stalker-->
@@ -3317,7 +3321,6 @@
         <CmdButtonArray index="Execute" DefaultButtonFace="AP_DarkTemplarBlink" Requirements="AP_UseDarkTemplarBlink">
             <Flags index="ToSelection" value="1"/>
         </CmdButtonArray>
-        <AbilSetId value="Blnk"/>
         <Cost>
             <Cooldown TimeUse="20"/>
         </Cost>
@@ -3380,7 +3383,7 @@
         </CmdButtonArray>
     </CAbilEffectTarget>
     <CAbilEffectTarget id="AP_BlinkDummy">
-        <!-- Fummy Ability for CActorRange -->
+        <!-- Dummy Ability for CActorRange -->
         <!-- See Effect AP_Blink -->
         <Range value="8"/>
         <Arc value="360"/>
@@ -4270,8 +4273,11 @@
     </CAbilEffectTarget>
     <CAbilAugment id="AP_ShadowCharge">
         <Alignment value="Negative"/>
+        <AbilSetId value="AP_Charge"/>
         <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
-        <CmdButtonArray index="Execute" DefaultButtonFace="AP_VoidZealotShadowCharge"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_VoidZealotShadowCharge">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
         <Flags index="AutoCast" value="1"/>
         <Flags index="AutoCastOn" value="1"/>
         <AbilCmd value="attack,Execute"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -4700,8 +4700,9 @@
         <EditorCategories value="Race:Zerg"/>
     </CButton>
     <CButton id="AP_MuscularAugments">
-        <Icon value="Assets\Textures\btn-upgrade-zerg-muscularaugments.dds"/>
-        <AlertIcon value="Assets\Textures\btn-upgrade-zerg-muscularaugments.dds"/>
+        <Icon value="assets\textures\btn-upgrade-zerg-evolvemuscularaugments.dds"/>
+        <AlertIcon value="assets\textures\btn-upgrade-zerg-evolvemuscularaugments.dds"/>
+        <EditorCategories value="Race:Zerg"/>
     </CButton>
     <CButton id="AP_AdaptiveTalons">
         <Icon value="Assets\Textures\btn-upgrade-zerg-adaptivetalons.dds"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -543,7 +543,6 @@
         <AlertIcon value="Assets\Textures\btn-unit-terran-sciencevessel.dds"/>
         <Hotkey value="Button/Hotkey/AP_ScienceVessel"/>
         <EditorCategories value="Race:Terran"/>
-        <HotkeyAlias value=""/>
     </CButton>
     <CButton id="AP_Irradiate">
         <Icon value="assets\textures\btn-upgrade-swann-irradiate.dds"/>
@@ -651,7 +650,6 @@
         <Icon value="AP\Assets\Textures\btn-unit-terran-valkyrie@scbw.dds"/>
         <AlertIcon value="AP\Assets\Textures\btn-unit-terran-valkyrie@scbw.dds"/>
         <EditorCategories value="Race:Terran"/>
-        <HotkeyAlias value=""/>
         <DefaultButtonLayout Column="2"/>
     </CButton>
     <CButton id="AP_WidowMine">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -2015,6 +2015,7 @@
         <Icon value="Assets\Textures\btn-ability-protoss-psistorm-color.dds"/>
         <AlertIcon value="Assets\Textures\btn-ability-protoss-psistorm-color.dds"/>
         <EditorCategories value="Race:Protoss"/>
+        <Universal value="1"/>
     </CButton>
     <CButton id="AP_HighArchonPsiStorm">
         <Icon value="Assets\Textures\btn-ability-protoss-psistorm-color.dds"/>
@@ -2022,6 +2023,8 @@
         <EditorCategories value="Race:Protoss"/>
         <Tooltip value="Button/Tooltip/AP_PsiStorm"/>
         <AlertTooltip value="Button/Tooltip/AP_PsiStorm"/>
+        <HotkeyAlias value="AP_PsiStorm"/>
+        <Universal value="1"/>
     </CButton>
     <CButton id="AP_VoidHighTemplarCloak">
         <Icon value="AP\Assets\Textures\btn-ability-protoss-permanentlycloaked-hightemplar-nerazim.dds"/>
@@ -2048,14 +2051,19 @@
         <Icon value="Assets\Textures\btn-ability-protoss-blink-color.dds"/>
         <AlertIcon value="Assets\Textures\btn-ability-protoss-blink-color.dds"/>
         <EditorCategories value="Race:Protoss"/>
+        <Universal value="1"/>
     </CButton>
     <CButton id="AP_StalkerBlinkMultiple">
         <Icon value="Assets\Textures\BTN-Ability-Protoss-BlinkCharges.dds"/>
         <AlertIcon value="Assets\Textures\BTN-Ability-Protoss-BlinkCharges.dds"/>
+        <HotkeyAlias value="AP_Blink"/>
+        <Universal value="1"/>
     </CButton>
     <CButton id="AP_StalkerBlinkShieldRestoreBase">
         <Icon value="Assets\Textures\btn-ability-protoss-blink-color.dds"/>
         <AlertIcon value="Assets\Textures\btn-ability-protoss-blink-color.dds"/>
+        <HotkeyAlias value="AP_Blink"/>
+        <Universal value="1"/>
     </CButton>
     <CButton id="AP_BlinkShieldRestoreUpgrade">
         <Icon value="Assets\Textures\btn-ability-protoss-blinkshieldrestore.dds"/>
@@ -2369,6 +2377,8 @@
         <Icon value="Assets\Textures\btn-ability-protoss-blink-color.dds"/>
         <AlertIcon value="Assets\Textures\btn-ability-protoss-blink-color.dds"/>
         <EditorCategories value="Race:Protoss"/>
+        <HotkeySet value="AP_Blink"/>
+        <HotkeyAlias value="AP_Blink"/>
     </CButton>
     <CButton id="AP_HotSMetabolicBoost">
         <Icon value="Assets\Textures\btn-upgrade-zerg-hotsmetabolicboost.dds"/>
@@ -3044,6 +3054,8 @@
         <Icon value="Assets\Textures\BTN-Ability-Protoss-ShadowCharge.dds"/>
         <AlertIcon value="Assets\Textures\BTN-Ability-Protoss-ShadowCharge.dds"/>
         <EditorCategories value="Race:Protoss"/>
+        <HotkeyAlias value="AP_Charge"/>
+        <Universal value="1"/>
     </CButton>
     <CButton id="AP_VoidZealotShadowChargeStun">
         <Icon value="Assets\Textures\btn-upgrade-vorazun-shadowstun.dds"/>
@@ -4123,6 +4135,7 @@
         <Icon value="Assets\Textures\btn-ability-protoss-charge-color.dds"/>
         <AlertIcon value="Assets\Textures\btn-ability-protoss-charge-color.dds"/>
         <EditorCategories value="Race:Protoss"/>
+        <Universal value="1"/>
     </CButton>
     <CButton id="AP_ChargePredator">
         <Icon value="Assets\Textures\btn-ability-protoss-charge-color.dds"/>
@@ -4439,6 +4452,8 @@
     <CButton id="AP_DarkTemplarShadowDash">
         <Icon value="Assets\Textures\btn-ability-protoss-shadowdash.dds"/>
         <AlertIcon value="Assets\Textures\btn-ability-protoss-shadowdash.dds"/>
+        <HotkeyAlias value="AP_Blink"/>
+        <Universal value="1"/>
     </CButton>
     <CButton id="AP_DarkTemplarShadowGuardTraining">
         <Icon value="Assets\Textures\btn-ability-terran-heal-color.dds"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -18833,7 +18833,7 @@
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
         <SelectAlias value="Stalker"/>
-        <!--        <GlossaryCategory value="Unit/Category/ProtossUnits"/>-->
+        <!-- <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/> -->
         <GlossaryPriority value="30"/>
         <GlossaryStrongArray value="Reaper"/>
         <GlossaryStrongArray value="Mutalisk"/>
@@ -18841,7 +18841,7 @@
         <GlossaryWeakArray value="Marauder"/>
         <GlossaryWeakArray value="Zergling"/>
         <GlossaryWeakArray value="Immortal"/>
-        <!--        <HotkeyCategory value="Unit/Category/ProtossUnits"/>-->
+        <!-- <HotkeyCategory value="Unit/Category/AP_ProtossUnitsGround"/> -->
         <Fidget>
             <ChanceArray index="Anim" value="5"/>
             <ChanceArray index="Idle" value="90"/>
@@ -18917,10 +18917,8 @@
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
-        <LeaderAlias value="Stalker"/>
-        <HotkeyAlias value="Stalker"/>
+        <LeaderAlias value="AP_Stalker"/>
         <SelectAlias value="Stalker"/>
-        <SubgroupAlias value="Stalker"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <GlossaryPriority value="30"/>
         <GlossaryStrongArray value="Reaper"/>
@@ -19016,6 +19014,7 @@
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
         <SelectAlias value="Stalker"/>
+        <LeaderAlias value="AP_Stalker"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <GlossaryPriority value="30"/>
         <GlossaryStrongArray value="Reaper"/>
@@ -19369,6 +19368,7 @@
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
         <SelectAlias value="Stalker"/>
+        <LeaderAlias value="AP_Stalker"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <GlossaryPriority value="30"/>
         <GlossaryStrongArray value="Reaper"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -15331,7 +15331,7 @@
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <AIEvalFactor value="0"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
-        <GlossaryPriority value="120"/>
+        <GlossaryPriority value="25"/>
         <HotkeyCategory value="Unit/Category/AP_ProtossUnitsGround"/>
     </CUnit>
     <CUnit id="AP_KhaydarinMonolith">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -17667,12 +17667,13 @@
             <LayoutButtons Face="Cancel" Type="AbilCmd" AbilCmd="AP_StarportAddOns,Halt" Row="2" Column="4"/>
             <LayoutButtons Face="CancelBuilding" Type="AbilCmd" AbilCmd="BuildInProgress,Cancel" Row="2" Column="4"/>
             <LayoutButtons Face="AP_TechReactor" Type="AbilCmd" AbilCmd="AP_StarportAddOns,Build4" Row="2" Column="0"/>
-            <LayoutButtons Face="SelectBuilder" Type="SelectBuilder" AbilCmd="AP_StarportTrain,4" Row="1" Column="3"/>
             <LayoutButtons Face="AP_Wraith" Type="AbilCmd" AbilCmd="AP_StarportTrain,7" Row="1" Column="0"/>
             <LayoutButtons Face="AP_BuildHercules" Type="AbilCmd" AbilCmd="AP_StarportTrain,5" Row="1" Column="1"/>
             <LayoutButtons Face="AP_BuildScienceVessel" Type="AbilCmd" AbilCmd="AP_StarportTrain,6" Row="1" Column="2"/>
             <LayoutButtons Face="AP_ValkyrieSCBW" Type="AbilCmd" AbilCmd="AP_StarportTrain,9" Row="2" Column="2"/>
             <LayoutButtons Face="AP_Liberator" Type="AbilCmd" AbilCmd="AP_StarportTrain,8" Row="1" Column="3"/>
+            <!-- Note: put this last so it can be overridden in the hotkeys menu -->
+            <LayoutButtons Face="SelectBuilder" Type="SelectBuilder" AbilCmd="AP_StarportTrain,4" Row="1" Column="3"/>
         </CardLayouts>
         <Radius value="1.625"/>
         <SeparationRadius value="1.625"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -6966,7 +6966,6 @@
             <LayoutButtons Face="Cancel" Type="AbilCmd" AbilCmd="que5,CancelLast" Row="2" Column="4"/>
             <LayoutButtons Face="Cancel" Type="AbilCmd" AbilCmd="AP_FactoryAddOns,30" Row="2" Column="4"/>
             <LayoutButtons Face="CancelBuilding" Type="AbilCmd" AbilCmd="BuildInProgress,Cancel" Row="2" Column="4"/>
-            <LayoutButtons Face="SelectBuilder" Type="SelectBuilder" Row="1" Column="3"/>
             <LayoutButtons Face="AP_TechReactor" Type="AbilCmd" AbilCmd="AP_FactoryAddOns,3" Row="2" Column="0"/>
             <LayoutButtons Face="AP_Goliath" Type="AbilCmd" AbilCmd="AP_FactoryTrain,6" Row="1" Column="2"/>
             <LayoutButtons Face="AP_Diamondback" Type="AbilCmd" AbilCmd="AP_FactoryTrain,7" Row="1" Column="1"/>
@@ -6974,7 +6973,9 @@
             <LayoutButtons Face="AP_Predator" Type="AbilCmd" AbilCmd="AP_FactoryTrain,9" Row="0" Column="3"/>
             <LayoutButtons Face="AP_BuildCyclone" Type="AbilCmd" AbilCmd="AP_FactoryTrain,11" Row="1" Column="3"/>
             <LayoutButtons Face="AP_WidowMine" Type="AbilCmd" AbilCmd="AP_FactoryTrain,10" Row="0" Column="4"/>
-            <LayoutButtons Face="AP_WarHound" Type="AbilCmd" AbilCmd="AP_FactoryTrain,12" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_WarHound" Type="AbilCmd" AbilCmd="AP_FactoryTrain,12" Row="2" Column="2"/>
+            <!-- Note: put this last so it can be overridden in the hotkeys menu -->
+            <LayoutButtons Face="SelectBuilder" Type="SelectBuilder" Row="1" Column="3"/>
         </CardLayouts>
         <Radius value="1.625"/>
         <SeparationRadius value="1.625"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -17671,7 +17671,7 @@
             <LayoutButtons Face="AP_Wraith" Type="AbilCmd" AbilCmd="AP_StarportTrain,7" Row="1" Column="0"/>
             <LayoutButtons Face="AP_BuildHercules" Type="AbilCmd" AbilCmd="AP_StarportTrain,5" Row="1" Column="1"/>
             <LayoutButtons Face="AP_BuildScienceVessel" Type="AbilCmd" AbilCmd="AP_StarportTrain,6" Row="1" Column="2"/>
-            <LayoutButtons Face="AP_ValkyrieSCBW" Type="AbilCmd" AbilCmd="AP_StarportTrain,9" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_ValkyrieSCBW" Type="AbilCmd" AbilCmd="AP_StarportTrain,9" Row="2" Column="2"/>
             <LayoutButtons Face="AP_Liberator" Type="AbilCmd" AbilCmd="AP_StarportTrain,8" Row="1" Column="3"/>
         </CardLayouts>
         <Radius value="1.625"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameHotkeys.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameHotkeys.txt
@@ -222,6 +222,7 @@ Button/Hotkey/AP_NovaDomination=D
 Button/Hotkey/AP_NovaGadgetFlashBangGrenades=F
 Button/Hotkey/AP_NovaGadgetHolographicDecoy=E
 Button/Hotkey/AP_NovaGadgetPulseGrenades=G
+Button/Hotkey/AP_NovaNukeArm=V
 Button/Hotkey/AP_NovaReleaseMinion=N
 Button/Hotkey/AP_NovaWeaponBlazefireBladeSwap=B
 Button/Hotkey/AP_NovaWeaponCanisterRifleSnipe=Q


### PR DESCRIPTION
* Fixed instigators not appearing in the hotkeys menu
* Linked Stalker, Instigator, and Slayer blink hotkeys to always be the same
* Linked High Templar and Archon psi storm hotkeys to always be the same
* Linked Zealot and Centurion Charge hotkeys to always be the same
* Linked Zealot and Centurion charge abilities so ordering it will cause both unit types to charge (used to only command current sub-selection)
* Moved Build Valkyrie button to column 3 where it's visible without building icons
  * I swear [this is like the third time someone has asked how to build valkyries after unlocking them](https://discord.com/channels/731205301247803413/980554570075873300/1199940681628667935)
* Made sure all starport unit build buttons show up in the hotkeys menu
  * Empty HotkeyAlias tags on the Science Vessel and Valkyrie caused them to be hidden
  * Lowered the priority of Select building worker so it would stop hiding the liberator
    * Note this hotkey can still be changed by changing it on other buildings. This strategy of hiding the button is already in use on the Merc Compound (hidden by Death Heads)
* Added a hotkey for building a Nova Nuke from the Shadow Ops. I chose V for "noVa" (N is already in use for the regular nukes)
* Changed the glossary / hotkey menu position of the havoc to match the other sentries (used to live with the immortals)

This should address issue [#145](https://github.com/Ziktofel/Archipelago/issues/145)
![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/fd78614b-b037-4537-8b9b-6738bf57b696)
![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/fb7510a9-0c3b-4692-95b2-b6f280de6613)
![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/059a7edf-e90d-4ce3-b286-28b4c2d6e9cf)
