### PR TITLE
sc2: Stim fixes

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -222,17 +222,17 @@
         </CmdButtonArray>
     </CAbilEffectInstant>
     <CAbilEffectInstant id="AP_StimpackMarauder" parent="AP_StimpackLargeBase">
-        <CmdButtonArray index="Execute" DefaultButtonFace="StimMarauder" State="Restricted" Requirements="AP_UseStimpackMarauder">
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimLarge" State="Restricted" Requirements="AP_UseStimpackMarauder">
             <Flags index="ToSelection" value="1"/>
         </CmdButtonArray>
     </CAbilEffectInstant>
     <CAbilEffectInstant id="AP_StimpackFirebat" parent="AP_StimpackLargeBase">
-        <CmdButtonArray index="Execute" DefaultButtonFace="StimMarauder" State="Restricted" Requirements="AP_UseStimpackFirebat">
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimLarge" State="Restricted" Requirements="AP_UseStimpackFirebat">
             <Flags index="ToSelection" value="1"/>
         </CmdButtonArray>
     </CAbilEffectInstant>
     <CAbilEffectInstant id="AP_StimpackHellbat" parent="AP_StimpackLargeBase">
-        <CmdButtonArray index="Execute" DefaultButtonFace="StimMarauder" State="Restricted" Requirements="AP_UseStimpackHellbat">
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimLarge" State="Restricted" Requirements="AP_UseStimpackHellbat">
             <Flags index="ToSelection" value="1"/>
         </CmdButtonArray>
     </CAbilEffectInstant>
@@ -357,16 +357,56 @@
     <CAbilRedirectInstant id="AP_StimpackRedirect">
         <AbilSetId value="Stimpack"/>
         <Abil value="AP_Stimpack"/>
-        <CmdButtonArray index="Execute" DefaultButtonFace="StimRedirect" Requirements="UseStimpack">
-            <!-- TODO: verify this -->
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimRedirect">
             <Flags index="ToSelection" value="1"/>
         </CmdButtonArray>
     </CAbilRedirectInstant>
     <CAbilRedirectInstant id="AP_StimpackMarauderRedirect">
         <AbilSetId value="Stimpack"/>
         <Abil value="AP_StimpackMarauder"/>
-        <CmdButtonArray index="Execute" DefaultButtonFace="StimRedirect" Requirements="UseStimpack">
-            <!-- TODO: verify this -->
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimRedirect">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+    </CAbilRedirectInstant>
+    <CAbilRedirectInstant id="AP_StimpackFirebatRedirect">
+        <AbilSetId value="Stimpack"/>
+        <Abil value="AP_StimpackFirebat"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimRedirect">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+    </CAbilRedirectInstant>
+    <CAbilRedirectInstant id="AP_StimpackReaperRedirect">
+        <AbilSetId value="Stimpack"/>
+        <Abil value="AP_StimpackReaper"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimRedirect">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+    </CAbilRedirectInstant>
+    <CAbilRedirectInstant id="AP_SuperStimpackMarineRedirect">
+        <AbilSetId value="Stimpack"/>
+        <Abil value="AP_SuperStimpackMarine"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimRedirect">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+    </CAbilRedirectInstant>
+    <CAbilRedirectInstant id="AP_SuperStimpackMarauderRedirect">
+        <AbilSetId value="Stimpack"/>
+        <Abil value="AP_SuperStimpackMarauder"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimRedirect">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+    </CAbilRedirectInstant>
+    <CAbilRedirectInstant id="AP_SuperStimpackFirebatRedirect">
+        <AbilSetId value="Stimpack"/>
+        <Abil value="AP_SuperStimpackFirebat"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimRedirect">
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+    </CAbilRedirectInstant>
+    <CAbilRedirectInstant id="AP_SuperStimpackReaperRedirect">
+        <AbilSetId value="Stimpack"/>
+        <Abil value="AP_SuperStimpackReaper"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="AP_StimRedirect">
             <Flags index="ToSelection" value="1"/>
         </CmdButtonArray>
     </CAbilRedirectInstant>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -3035,6 +3035,14 @@
         <Icon value="Assets\Textures\btn-ability-terran-stimpack-color.dds"/>
         <AlertIcon value="Assets\Textures\btn-ability-terran-stimpack-color.dds"/>
         <EditorCategories value="Race:Terran"/>
+        <HotkeyAlias value="Stim"/>
+        <Universal value="1"/>
+    </CButton>
+    <CButton id="AP_StimLarge">
+        <Icon value="Assets\Textures\btn-ability-terran-stimpack-color.dds"/>
+        <AlertIcon value="Assets\Textures\btn-ability-terran-stimpack-color.dds"/>
+        <EditorCategories value="Race:Terran"/>
+        <HotkeyAlias value="Stim"/>
         <Universal value="1"/>
     </CButton>
     <CButton id="AP_VoidZealotWhirlwind">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -473,7 +473,7 @@
                 <Row value="1"/>
                 <Column value="4"/>
             </LayoutButtons>
-            <LayoutButtons Face="StimMarauder" Type="AbilCmd" AbilCmd="AP_StimpackFirebat,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimLarge" Type="AbilCmd" AbilCmd="AP_StimpackFirebat,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_SuperStimpackLarge" Type="AbilCmd" AbilCmd="AP_SuperStimpackFirebat,0" Row="2" Column="0"/>
         </CardLayouts>
         <InnerRadius value="0.4375"/>
@@ -568,7 +568,7 @@
             </LayoutButtons>
             <LayoutButtons Face="AP_LaserTargetingSystem" Type="Passive" Requirements="AP_HaveLaserTargetingSystemMarauder" Row="1" Column="2"/>
             <LayoutButtons Face="AP_JuggernautPlatingMarauder" Type="Passive" Requirements="AP_UseJuggernautPlatingMarauder" Row="1" Column="3"/>
-            <LayoutButtons Face="StimMarauder" Type="AbilCmd" AbilCmd="AP_StimpackMarauder,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimLarge" Type="AbilCmd" AbilCmd="AP_StimpackMarauder,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_SuperStimpackLarge" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarauder,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_MagrailMunitions" Type="AbilCmd" AbilCmd="AP_MagrailMunitionsMarauder,Execute" Row="2" Column="1"/>
         </CardLayouts>
@@ -956,7 +956,7 @@
                 <Column value="1"/>
             </LayoutButtons>
             <LayoutButtons Face="AP_NovaMultiTaskMAFServosHellion" Type="Passive" Requirements="AP_HaveMultiTaskMAFServosHellion" Row="1" Column="2"/>
-            <LayoutButtons Face="StimMarauder" Type="AbilCmd" AbilCmd="AP_StimpackHellbat,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimLarge" Type="AbilCmd" AbilCmd="AP_StimpackHellbat,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_SuperStimpackLarge" Type="AbilCmd" AbilCmd="AP_SuperStimpackHellbat,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_MorphToHellionTank" Type="AbilCmd" AbilCmd="AP_MorphToHellionTank,0" Row="2" Column="1"/>
             <LayoutButtons Face="AP_HellbatCharge" Type="Passive" Requirements="AP_HaveHoverHellbat" Row="1" Column="3"/>
@@ -3924,7 +3924,7 @@
             <LayoutButtons Face="MoveHoldPosition" Type="AbilCmd" AbilCmd="move,HoldPos" Row="0" Column="2"/>
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
             <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
-            <LayoutButtons Face="Stim" Type="AbilCmd" AbilCmd="AP_Stimpack,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_Stim" Type="AbilCmd" AbilCmd="AP_Stimpack,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_SuperStimpackSmall" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarine,0" Row="2" Column="0"/>
             <LayoutButtons>
                 <Face value="AP_CombatShield"/>
@@ -4045,7 +4045,7 @@
                 <Row value="1"/>
                 <Column value="4"/>
             </LayoutButtons>
-            <LayoutButtons Face="StimMarauder" Type="AbilCmd" AbilCmd="AP_StimpackFirebat,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimLarge" Type="AbilCmd" AbilCmd="AP_StimpackFirebat,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_SuperStimpackLarge" Type="AbilCmd" AbilCmd="AP_SuperStimpackFirebat,0" Row="2" Column="0"/>
         </CardLayouts>
         <InnerRadius value="0.4375"/>
@@ -4134,7 +4134,7 @@
             </LayoutButtons>
             <LayoutButtons Face="AP_LaserTargetingSystem" Type="Passive" Requirements="AP_HaveLaserTargetingSystemMarauder" Row="1" Column="2"/>
             <LayoutButtons Face="AP_JuggernautPlatingMarauder" Type="Passive" Requirements="AP_UseJuggernautPlatingMarauder" Row="1" Column="3"/>
-            <LayoutButtons Face="StimMarauder" Type="AbilCmd" AbilCmd="AP_StimpackMarauder,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimLarge" Type="AbilCmd" AbilCmd="AP_StimpackMarauder,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_SuperStimpackLarge" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarauder,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_MagrailMunitions" Type="AbilCmd" AbilCmd="AP_MagrailMunitionsMarauder,Execute" Row="2" Column="1"/>
         </CardLayouts>
@@ -6592,6 +6592,12 @@
         <AbilArray Link="Rally"/>
         <AbilArray Link="AP_StimpackRedirect"/>
         <AbilArray Link="AP_StimpackMarauderRedirect"/>
+        <AbilArray Link="AP_StimpackFirebatRedirect"/>
+        <AbilArray Link="AP_StimpackReaperRedirect"/>
+        <AbilArray Link="AP_SuperStimpackMarineRedirect"/>
+        <AbilArray Link="AP_SuperStimpackMarauderRedirect"/>
+        <AbilArray Link="AP_SuperStimpackFirebatRedirect"/>
+        <AbilArray Link="AP_SuperStimpackReaperRedirect"/>
         <AbilArray Link="AP_StopRedirect"/>
         <AbilArray Link="AP_AttackRedirect"/>
         <AbilArray Link="AP_healRedirect"/>
@@ -6605,8 +6611,14 @@
         <CardLayouts>
             <LayoutButtons Face="AttackRedirect" Type="AbilCmd" AbilCmd="AP_AttackRedirect,0" Row="0" Column="4"/>
             <LayoutButtons Face="Stop" Type="AbilCmd" AbilCmd="AP_StopRedirect,0" Row="0" Column="1"/>
+            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarineRedirect,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarauderRedirect,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackFirebatRedirect,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackReaperRedirect,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_StimpackRedirect,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_StimpackMarauderRedirect,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_StimpackFirebatRedirect,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_StimpackReaperRedirect,0" Row="2" Column="0"/>
             <LayoutButtons Face="SetBunkerRallyPoint" Type="AbilCmd" AbilCmd="Rally,Rally1" Row="1" Column="4"/>
             <LayoutButtons Face="BunkerLoad" Type="AbilCmd" AbilCmd="AP_BunkerTransport,0" Row="2" Column="1"/>
             <LayoutButtons Face="BunkerUnloadAll" Type="AbilCmd" AbilCmd="AP_BunkerTransport,1" Row="2" Column="2"/>
@@ -10344,7 +10356,7 @@
             <LayoutButtons Face="AP_NovaMultiTaskMAFServos" Type="Passive" Requirements="AP_HaveMultiTaskMAFServosHellion" Row="1" Column="2"/>
             <LayoutButtons Face="AP_MorphToHellion" Type="AbilCmd" AbilCmd="AP_MorphToHellion,0" Row="2" Column="2"/>
             <LayoutButtons Face="AP_HellbatCharge" Type="Passive" Requirements="AP_HaveHoverHellbat" Row="1" Column="3"/>
-            <LayoutButtons Face="StimMarauder" Type="AbilCmd" AbilCmd="AP_StimpackHellbat,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_StimLarge" Type="AbilCmd" AbilCmd="AP_StimpackHellbat,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_SuperStimpackLarge" Type="AbilCmd" AbilCmd="AP_SuperStimpackHellbat,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_HellArmor" Type="Passive" Requirements="AP_HaveHellbatHellArmor" Row="1" Column="4"/>
         </CardLayouts>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameHotkeys.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameHotkeys.txt
@@ -358,6 +358,7 @@ Button/Hotkey/AP_StalkerHallucination=S
 Button/Hotkey/AP_Stargate=S
 Button/Hotkey/AP_Starport=S
 Button/Hotkey/AP_Stim=T
+Button/Hotkey/AP_StimLarge=T
 Button/Hotkey/AP_StimRedirect=T
 Button/Hotkey/AP_StopPlanetaryFortress=P
 Button/Hotkey/AP_SuperStimpackLarge=T

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -1464,6 +1464,7 @@ Button/Name/AP_StalkerShakuras=Warp in Stalker
 Button/Name/AP_Stargate=Warp In Stargate
 Button/Name/AP_Starport=Build Starport
 Button/Name/AP_Stim=Stimpack
+Button/Name/AP_StimLarge=Stimpack
 Button/Name/AP_StimRedirect=Use Stimpack
 Button/Name/AP_StopPlanetaryFortress=Stop
 Button/Name/AP_SuperStimpackLarge=Super Stimpack
@@ -2461,8 +2462,9 @@ Button/Tooltip/AP_Stargate=Warps in Protoss air units.
 Button/Tooltip/AP_StargateWarp=Enables warp in of Protoss air units.
 Button/Tooltip/AP_Starport=Air-unit production facility. <n/><n/><c val="ffff8a">Enables:</c><n/>- Vikings<n/>- Medivacs
 Button/Tooltip/AP_StarportFlying=Starport must land to start unit production.
-Button/Tooltip/AP_Stim=Injects the unit with powerful stimulants that greatly increase attack and movement speeds for a few seconds. Injures the unit for 10 of the unit's life.
-Button/Tooltip/AP_StimRedirect=Orders Marines inside of the Bunker to use Stimpacks. They will take damage and have increased attack speed as normal.
+Button/Tooltip/AP_Stim=Injects the unit with powerful stimulants that greatly increase attack and movement speeds for a few seconds. Injures the unit for <d ref="Abil,AP_StimpackSmallBase,Cost[0].Vital[Life]"/> of the unit's life.
+Button/Tooltip/AP_StimLarge=Injects the unit with powerful stimulants that greatly increase attack and movement speeds for a few seconds. Injures the unit for <d ref="Abil,AP_StimpackLargeBase,Cost[0].Vital[Life]"/> of the unit's life.
+Button/Tooltip/AP_StimRedirect=Orders infantry inside of the Bunker to use Stimpacks. They will take damage and have increased attack speed as normal.
 Button/Tooltip/AP_StopPlanetaryFortress=Orders selected units to cancel all orders and stop moving.
 Button/Tooltip/AP_SuperStimpackLarge=Increases the unit's attack and movement speeds for <d ref="Behavior,AP_SuperStim,Duration"/> seconds. Heals the unit for <d ref="Effect,AP_SuperStimpackLargeSetMU,VitalArray[Life].Change"/> life.
 Button/Tooltip/AP_SuperStimpackNova=Increases Nova's attack speed and movement speeds by <d ref="Behavior,AP_SuperStimNova,Modification.AttackSpeedMultiplier *100-100"/>% for <d ref="Behavior,AP_SuperStimNova,Duration"/> seconds. Heals Nova for <d ref="Behavior,AP_SuperStimNova,Modification.VitalRegenArray[Life]*Behavior,AP_SuperStimNova,Duration"/> life over the effect's duration.


### PR DESCRIPTION
* All infantry can now use stim from bunkers
* Can use superstim from bunkers
* Updated buttons and descriptions

This should fix _some_ of the issues in issue [#11](https://github.com/Ziktofel/Archipelago/issues/11), though I haven't covered mind-controlled units in bunkers and I'm now fairly confident they _won't_ work.

### Changes
* Prior to my change, the "stim units in bunker" button would only appear if
  * `(marine stimpack && !(marine super stimpack)) || (marauder stimpack && !(marauder super stimpack)) && (any unit that can stim is in the bunker)`
* With my change, any AP infantry with stim or super-stim can be in the bunker and the button will appear
* I've set the super-stimpack behaviour to dominate, so it will allow enabling / disabling auto-cast if a superstim marine and normal-stim firebat are in the bunker together
* I've updated some stim abilities

### Understanding
* The bunker has a "stim redirect" button
* This button links to an ability, and only appears if a unit with an _exact_ match for that ability can execute it
* When clicked, it will send out the command for the `AbilSetId`, which means it can command a stim for all units despite their different abilities because they all link to the "Stimpack" `AbilSetId`
* To ensure the button is always available, 8 buttons are layered on the same slot, all referencing different abilities
* This pattern is pulled from blizzard's own liberty.sc2mod

This means that I don't think mind-controlled or vanilla marine or marauder stim will work with the AP bunker; we'd need to explicitly add a new redirect for all stim variants.

This same redirect pattern is also what's causing issue [#10](https://github.com/Ziktofel/Archipelago/issues/10) -- the attack command in the command-card is really a redirect to the containing units' attacks. We'd either need to add a new button or do a similar button-layering trick to make the attack command work as expected.
