### PR TITLE
sc2: Fixed swapped bonus objective locations in templar's charge

### DIFF
--- a/Maps/ArchipelagoCampaign/LotV/ap_templar_s_charge.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/LotV/ap_templar_s_charge.SC2Map/MapScript.galaxy
@@ -984,7 +984,7 @@ bool gt_WestHybridStatisChamber_Func (bool testConds, bool runActions) {
 //--------------------------------------------------------------------------------------------------
 void gt_WestHybridStatisChamber_Init () {
     gt_WestHybridStatisChamber = TriggerCreate("gt_WestHybridStatisChamber_Func");
-    TriggerAddEventUnitDied(gt_WestHybridStatisChamber, UnitRefFromVariable("gv_hybridCellUnits[1]"));
+    TriggerAddEventUnitDied(gt_WestHybridStatisChamber, UnitRefFromVariable("gv_hybridCellUnits[2]"));
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1005,7 +1005,7 @@ bool gt_SoutheastHybridStatisChamber_Func (bool testConds, bool runActions) {
 //--------------------------------------------------------------------------------------------------
 void gt_SoutheastHybridStatisChamber_Init () {
     gt_SoutheastHybridStatisChamber = TriggerCreate("gt_SoutheastHybridStatisChamber_Func");
-    TriggerAddEventUnitDied(gt_SoutheastHybridStatisChamber, UnitRefFromVariable("gv_hybridCellUnits[2]"));
+    TriggerAddEventUnitDied(gt_SoutheastHybridStatisChamber, UnitRefFromVariable("gv_hybridCellUnits[1]"));
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Maps/ArchipelagoCampaign/LotV/ap_templar_s_charge.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/LotV/ap_templar_s_charge.SC2Map/Triggers
@@ -835,7 +835,7 @@
         <Array Type="Param" Id="8DFFA166"/>
     </Element>
     <Element Type="Param" Id="8DFFA166">
-        <Value>1</Value>
+        <Value>2</Value>
         <ValueType Type="int"/>
     </Element>
     <Element Type="FunctionCall" Id="93A3CFAD">
@@ -878,7 +878,7 @@
         <Array Type="Param" Id="30D296AB"/>
     </Element>
     <Element Type="Param" Id="30D296AB">
-        <Value>2</Value>
+        <Value>1</Value>
         <ValueType Type="int"/>
     </Element>
     <Element Type="FunctionCall" Id="C93160F0">


### PR DESCRIPTION
Fixing the issue reported by BicolourSnake:
> Bug Report: on Templar's Charge, the southeast Stasis Chamber sent the West Stasis Chamber location.

It's a quick fix; looks like the indices of the HybridCellUnits array just got swapped in the triggers.