### PR TITLE
sc2: Used button instead of wireframe for signifier build button

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -3120,8 +3120,8 @@
         <Universal value="1"/>
     </CButton>
     <CButton id="AP_HighTemplarShakuras">
-        <Icon value="AP\Assets\Textures\wireframe-protoss-hightemplar-nerazim.dds"/>
-        <AlertIcon value="AP\Assets\Textures\wireframe-protoss-hightemplar-nerazim.dds"/>
+        <Icon value="AP\Assets\Textures\btn-unit-protoss-hightemplar-nerazim.dds"/>
+        <AlertIcon value="AP\Assets\Textures\btn-unit-protoss-hightemplar-nerazim.dds"/>
         <EditorCategories value="Race:Protoss"/>
         <HotkeyAlias value="AP_HighTemplar"/>
         <Hotkey value="Button/Hotkey/AP_HighTemplar"/>


### PR DESCRIPTION
Just noticed the signifier build button was using the wireframe instead of the build button. Noticed before but thought it was because there was no build button, but then I spotted it while looking into cloak icons.

New:
![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/4235819a-0f1b-4768-816f-ae396e043776)

Old:
![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/8c04514f-262c-43e1-9ff4-b8a05cbfad78)
