### PR TITLE
sc2: fix disruptor stats

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -14936,7 +14936,7 @@
         <StationaryTurningRate value="999.8437"/>
         <TurningRate value="999.8437"/>
         <Sight value="9"/>
-        <Food value="-4"/>
+        <Food value="-3"/>
         <CostCategory value="Army"/>
         <CostResource index="Minerals" value="150"/>
         <CostResource index="Vespene" value="150"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -14918,14 +14918,15 @@
         <Collide index="Ground" value="1"/>
         <Collide index="ForceField" value="1"/>
         <Collide index="Small" value="1"/>
-        <Attributes index="Light" value="1"/>
+        <Collide index="Locust" value="1"/>
+        <Attributes index="Armored" value="1"/>
         <Attributes index="Mechanical" value="1"/>
         <LifeStart value="100"/>
         <LifeMax value="100"/>
         <LifeArmor value="1"/>
         <LifeArmorName value="Unit/LifeArmorName/ProtossArmor"/>
-        <ShieldsStart value="150"/>
-        <ShieldsMax value="150"/>
+        <ShieldsStart value="100"/>
+        <ShieldsMax value="100"/>
         <ShieldRegenDelay value="10"/>
         <ShieldRegenRate value="2"/>
         <ShieldArmorName value="Unit/ShieldArmorName/ProtossPlasmaShields"/>
@@ -14938,7 +14939,7 @@
         <Food value="-4"/>
         <CostCategory value="Army"/>
         <CostResource index="Minerals" value="150"/>
-        <CostResource index="Vespene" value="300"/>
+        <CostResource index="Vespene" value="150"/>
         <AttackTargetPriority value="20"/>
         <DamageDealtXP value="1"/>
         <DamageTakenXP value="1"/>
@@ -14965,17 +14966,18 @@
         <ScoreKill value="100"/>
         <ScoreResult value="BuildOrder"/>
         <SubgroupPriority value="40"/>
-        <MinimapRadius value="0.375"/>
+        <MinimapRadius value="0.625"/>
+        <Radius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkDisruptor"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <GlossaryPriority value="135"/>
         <GlossaryStrongArray value="Marauder"/>
         <GlossaryStrongArray value="Hydralisk"/>
-        <GlossaryStrongArray value="Probe"/>
+        <GlossaryStrongArray value="Stalker"/>
         <GlossaryWeakArray value="Thor"/>
         <GlossaryWeakArray value="Ultralisk"/>
-        <GlossaryWeakArray value="Immortal"/>
+        <GlossaryWeakArray value="Tempest"/>
         <HotkeyCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <KillDisplay value="Always"/>
         <RankDisplay value="Always"/>


### PR DESCRIPTION
The current disruptor stats are woefully out-of-date and don't match any disruptor that has been in-game for many years. Updated the base unit's stats with what's in voidmulti.sc2mod's unitdata.xml