### PR TITLE
sc2: Unit feel fixes

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -4435,7 +4435,6 @@
         <AreaArray Radius="0.5" Effect="AP_RavagerCorrosiveBileSet"/>
         <AINotifyFlags index="HurtFriend" value="1"/>
         <AINotifyFlags index="HurtEnemy" value="1"/>
-        <AINotifyFlags index="MajorDanger" value="1"/>
     </CEffectEnumArea>
     <CEffectEnumArea id="AP_RavagerCorrosiveBileWarningDummySearch">
         <EditorCategories value="Race:Zerg"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -15049,7 +15049,6 @@
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAIThink value="AIThinkDisruptorPhased"/>
-        <AINotifyEffect value="AIPurificationNovaDanger"/>
         <GlossaryStrongArray value="Marauder"/>
         <GlossaryStrongArray value="Hydralisk"/>
         <GlossaryStrongArray value="Probe"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -18543,7 +18543,6 @@
         <FlagArray index="PreventDestroy" value="1"/>
         <FlagArray index="UseLineOfSight" value="1"/>
         <FlagArray index="AIThreatGround" value="1"/>
-        <FlagArray index="AIHighPrioTarget" value="1"/>
         <FlagArray index="AIPressForwardDisabled" value="1"/>
         <FlagArray index="ArmySelect" value="1"/>
         <PlaneArray index="Ground" value="1"/>
@@ -18631,7 +18630,6 @@
         <FlagArray index="Cloaked" value="1"/>
         <FlagArray index="Buried" value="1"/>
         <FlagArray index="AIThreatGround" value="1"/>
-        <FlagArray index="AIHighPrioTarget" value="1"/>
         <FlagArray index="AIPressForwardDisabled" value="1"/>
         <FlagArray index="ArmySelect" value="1"/>
         <PlaneArray index="Ground" value="1"/>
@@ -18704,7 +18702,6 @@
         <FlagArray index="PreventDestroy" value="1"/>
         <FlagArray index="UseLineOfSight" value="1"/>
         <FlagArray index="AIThreatGround" value="1"/>
-        <FlagArray index="AIHighPrioTarget" value="1"/>
         <FlagArray index="AIPressForwardDisabled" value="1"/>
         <FlagArray index="ArmySelect" value="1"/>
         <PlaneArray index="Ground" value="1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -29,10 +29,6 @@
         <Backswing value="1"/>
         <Effect value="AP_FirebatSet"/>
     </CWeaponLegacy>
-    <CWeaponLegacy id="Firebat">
-        <!-- Give the damage point buff to enemy firebats as well -->
-        <DamagePoint value="0"/>
-    </CWeaponLegacy>
     <CWeaponLegacy id="AP_PunisherGrenades">
         <EditorCategories value="Race:Terran"/>
         <Icon value="Assets\Textures\btn-upgrade-terran-infantryweaponslevel0.dds"/>
@@ -703,10 +699,6 @@
         <DamagePoint value="0"/>
         <Backswing value="1"/>
         <Effect value="AP_DevilDogSet"/>
-    </CWeaponLegacy>
-    <CWeaponLegacy id="DevilDogFlameThrower">
-        <!-- Give the damage point buff to enemy firebats as well -->
-        <DamagePoint value="0"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="AP_HammerSecurity">
         <EditorCategories value="Race:Terran"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -25,9 +25,13 @@
             <MatchFlags index="Id" value="1"/>
         </Marker>
         <Period value="1.4"/>
-        <DamagePoint value="0.5"/>
+        <DamagePoint value="0"/>
         <Backswing value="1"/>
         <Effect value="AP_FirebatSet"/>
+    </CWeaponLegacy>
+    <CWeaponLegacy id="Firebat">
+        <!-- Give the damage point buff to enemy firebats as well -->
+        <DamagePoint value="0"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="AP_PunisherGrenades">
         <EditorCategories value="Race:Terran"/>
@@ -696,9 +700,13 @@
             <MatchFlags index="Id" value="1"/>
         </Marker>
         <Period value="1.4"/>
-        <DamagePoint value="0.5"/>
+        <DamagePoint value="0"/>
         <Backswing value="1"/>
         <Effect value="AP_DevilDogSet"/>
+    </CWeaponLegacy>
+    <CWeaponLegacy id="DevilDogFlameThrower">
+        <!-- Give the damage point buff to enemy firebats as well -->
+        <DamagePoint value="0"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="AP_HammerSecurity">
         <EditorCategories value="Race:Terran"/>


### PR DESCRIPTION
* Set Firebat damage point to 0 ~~(applied this to enemies as well)~~
  * Mostly a gamefeel thing, the overall DPS is unchanged. Closing firebats just have to be focused slightly more to avoid damage
* AI no longer avoid disruptor shots
  * This felt way less jank. It actually made disruptors _less_ powerful vs hybrid, as they couldn't zone them out indefinitely with just 4 of them
  * Splash on own units now meant there was more risk to using them. With dodge behaviour, enemies would always run from your own units when sending out a nova
* AI no longer dodges corruptor shots
  * This fixes [#165](https://github.com/Ziktofel/Archipelago/issues/165)
* Changed AI behaviour around swarm hosts
  * Removed the AIHighPrioTarget flag -- this keeps the AI from beelining for them past armies or locusts
  * Testing, the AI was still willing to start attacking swarm hosts even with locusts around, though would have to get close enough so screening is important
  * Uprooting a swarm host causes attackers to look for another target (despite having same flags and attack priority)