### PR TITLE
sc2: Bunker superstim icons

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -943,6 +943,13 @@
         <HotkeyAlias value="Stim"/>
         <Universal value="1"/>
     </CButton>
+    <CButton id="AP_SuperStimRedirect">
+        <Icon value="Assets\Textures\btn-upgrade-terran-superstimppack.dds"/>
+        <AlertIcon value="Assets\Textures\btn-upgrade-terran-superstimppack.dds"/>
+        <EditorCategories value="Race:Terran"/>
+        <HotkeyAlias value="Stim"/>
+        <Universal value="1"/>
+    </CButton>
     <CButton id="AP_HellstormMissileBatteries">
         <Icon value="assets\textures\btn-ability-stetmann-corruptormissilebarrage.dds"/>
         <EditorCategories value="Race:Terran"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -6616,14 +6616,14 @@
         <CardLayouts>
             <LayoutButtons Face="AttackRedirect" Type="AbilCmd" AbilCmd="AP_AttackRedirect,0" Row="0" Column="4"/>
             <LayoutButtons Face="Stop" Type="AbilCmd" AbilCmd="AP_StopRedirect,0" Row="0" Column="1"/>
-            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarineRedirect,0" Row="2" Column="0"/>
-            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarauderRedirect,0" Row="2" Column="0"/>
-            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackFirebatRedirect,0" Row="2" Column="0"/>
-            <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackReaperRedirect,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_StimpackRedirect,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_StimpackMarauderRedirect,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_StimpackFirebatRedirect,0" Row="2" Column="0"/>
             <LayoutButtons Face="AP_StimRedirect" Type="AbilCmd" AbilCmd="AP_StimpackReaperRedirect,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_SuperStimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarineRedirect,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_SuperStimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarauderRedirect,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_SuperStimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackFirebatRedirect,0" Row="2" Column="0"/>
+            <LayoutButtons Face="AP_SuperStimRedirect" Type="AbilCmd" AbilCmd="AP_SuperStimpackReaperRedirect,0" Row="2" Column="0"/>
             <LayoutButtons Face="SetBunkerRallyPoint" Type="AbilCmd" AbilCmd="Rally,Rally1" Row="1" Column="4"/>
             <LayoutButtons Face="BunkerLoad" Type="AbilCmd" AbilCmd="AP_BunkerTransport,0" Row="2" Column="1"/>
             <LayoutButtons Face="BunkerUnloadAll" Type="AbilCmd" AbilCmd="AP_BunkerTransport,1" Row="2" Column="2"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -1469,6 +1469,7 @@ Button/Name/AP_Stim=Stimpack
 Button/Name/AP_StimLarge=Stimpack
 Button/Name/AP_StimRedirect=Use Stimpack
 Button/Name/AP_StopPlanetaryFortress=Stop
+Button/Name/AP_SuperStimRedirect=Use Stimpack
 Button/Name/AP_SuperStimpackLarge=Super Stimpack
 Button/Name/AP_SuperStimpackNova=Stim Infusion
 Button/Name/AP_SuperStimpackSmall=Super Stimpack
@@ -2471,6 +2472,7 @@ Button/Tooltip/AP_StimRedirect=Orders infantry inside of the Bunker to use Stimp
 Button/Tooltip/AP_StopPlanetaryFortress=Orders selected units to cancel all orders and stop moving.
 Button/Tooltip/AP_SuperStimpackLarge=Increases the unit's attack and movement speeds for <d ref="Behavior,AP_SuperStim,Duration"/> seconds. Heals the unit for <d ref="Effect,AP_SuperStimpackLargeSetMU,VitalArray[Life].Change"/> life.
 Button/Tooltip/AP_SuperStimpackNova=Increases Nova's attack speed and movement speeds by <d ref="Behavior,AP_SuperStimNova,Modification.AttackSpeedMultiplier *100-100"/>% for <d ref="Behavior,AP_SuperStimNova,Duration"/> seconds. Heals Nova for <d ref="Behavior,AP_SuperStimNova,Modification.VitalRegenArray[Life]*Behavior,AP_SuperStimNova,Duration"/> life over the effect's duration.
+Button/Tooltip/AP_SuperStimRedirect=Orders infantry inside of the Bunker to use Super Stimpacks. They will heal and have increased attack speed as normal.
 Button/Tooltip/AP_SuperStimpackSmall=Increases the unit's attack and movement speeds for <d ref="Behavior,AP_SuperStim,Duration"/> seconds. Heals the unit for <d ref="Effect,AP_SuperStimpackSmallSetMU,VitalArray[Life].Change"/> life.
 Button/Tooltip/AP_SuperiorWarpGates=Warp Gates can hold up to 3 charges.<n/><n/><c val ="#ColorAttackInfo">Passive Ability.<c/>
 Button/Tooltip/AP_SupplicantShieldRegeneration=Increases Shield regeneration.


### PR DESCRIPTION
Per Hopop's request in the discord:
> can we get the bunkers to use the super stim icon when the units inside have superstim?

If units with regular stimpack are mixed in, the regular stimpack icon will dominate

![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/a905d575-7ee0-4109-b0a9-97e4a1c34099)

https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/aa42d4f1-afcb-445c-ae03-931be3fc7cff

