### PR TITLE
sc2: Properly linking upgrade hotkeys to across levels

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -2269,13 +2269,13 @@
         <Icon value="Assets\Textures\BTN-Upgrade-Protoss-GroundArmorLevel2.dds"/>
         <AlertIcon value="Assets\Textures\BTN-Upgrade-Protoss-GroundArmorLevel2.dds"/>
         <EditorCategories value="Race:Protoss"/>
-        <HotkeyAlias value="ProtossGroundArmorLevel1"/>
+        <HotkeyAlias value="AP_ProtossGroundArmorLevel1"/>
     </CButton>
     <CButton id="AP_ProtossGroundArmorLevel3">
         <Icon value="Assets\Textures\BTN-Upgrade-Protoss-GroundArmorLevel3.dds"/>
         <AlertIcon value="Assets\Textures\BTN-Upgrade-Protoss-GroundArmorLevel3.dds"/>
         <EditorCategories value="Race:Protoss"/>
-        <HotkeyAlias value="ProtossGroundArmorLevel1"/>
+        <HotkeyAlias value="AP_ProtossGroundArmorLevel1"/>
     </CButton>
     <CButton id="AP_ProtossGroundWeaponsLevel1">
         <Icon value="Assets\Textures\BTN-Upgrade-Protoss-GroundWeaponsLevel1.dds"/>
@@ -2286,13 +2286,13 @@
         <Icon value="Assets\Textures\BTN-Upgrade-Protoss-GroundWeaponsLevel2.dds"/>
         <AlertIcon value="Assets\Textures\BTN-Upgrade-Protoss-GroundWeaponsLevel2.dds"/>
         <EditorCategories value="Race:Protoss"/>
-        <HotkeyAlias value="ProtossGroundWeaponsLevel1"/>
+        <HotkeyAlias value="AP_ProtossGroundWeaponsLevel1"/>
     </CButton>
     <CButton id="AP_ProtossGroundWeaponsLevel3">
         <Icon value="Assets\Textures\BTN-Upgrade-Protoss-GroundWeaponsLevel3.dds"/>
         <AlertIcon value="Assets\Textures\BTN-Upgrade-Protoss-GroundWeaponsLevel3.dds"/>
         <EditorCategories value="Race:Protoss"/>
-        <HotkeyAlias value="ProtossGroundWeaponsLevel1"/>
+        <HotkeyAlias value="AP_ProtossGroundWeaponsLevel1"/>
     </CButton>
     <CButton id="AP_ProtossShieldsLevel1">
         <Icon value="Assets\Textures\BTN-Upgrade-Protoss-ShieldsLevel1.dds"/>
@@ -2303,13 +2303,13 @@
         <Icon value="Assets\Textures\BTN-Upgrade-Protoss-ShieldsLevel2.dds"/>
         <AlertIcon value="Assets\Textures\BTN-Upgrade-Protoss-ShieldsLevel2.dds"/>
         <EditorCategories value="Race:Protoss"/>
-        <HotkeyAlias value="ProtossShieldsLevel1"/>
+        <HotkeyAlias value="AP_ProtossShieldsLevel1"/>
     </CButton>
     <CButton id="AP_ProtossShieldsLevel3">
         <Icon value="Assets\Textures\BTN-Upgrade-Protoss-ShieldsLevel3.dds"/>
         <AlertIcon value="Assets\Textures\BTN-Upgrade-Protoss-ShieldsLevel3.dds"/>
         <EditorCategories value="Race:Protoss"/>
-        <HotkeyAlias value="ProtossShieldsLevel1"/>
+        <HotkeyAlias value="AP_ProtossShieldsLevel1"/>
     </CButton>
     <CButton id="AP_SOAQuatro">
         <Icon value="Assets\Textures\btn-upgrade-protoss-groundweaponslevel3.dds"/>
@@ -2663,14 +2663,14 @@
         <Icon value="Assets\Textures\btn-upgrade-zerg-flyercarapace-level2.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-flyercarapace-level2.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zergflyerarmor1"/>
+        <HotkeyAlias value="AP_zergflyerarmor1"/>
         <Universal value="1"/>
     </CButton>
     <CButton id="AP_zergflyerarmor3">
         <Icon value="Assets\Textures\btn-upgrade-zerg-flyercarapace-level3.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-flyercarapace-level3.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zergflyerarmor1"/>
+        <HotkeyAlias value="AP_zergflyerarmor1"/>
         <Universal value="1"/>
     </CButton>
     <CButton id="AP_zergflyerattack1">
@@ -2683,14 +2683,14 @@
         <Icon value="Assets\Textures\btn-upgrade-zerg-airattacks-level2.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-airattacks-level2.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zergflyerattack1"/>
+        <HotkeyAlias value="AP_zergflyerattack1"/>
         <Universal value="1"/>
     </CButton>
     <CButton id="AP_zergflyerattack3">
         <Icon value="Assets\Textures\btn-upgrade-zerg-airattacks-level3.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-airattacks-level3.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zergflyerattack1"/>
+        <HotkeyAlias value="AP_zergflyerattack1"/>
         <Universal value="1"/>
     </CButton>
     <CButton id="AP_HydraliskLurkerPassive">
@@ -2847,13 +2847,13 @@
         <Icon value="Assets\Textures\btn-upgrade-zerg-groundcarapace-level2.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-groundcarapace-level2.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zerggroundarmor1"/>
+        <HotkeyAlias value="AP_zerggroundarmor1"/>
     </CButton>
     <CButton id="AP_zerggroundarmor3">
         <Icon value="Assets\Textures\btn-upgrade-zerg-groundcarapace-level3.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-groundcarapace-level3.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zerggroundarmor1"/>
+        <HotkeyAlias value="AP_zerggroundarmor1"/>
     </CButton>
     <CButton id="AP_zergmeleeweapons1">
         <Icon value="Assets\Textures\btn-upgrade-zerg-meleeattacks-level1.dds"/>
@@ -2864,13 +2864,13 @@
         <Icon value="Assets\Textures\btn-upgrade-zerg-meleeattacks-level2.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-meleeattacks-level2.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zergmeleeweapons1"/>
+        <HotkeyAlias value="AP_zergmeleeweapons1"/>
     </CButton>
     <CButton id="AP_zergmeleeweapons3">
         <Icon value="Assets\Textures\btn-upgrade-zerg-meleeattacks-level3.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-meleeattacks-level3.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zergmeleeweapons1"/>
+        <HotkeyAlias value="AP_zergmeleeweapons1"/>
     </CButton>
     <CButton id="AP_zergmissileweapons1">
         <Icon value="Assets\Textures\btn-upgrade-zerg-missileattacks-level1.dds"/>
@@ -2881,13 +2881,13 @@
         <Icon value="Assets\Textures\btn-upgrade-zerg-missileattacks-level2.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-missileattacks-level2.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zergmissileweapons1"/>
+        <HotkeyAlias value="AP_zergmissileweapons1"/>
     </CButton>
     <CButton id="AP_zergmissileweapons3">
         <Icon value="Assets\Textures\btn-upgrade-zerg-missileattacks-level3.dds"/>
         <AlertIcon value="Assets\Textures\btn-upgrade-zerg-missileattacks-level3.dds"/>
         <EditorCategories value="Race:Zerg"/>
-        <HotkeyAlias value="zergmissileweapons1"/>
+        <HotkeyAlias value="AP_zergmissileweapons1"/>
     </CButton>
     <CButton id="AP_BansheeSpeed">
         <Icon value="Assets\Textures\btn-upgrade-terran-hyperflightrotors.dds"/>


### PR DESCRIPTION
Rebinding the hotkeys on upgrades didn't properly apply to higher levels of the same upgrade. Fixed for evo chamber, spire, and forge. The Cybernetics Core uses the base (non-AP) button data for upgrades, so should have this issue.

![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/fb5d1f0a-48fe-45bc-a487-1aa57eff18cd)
