### PR TITLE
sc2: Removed rock icons with MindHawk's recommended change

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/GameUIData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/GameUIData.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Catalog>
+    <CGameUI id="Dflt">
+        <ObjectGroupData index="0" removed="1"/>
+        <ObjectGroupData index="1" removed="1"/>
+    </CGameUI>
+</Catalog>


### PR DESCRIPTION
Big thanks to MindHawk for explaining in the discord how to fix this:

https://discord.com/channels/731205301247803413/980554570075873300/1224532701978300509
(2024-04-01)

This fixes one of the issues he posted on ap-sc2-data issue [#111](https://github.com/Ziktofel/Archipelago-SC2-data/issues/111)

## Tested on Trains
![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/665c675e-c60a-44dd-8230-aaa64b996608)

This position would normally have 2 rock icons on it without the fix