### PR TITLE
sc2: Gave Kerrigan better lighting

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/LightData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/LightData.xml
@@ -1305,26 +1305,22 @@
         <EditorCategories value="LightGroup:PortraitsUnitsZerg"/>
     </CLight>
     <CLight id="AP_KerriganGhostPortrait">
-        <ToDInfoArray index="0">
-            <Id value="CLight"/>
-            <AmbientColor value="0.231373,0.176471,0.235294"/>
-            <OperatorHDR value="3"/>
-            <TerrainUseBackLight value="1"/>
+        <ToDInfoArray index="0" Id="NoLight" AmbientColor="0.231373,0.176471,0.235294" OperatorHDR="3">
             <Param index="HDRExposure" value="1.475000"/>
-            <Param index="HDRWhitePoint" value="1.850000"/>
-            <Param index="HDRGain" value="1.000000"/>
-            <Param index="HDRScale" value="1.000000"/>
-            <Param index="TerrainSpecularExp" value="34.330002"/>
-            <Param index="TerrainHDRDiffuse" value="0.900000"/>
-            <Param index="TerrainHDRSpecular" value="2.410000"/>
-            <Param index="CreepHDRSpecMultiplier" value="0.800000"/>
+            <Param index="HDRGain" value="0.000000"/>
+            <Param index="HDRScale" value="0.000000"/>
             <Param index="AOOcclusionRadius" value="1.000000"/>
             <Param index="AONoOcclusion" value="0.900000"/>
             <Param index="AOOcclusionPower" value="2.000000"/>
             <Param index="AODetailOcclusionRadius" value="0.010000"/>
             <Param index="AODetailNoOcclusion" value="0.060000"/>
             <Param index="AODetailOcclusionPower" value="4.000000"/>
-            <DirectionalLight index="Key" Color="0.992157,0.772549,0.654902" SpecColorMultiplier="1.884000" Direction="-0.845491,0.518524,-0.127584"/>
+            <DirectionalLight index="Key">
+                <Color value="0.992157,0.772549,0.654902"/>
+                <ColorMultiplier value="1.000000"/>
+                <SpecColorMultiplier value="1.884000"/>
+                <Direction value="-0.845491,0.518524,-0.127584"/>
+            </DirectionalLight>
             <DirectionalLight index="Fill" Color="0.000000,0.509804,1.000000" ColorMultiplier="2.018000" Direction="0.616434,-0.770537,-0.162121"/>
             <DirectionalLight index="Back" Color="1.000000,0.839216,0.662745" ColorMultiplier="0.260000" Direction="0.747741,0.507783,0.427831"/>
         </ToDInfoArray>


### PR DESCRIPTION
Updated Ghost Kerrigan's portrait lighting to match vanilla HotS campaign (swarm.sc2campaign). This resolves an item within MindHawk's compiled bug reports (#111 ). There may be other light objects that are different from vanilla, I did not check anything else.

Kerrigan is no longer talking with that weird Chancellor guy. Never even heard of Darth Infestis, and frankly not interested.

![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/9c68910a-686f-4b2f-a00a-ad90d7a227ed)
