### PR TITLE
Fix Corsair damage effect filter

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -10531,7 +10531,7 @@
         <Amount value="5"/>
         <AreaArray Radius="1.25" Fraction="1"/>
         <ExcludeArray Value="Target"/>
-        <SearchFilters value="Air,Visible;Player,Ally,Neutral"/>
+        <SearchFilters value="Air,Visible;Player,Ally,Neutral,Missile,Item,Stasis,Dead,Hidden,Invulnerable"/>
     </CEffectDamage>
     <CEffectCreatePersistent id="AP_ScoutMPAir">
         <EditorCategories value="Race:Protoss"/>


### PR DESCRIPTION
Corsair weapon shouldn't destroy missiles, invulnerable units, or transported units anymore.