### PR TITLE
Adding cancel-build button to Ultralisk Cavern

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -21843,6 +21843,7 @@
             <LayoutButtons Face="AP_UltraliskTorrasquePassive" Type="Passive" Requirements="AP_HaveHotSTorrasque" Row="1" Column="0"/>
             <LayoutButtons Face="AP_UltraliskNoxiousPassive" Type="Passive" Requirements="AP_HaveHotSNoxious" Row="1" Column="0"/>
             <LayoutButtons Face="AP_UltraliskPassive" Type="Passive" Row="1" Column="0"/>
+            <LayoutButtons Face="CancelBuilding" Type="AbilCmd" AbilCmd="BuildInProgress,Cancel" Row="2" Column="4"/>
         </CardLayouts>
         <Radius value="1.5"/>
         <SeparationRadius value="1.5"/>


### PR DESCRIPTION
Ultralisk Cavern was unable to be cancelled once building started; this PR adds the missing button back in. Tested and confirmed functional.