### PR TITLE
sc2: Fixing Warp robo/stargate validators so Karax production boost works properly on salvation

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -2933,18 +2933,9 @@
         <CombineArray value="AP_IsVanillaStargate"/>
         <CombineArray value="AP_IsAPStargate"/>
     </CValidatorCombine>
-    <CValidatorUnitType id="AP_IsVanillaStargateWarp">
-        <Value value="StargateWarp"/>
-    </CValidatorUnitType>
     <CValidatorUnitType id="AP_IsAPStargateWarp">
         <Value value="AP_StargateWarp"/>
     </CValidatorUnitType>
-    <CValidatorCombine id="IsStargateWarp" parent="CValidatorCombine">
-        <!-- Used by Karax's Prodigal Engineer on Salvation -->
-        <!-- Override -->
-        <CombineArray value="AP_IsVanillaStargateWarp"/>
-        <CombineArray value="AP_IsAPStargateWarp"/>
-    </CValidatorCombine>
     <CValidatorUnitType id="AP_IsVanillaRoboticsFacility">
         <Value value="RoboticsFacility"/>
     </CValidatorUnitType>
@@ -2959,15 +2950,6 @@
     <CValidatorUnitType id="AP_IsAPRoboticsFacilityWarp">
         <Value value="AP_RoboticsFacilityWarp"/>
     </CValidatorUnitType>
-    <CValidatorUnitType id="AP_IsVanillaRoboticsFacilityWarp">
-        <Value value="RoboticsFacilityWarp"/>
-    </CValidatorUnitType>
-    <CValidatorCombine id="IsRoboticsFacilityWarp" parent="CValidatorCombine">
-        <!-- Used by Karax's Prodigal Engineer on Salvation -->
-        <!-- Override -->
-        <CombineArray value="AP_IsVanillaRoboticsFacilityWarp"/>
-        <CombineArray value="AP_IsAPRoboticsFacilityWarp"/>
-    </CValidatorCombine>
     <CValidatorPlayerRequirement id="AP_HaveSOARadar">
         <Value value="AP_HaveSOARadar"/>
         <Find value="1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -2919,15 +2919,9 @@
     </CValidatorPlayerRequirement>
     <CValidatorCombine id="TimewarpProduction">
         <!-- Override -->
-        <CombineArray value="AP_IsStargateWarp"/>
-        <CombineArray value="AP_IsRoboticsFacilityWarp"/>
+        <CombineArray value="AP_IsAPStargateWarp"/>
+        <CombineArray value="AP_IsAPRoboticsFacilityWarp"/>
     </CValidatorCombine>
-    <CValidatorUnitType id="AP_IsStargateWarp">
-        <Value value="AP_StargateWarp"/>
-    </CValidatorUnitType>
-    <CValidatorUnitType id="AP_IsRoboticsFacilityWarp">
-        <Value value="AP_RoboticsFacilityWarp"/>
-    </CValidatorUnitType>
     <CValidatorUnitType id="AP_IsVanillaStargate">
         <Value value="Stargate"/>
     </CValidatorUnitType>
@@ -2939,6 +2933,18 @@
         <CombineArray value="AP_IsVanillaStargate"/>
         <CombineArray value="AP_IsAPStargate"/>
     </CValidatorCombine>
+    <CValidatorUnitType id="AP_IsVanillaStargateWarp">
+        <Value value="StargateWarp"/>
+    </CValidatorUnitType>
+    <CValidatorUnitType id="AP_IsAPStargateWarp">
+        <Value value="AP_StargateWarp"/>
+    </CValidatorUnitType>
+    <CValidatorCombine id="IsStargateWarp" parent="CValidatorCombine">
+        <!-- Used by Karax's Prodigal Engineer on Salvation -->
+        <!-- Override -->
+        <CombineArray value="AP_IsVanillaStargateWarp"/>
+        <CombineArray value="AP_IsAPStargateWarp"/>
+    </CValidatorCombine>
     <CValidatorUnitType id="AP_IsVanillaRoboticsFacility">
         <Value value="RoboticsFacility"/>
     </CValidatorUnitType>
@@ -2949,6 +2955,18 @@
         <!-- Override -->
         <CombineArray value="AP_IsVanillaRoboticsFacility"/>
         <CombineArray value="AP_IsAPRoboticsFacility"/>
+    </CValidatorCombine>
+    <CValidatorUnitType id="AP_IsAPRoboticsFacilityWarp">
+        <Value value="AP_RoboticsFacilityWarp"/>
+    </CValidatorUnitType>
+    <CValidatorUnitType id="AP_IsVanillaRoboticsFacilityWarp">
+        <Value value="RoboticsFacilityWarp"/>
+    </CValidatorUnitType>
+    <CValidatorCombine id="IsRoboticsFacilityWarp" parent="CValidatorCombine">
+        <!-- Used by Karax's Prodigal Engineer on Salvation -->
+        <!-- Override -->
+        <CombineArray value="AP_IsVanillaRoboticsFacilityWarp"/>
+        <CombineArray value="AP_IsAPRoboticsFacilityWarp"/>
     </CValidatorCombine>
     <CValidatorPlayerRequirement id="AP_HaveSOARadar">
         <Value value="AP_HaveSOARadar"/>
@@ -4394,11 +4412,11 @@
     </CValidatorCombine>
     <CValidatorCombine id="AP_IsAPRoboLike">
         <CombineArray value="AP_IsAPRoboticsFacility"/>
-        <CombineArray value="AP_IsRoboticsFacilityWarp"/>
+        <CombineArray value="AP_IsAPRoboticsFacilityWarp"/>
     </CValidatorCombine>
     <CValidatorCombine id="AP_IsAPStargateLike">
         <CombineArray value="AP_IsAPStargate"/>
-        <CombineArray value="AP_IsStargateWarp"/>
+        <CombineArray value="AP_IsAPStargateWarp"/>
     </CValidatorCombine>
     <CValidatorUnitCompareBehaviorCount id="AP_IsSupplicantWarpingIn">
         <Compare value="GT"/>

--- a/Mods/ArchipelagoPlayerLotV.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayerLotV.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Catalog>
+    <CValidatorUnitType id="AP_IsVanillaStargateWarp">
+        <Value value="StargateWarp"/>
+    </CValidatorUnitType>
+    <CValidatorCombine id="IsStargateWarp" parent="CValidatorCombine">
+        <!-- Used by Karax's Prodigal Engineer on Salvation -->
+        <!-- Override -->
+        <CombineArray value="AP_IsVanillaStargateWarp"/>
+        <CombineArray value="AP_IsAPStargateWarp"/>
+    </CValidatorCombine>
+    <CValidatorUnitType id="AP_IsVanillaRoboticsFacilityWarp">
+        <Value value="RoboticsFacilityWarp"/>
+    </CValidatorUnitType>
+    <CValidatorCombine id="IsRoboticsFacilityWarp" parent="CValidatorCombine">
+        <!-- Used by Karax's Prodigal Engineer on Salvation -->
+        <!-- Override -->
+        <CombineArray value="AP_IsVanillaRoboticsFacilityWarp"/>
+        <CombineArray value="AP_IsAPRoboticsFacilityWarp"/>
+    </CValidatorCombine>
+</Catalog>


### PR DESCRIPTION
Karax's production boost aura doesn't work on warp robotics facilities and warp stargates. This PR fixes that.

## Credits
Issue reported by Timo here: https://discord.com/channels/731205301247803413/980554570075873300/1251054899601346661

Also thanks to Ferin for doing a quick sanity test.

## Testing
Did a quick test to verify it works. Notice the behaviour icons are now visible on the warp buildings (wasn't there before):

![Screenshot2024-06-14 00_14_32](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/dbf03a6d-14a6-44b3-96fa-aa65dc0f7a16)

![Screenshot2024-06-14 00_14_34](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/6cb88c6b-e0c8-48be-9aa9-8dd450b542b9)



