### PR TITLE
sc2: Opened and saved APCoreMod to fix broken triggers file

### DIFF
--- a/Mods/ArchipelagoCore.SC2Mod/Triggers
+++ b/Mods/ArchipelagoCore.SC2Mod/Triggers
@@ -9820,7 +9820,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="C87ADC92"/>
             <Parameter Type="Param" Library="5BD4895D" Id="FC3B671F"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="50A66DF6"/>
         </Element>
         <Element Type="Param" Id="C87ADC92">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -12456,7 +12455,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="E2A3AC83"/>
             <Parameter Type="Param" Library="5BD4895D" Id="C32CBE32"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="EABDE05B"/>
         </Element>
         <Element Type="Param" Id="E2A3AC83">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -12716,7 +12714,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="519B0112"/>
             <Parameter Type="Param" Library="5BD4895D" Id="619C16F5"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="560E1A50"/>
         </Element>
         <Element Type="Param" Id="519B0112">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -12876,7 +12873,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="3B178B51"/>
             <Parameter Type="Param" Library="5BD4895D" Id="32C63BE4"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="E4B4D136"/>
         </Element>
         <Element Type="Param" Id="3B178B51">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -13034,7 +13030,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="2BD1C788"/>
             <Parameter Type="Param" Library="5BD4895D" Id="D111B90D"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="CCA17A69"/>
         </Element>
         <Element Type="Param" Id="2BD1C788">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -13193,7 +13188,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="8C532A85"/>
             <Parameter Type="Param" Library="5BD4895D" Id="B2CF5F31"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="9900F408"/>
         </Element>
         <Element Type="Param" Id="8C532A85">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -13338,7 +13332,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="F07C70B8"/>
             <Parameter Type="Param" Library="5BD4895D" Id="DD814919"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="8F11FDDC"/>
         </Element>
         <Element Type="Param" Id="F07C70B8">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -13457,7 +13450,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="341277CF"/>
             <Parameter Type="Param" Library="5BD4895D" Id="5ADABCEA"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="4C522A64"/>
         </Element>
         <Element Type="Param" Id="341277CF">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -13679,7 +13671,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="2BBF18C2"/>
             <Parameter Type="Param" Library="5BD4895D" Id="6D5AD331"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="4080B645"/>
         </Element>
         <Element Type="Param" Id="2BBF18C2">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -14004,7 +13995,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="A895B525"/>
             <Parameter Type="Param" Library="5BD4895D" Id="1106EF83"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="464E0E53"/>
         </Element>
         <Element Type="Param" Id="A895B525">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -20815,7 +20805,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="FED42B68"/>
             <Parameter Type="Param" Library="5BD4895D" Id="1679CDD9"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="21E8E4A6"/>
         </Element>
         <Element Type="Param" Id="FED42B68">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>
@@ -21035,7 +21024,6 @@
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="67875F0F"/>
             <Parameter Type="Param" Library="5BD4895D" Id="D4FF2568"/>
             <Parameter Type="Param" Library="5BD4895D" Id="AE0AD3BF"/>
-            <Parameter Type="Param" Library="5BD4895D" Id="865705DB"/>
         </Element>
         <Element Type="Param" Id="D4FF2568">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="C0EC3911"/>


### PR DESCRIPTION
Opened APCore mod and saved it to fix dangling references in the Triggers file.
![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/615b8de6-e28a-4354-a4dd-cdaf17ae4cc4)

Spotted the issue thanks to my WIP script. Getting this checked in makes it easier to keep testing it out.