### PR TITLE
Schemas, cleanup, grapple pull icon

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -18583,7 +18583,7 @@
         <GroupIcon>
             <Image value="Assets\Textures\btn-unit-protoss-fenix.dds"/>
         </GroupIcon>
-        <HeroIcon value="Assets\Textures\BTN-Unit-Protoss-stonezealot.dds"/>
+        <HeroIcon value="Assets\Textures\btn-hero-fenix.dds"/>
         <LifeArmorIcon value="Assets\Textures\btn-upgrade-protoss-groundarmorlevel0.dds"/>
         <SoundArray index="Ready" value="AP_Fenix_Ready"/>
         <SoundArray index="Help" value="AP_Fenix_Help"/>
@@ -18592,7 +18592,7 @@
         <SoundArray index="Attack" value="AP_Fenix_Attack"/>
         <SoundArray index="Pissed" value="AP_Fenix_Pissed"/>
         <UnitFlags index="SuppressDefaultStatusBar" value="1"/>
-        <UnitIcon value="Assets\Textures\BTN-Unit-Protoss-stonezealot.dds"/>
+        <UnitIcon value="Assets\Textures\btn-unit-protoss-fenix.dds"/>
         <Wireframe>
             <Image value="Assets\Textures\wireframe-protoss-fenix.dds"/>
         </Wireframe>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -813,7 +813,7 @@
     </CBehaviorBuff>
     <CBehaviorBuff id="AP_Irradiate">
         <Alignment value="Negative"/>
-        <InfoIcon value="AP\Assets\Textures\btn-ability-terran-irradiate.dds"/>
+        <InfoIcon value="assets\textures\btn-upgrade-swann-irradiate.dds"/>
         <EditorCategories value="AbilityorEffectType:Units"/>
         <Duration value="30"/>
         <Period value="1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -109,8 +109,8 @@
         <EditorCategories value="Race:Terran"/>
     </CButton>
     <CButton id="AP_HercGrapplePull">
-        <Icon value="AP\Assets\Custom\Textures\btn-ability-herc-grapple-pull.dds"/>
-        <AlertIcon value="AP\Assets\Custom\Textures\btn-ability-herc-grapple-pull.dds"/>
+        <Icon value="assets/textures/btn-ability-tychus-herc-heavyimpact.dds"/>
+        <AlertIcon value="assets/textures/btn-ability-tychus-herc-heavyimpact.dds"/>
         <EditorCategories value="Race:Terran"/>
     </CButton>
     <CButton id="Move">
@@ -221,11 +221,6 @@
     </CButton>
     <CButton id="AP_CerberusMines">
         <Icon value="assets\textures\btn-upgrade-raynor-cerberusmines.dds"/>
-        <EditorCategories value="Race:Terran"/>
-    </CButton>
-    <CButton id="AP_ResearchSpiderMinesSC1">
-        <Icon value="Assets\Textures\btn-unit-terran-spidermine.dds"/>
-        <AlertIcon value="AP\Assets\Textures\btn-unit-terran-spidermine.dds"/>
         <EditorCategories value="Race:Terran"/>
     </CButton>
     <CButton id="AP_SpiderMine">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementNodeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementNodeData.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Catalog>
-    <CRequirementCountUpgrade default="1" id="AP_SCBW_UpgradeCount">
-        <?token id="x" type="CUpgradeLink" value="Research"?>
-        <Count Link="##x##" State="CompleteOnly"/>
-    </CRequirementCountUpgrade>
     <CRequirementCountUpgrade id="AP_CountUpgradeHotSHaveRaptorCompleteOnly">
         <Flags index="TechTreeCheat" value="0"/>
         <Count Link="AP_HotSHaveRaptor" State="CompleteOnly"/>
@@ -3215,15 +3211,21 @@
     <CRequirementAnd id="AP_GhostSCBWLockdown@Show">
         <OperandArray value="AP_GhostSCBWLockdownResearch@Count"/>
     </CRequirementAnd>
-    <CRequirementCountUpgrade id="AP_GhostSCBWLockdownResearch@Count" parent="AP_SCBW_UpgradeCount" x="AP_GhostSCBWLockdownResearch"/>
+    <CRequirementCountUpgrade id="AP_GhostSCBWLockdownResearch@Count">
+        <Count Link="AP_GhostSCBWLockdownResearch" State="CompleteOnly"/>
+    </CRequirementCountUpgrade>
     <CRequirementAnd id="AP_MedicSCBWRestoration@Show">
         <OperandArray value="AP_MedicSCBWRestorationResearch@Count"/>
     </CRequirementAnd>
-    <CRequirementCountUpgrade id="AP_MedicSCBWRestorationResearch@Count" parent="AP_SCBW_UpgradeCount" x="AP_MedicSCBWRestorationResearch"/>
+    <CRequirementCountUpgrade id="AP_MedicSCBWRestorationResearch@Count">
+        <Count Link="AP_MedicSCBWRestorationResearch" State="CompleteOnly"/>
+    </CRequirementCountUpgrade>
     <CRequirementAnd id="AP_MedicSCBWOpticFlare@Show">
         <OperandArray value="AP_MedicSCBWOpticFlareResearch@Count"/>
     </CRequirementAnd>
-    <CRequirementCountUpgrade id="AP_MedicSCBWOpticFlareResearch@Count" parent="AP_SCBW_UpgradeCount" x="AP_MedicSCBWOpticFlareResearch"/>
+    <CRequirementCountUpgrade id="AP_MedicSCBWOpticFlareResearch@Count">
+        <Count Link="AP_MedicSCBWOpticFlareResearch" State="CompleteOnly"/>
+    </CRequirementCountUpgrade>
     <CRequirementCountUpgrade id="AP_CountUpgradeValkyrieEnhancedClusterLaunchersCompleteOnly">
         <Count Link="AP_ValkyrieEnhancedClusterLaunchers" State="CompleteOnly"/>
     </CRequirementCountUpgrade>
@@ -3261,7 +3263,9 @@
     <CRequirementAnd id="AP_ScienceVesselSCBWEMPShockwave@Show">
         <OperandArray value="AP_ScienceVesselSCBWEMPShockwaveResearch@Count"/>
     </CRequirementAnd>
-    <CRequirementCountUpgrade id="AP_ScienceVesselSCBWEMPShockwaveResearch@Count" parent="AP_SCBW_UpgradeCount" x="AP_ScienceVesselSCBWEMPShockwaveResearch"/>
+    <CRequirementCountUpgrade id="AP_ScienceVesselSCBWEMPShockwaveResearch@Count">
+        <Count Link="AP_ScienceVesselSCBWEMPShockwaveResearch" State="CompleteOnly"/>
+    </CRequirementCountUpgrade>
     <CRequirementAnd id="AP_ScienceVesselSCBWDefensiveMatrix@Show">
         <OperandArray value="AP_CountUpgradeScienceVesselDefensiveMatrixCompleteOnly"/>
     </CRequirementAnd>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameHotkeys.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameHotkeys.txt
@@ -303,7 +303,6 @@ Button/Hotkey/AP_Refinery=R
 Button/Hotkey/AP_RepairDrones=E
 Button/Hotkey/AP_ResearchCycloneRapidFireLaunchers=A
 Button/Hotkey/AP_ResearchMagFieldLaunchers=R
-Button/Hotkey/AP_ResearchSpiderMinesSC1=M
 Button/Hotkey/AP_RespawnZergling=Z
 Button/Hotkey/AP_Roach=R
 Button/Hotkey/AP_RoachWarren=R

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -1389,7 +1389,6 @@ Button/Name/AP_ResearchAlarakHighTemplarPsionicOrbTravelDistancePassive=Chaotic 
 Button/Name/AP_ResearchCycloneRapidFireLaunchers=Research Rapid Fire Launchers
 Button/Name/AP_ResearchLiberatorAGMode=Research Defender Mode
 Button/Name/AP_ResearchMagFieldLaunchers=Research Mag-Field Launchers
-Button/Name/AP_ResearchSpiderMinesSC1=Research Spider Mines
 Button/Name/AP_RespawnZergling=Zergling Reconstitution
 Button/Name/AP_RetributionField=Lightning Field
 Button/Name/AP_RipwaveMissiles=Ripwave Missiles
@@ -2458,7 +2457,6 @@ Button/Tooltip/AP_RepairDrones=Two repair drones automatically heal friendly mec
 Button/Tooltip/AP_ResearchAlarakHighTemplarPsionicOrbTravelDistancePassive=Increases Psionic Orb's travel distance by 25%.
 Button/Tooltip/AP_ResearchCycloneRapidFireLaunchers=Increases the attack speed of the first 12 shots of the <c val="ffff8a">Cyclone's</c> Lock On.
 Button/Tooltip/AP_ResearchMagFieldLaunchers=Increases <c val="ffff8a">Cyclone's</c> attack range by +<d ref="$UpgradeEffectArrayValue:AP_MagFieldLaunchers:Weapon,AP_TyphoonMissilePod,Range$"/>.
-Button/Tooltip/AP_ResearchSpiderMinesSC1=Enables the Vulture to carry Spider Mines. Spider Mines burrow into the ground and become cloaked unless spotted with a detector or effect. When most types of enemy ground units pass nearby, the Spider Mine will unburrow, chase down the units, and detonate.
 Button/Tooltip/AP_RespawnZergling=Respawns up to <d ref="Effect,ZerglingRespawnTooltipDummy,SpawnCount"/> Zerglings at no cost until all Zerglings have returned to life.
 Button/Tooltip/AP_RetributionField=The Predator unleashes a deadly field of electricity each time it attacks. Deals 20 damage.
 Button/Tooltip/AP_RipwaveMissiles=Viking missiles deal area damage.

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/ObjectStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/ObjectStrings.txt
@@ -2703,7 +2703,6 @@ Button/EditorSuffix/AP_QueenStukovSpawnBroodlings=(Stukov)
 Button/EditorSuffix/AP_RapidDeployment=(Hercules)
 Button/EditorSuffix/AP_RapidDeploymentTubes=(Medivac)
 Button/EditorSuffix/AP_ReaverScarabs=
-Button/EditorSuffix/AP_ResearchSpiderMinesSC1=(Vulture)
 Button/EditorSuffix/AP_RuptureUpgrade=Upgrade
 Button/EditorSuffix/AP_SpectreConsumption=(Spectre)
 Button/EditorSuffix/AP_SpectreHoldFire=(Spectre)

--- a/schemas/SchemaRequirementData.xsd
+++ b/schemas/SchemaRequirementData.xsd
@@ -1,0 +1,59 @@
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="Catalog" type="RequirementDataCatalog"/>
+
+    <xs:complexType name="RequirementDataCatalog">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="CRequirement" type="Requirement"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Seems RedHat's vscode extension doesn't support xsd 1.1, so we have to do some jank for -->
+    <!-- mixed "only once" and "unbounded" elements in an unsequenced list. -->
+    <!-- Based off this SO answer: https://stackoverflow.com/a/12012599 -->
+    <xs:group name="unboundedElements">
+        <xs:choice>
+            <xs:element ref="NodeArray"/>
+            <xs:element ref="CanBeSuppressed"/>
+        </xs:choice>
+    </xs:group>
+    <xs:complexType name="Requirement">
+        <xs:sequence>
+            <xs:group ref="unboundedElements" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element ref="EditorCategories" minOccurs="0" maxOccurs="1"/>
+            <xs:group ref="unboundedElements" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="id" use="required" type="xs:ID"/>
+        <xs:attribute name="default" use="optional" type="ZeroOrOne"/>
+        <xs:attribute name="parent" use="optional" type="xs:IDREF"/>
+    </xs:complexType>
+
+    <xs:element name="EditorCategories" type="EditorCategories"/>
+    <xs:element name="NodeArray" type="RequirementNodeLink"/>
+    <xs:element name="CanBeSuppressed" type="CanBeSuppressed"/>
+    
+    <xs:complexType name="RequirementNodeLink">
+        <xs:attribute name="index" type="UseOrShow"/>
+        <xs:attribute name="Link" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="EditorCategories">
+        <xs:attribute name="value" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="CanBeSuppressed">
+        <xs:attribute name="index" type="xs:string"/>
+        <xs:attribute name="value" type="ZeroOrOne"/>
+    </xs:complexType>
+
+    <xs:simpleType name="ZeroOrOne">
+        <xs:restriction base="xs:int">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="UseOrShow">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Use"/>
+            <xs:enumeration value="Show"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema> 

--- a/schemas/SchemaRequirementNodeData.xsd
+++ b/schemas/SchemaRequirementNodeData.xsd
@@ -1,0 +1,151 @@
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="Catalog">
+        <xs:complexType>
+            <xs:sequence maxOccurs="unbounded">
+                <xs:group ref="top_level_elements"/>
+            </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="ids_within_a_document_must_be_unique">
+            <xs:selector xpath="
+            CRequirementAllowAbil
+            |CRequirementAllowUnit
+            |CRequirementAllowUpgrade
+            |CRequirementCountBehavior
+            |CRequirementCountUnit
+            |CRequirementCountUpgrade
+            |CRequirementNot
+            |CRequirementAnd
+            |CRequirementOr
+            |CRequirementEq
+            |CRequirementLT
+            |CRequirementGT
+            "/>
+            <xs:field xpath="@id"/>
+        </xs:unique>
+    </xs:element>
+    <xs:group name="top_level_elements">
+        <xs:choice>
+            <xs:element name="CRequirementAllowAbil" type="RequirementTypeAllow"/>
+            <xs:element name="CRequirementAllowUnit" type="RequirementTypeAllow"/>
+            <xs:element name="CRequirementAllowUpgrade" type="RequirementTypeAllow"/>
+            <xs:element name="CRequirementCountBehavior" type="RequirementTypeCount"/>
+            <xs:element name="CRequirementCountUnit" type="RequirementTypeCount"/>
+            <xs:element name="CRequirementCountUpgrade" type="RequirementTypeCount"/>
+            <xs:element name="CRequirementNot" type="RequirementTypeUnaryOp"/>
+            <xs:element name="CRequirementAnd" type="RequirementTypeOp"/>
+            <xs:element name="CRequirementOr" type="RequirementTypeOp"/>
+            <xs:element name="CRequirementEq" type="RequirementTypeOp"/>
+            <xs:element name="CRequirementLT" type="RequirementTypeOp"/>
+            <xs:element name="CRequirementGT" type="RequirementTypeOp"/>
+        </xs:choice>
+    </xs:group>
+    
+    <xs:complexType name="RequirementType">
+        <xs:attribute name="id" type="xs:string"/>
+        <xs:attribute name="default" type="ZeroOrOne" use="optional"/>
+        <xs:attribute name="parent" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="RequirementTypeAllow">
+        <xs:complexContent>
+            <xs:extension base="RequirementType">
+                <xs:all>
+                    <xs:element ref="Link"/>
+                    <xs:element ref="Flags" minOccurs="0"/>
+                    <xs:element ref="Tooltip" minOccurs="0"/>
+                </xs:all>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="RequirementTypeCount">
+        <xs:complexContent>
+            <xs:extension base="RequirementType">
+                <xs:all>
+                    <xs:element ref="Count"/>
+                    <xs:element ref="Flags" minOccurs="0"/>
+                    <xs:element ref="Tooltip" minOccurs="0"/>
+                </xs:all>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="RequirementTypeUnaryOp">
+        <xs:complexContent>
+            <xs:extension base="RequirementType">
+                <xs:all>
+                    <xs:element ref="OperandArray" minOccurs="0"/>
+                    <xs:element ref="Flags" minOccurs="0"/>
+                    <xs:element ref="Tooltip" minOccurs="0"/>
+                </xs:all>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="RequirementTypeOp">
+        <xs:complexContent>
+            <xs:extension base="RequirementType">
+                <xs:choice>
+                    <xs:sequence>
+                        <xs:element ref="OperandArray" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="Flags" minOccurs="0"/>
+                        <xs:element ref="OperandArray" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="Tooltip" minOccurs="0"/>
+                        <xs:element ref="OperandArray" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                    <xs:sequence>
+                        <xs:element ref="OperandArray" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="Tooltip" minOccurs="0"/>
+                        <xs:element ref="OperandArray" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element ref="Flags" minOccurs="0"/>
+                        <xs:element ref="OperandArray" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:element name="OperandArray">
+        <xs:complexType>
+            <xs:attribute name="index" type="ZeroOrOne"/>
+            <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="Flags">
+        <xs:complexType>
+            <xs:attribute name="index" type="xs:string"/>
+            <xs:attribute name="value" type="ZeroOrOne"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="Tooltip">
+        <xs:complexType>
+            <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="Count">
+        <xs:complexType>
+            <xs:attribute name="Link" type="xs:string"/>
+            <xs:attribute name="State" type="xs:string"/>
+            <xs:attribute name="Unlock" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="Link">
+        <xs:complexType>
+            <xs:attribute name="value" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="ZeroOrOne">
+        <xs:restriction base="xs:int">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="UseOrShow">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Use"/>
+            <xs:enumeration value="Show"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema> 

--- a/schemas/settings.jsonc
+++ b/schemas/settings.jsonc
@@ -1,0 +1,7 @@
+{
+    // Use this in your .vscode settings to set the .xsd associations with the Red Hat XML extension
+    "xml.fileAssociations": [
+        {"pattern": "RequirementData.xml", "systemId": "./schemas/SchemaRequirementData.xsd"},
+        {"pattern": "RequirementNodeData.xml", "systemId": "./schemas/SchemaRequirementNodeData.xsd"},
+    ]
+}


### PR DESCRIPTION
Results of some aimless tinkering this evening:
* Updated the HERC Grapple pull icon (see [below](#new-icon))
* Some cleanups to RequirementNodeData, BehaviorData, UnitData to get the editor to stop spitting warnings to the console
  * RequirementNodeData no longer uses the SCBW `?token` macro thing for some upgrades. It was only used in like 4 places and for one line so I don't really see the point of complicating things like that, and it doesn't play nice with schemas
  * UnitData no longer tries to apply the non-existent stone zealot icons to Fenix's unit/hero icons
  * BehaviorData no longer references the removed
* Added .xsd schemas to validate RequirementData and RequirementNodeData xml files

## New Icon <a id="new-icon"/>
![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/144e3194-0db9-4800-a332-f1d6fc0e8390)

## Schema validation
Catches things like duplicate item IDs, incorrect types, incorrect tags. Requirement and RequirementNode data is pretty simple so it was fun to tinker with, but I doubt I'll do something like this for unit/actor data or anything too complex.
![image](https://github.com/Ziktofel/Archipelago-SC2-data/assets/31861583/1220a8db-7b84-4548-9684-6518a4be47e0)

