### PR TITLE
sc2: Fixed a bug where Midnight Riders could not siege

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -3412,7 +3412,7 @@
         <LifeStart value="250"/>
         <LifeMax value="250"/>
         <AbilArray index="3" Link="AP_MercLiberatorMorphtoAG"/>
-        <AbilArray index="5" Link="AP_MercLiberatorAGTarget"/>
+        <AbilArray index="4" Link="AP_MercLiberatorAGTarget"/>
         <WeaponArray index="0" Link="AP_MercLiberatorMissileLaunchers"/>
         <WeaponArray index="1" Turret="AP_MercLiberator"/>
         <CardLayouts index="0">


### PR DESCRIPTION
Fixed a bug where Merc liberators couldn't siege (simple off-by-one in the abilArray override by index).

The issue was introduced in #144