### PR TITLE
sc2: Fixed spines and spores with creep stomach and twin drones costing minerals to root

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -8820,8 +8820,10 @@
         <!--        <EffectArray Operation="Subtract" Reference="Unit,AP_NydusNetwork,CostResource[Minerals]" Value="25"/>-->
         <EffectArray Operation="Subtract" Reference="Unit,AP_SporeCrawler,CostResource[Minerals]" Value="25"/>
         <EffectArray Operation="Subtract" Reference="Unit,AP_SporeCrawlerUprooted,CostResource[Minerals]" Value="25"/>
+        <EffectArray Operation="Subtract" Reference="Unit,AP_SporeCrawlerRootableAnywhere,CostResource[Minerals]" Value="25"/>
         <EffectArray Operation="Subtract" Reference="Unit,AP_SpineCrawler,CostResource[Minerals]" Value="25"/>
         <EffectArray Operation="Subtract" Reference="Unit,AP_SpineCrawlerUprooted,CostResource[Minerals]" Value="25"/>
+        <EffectArray Operation="Subtract" Reference="Unit,AP_SpineCrawlerRootableAnywhere,CostResource[Minerals]" Value="25"/>
         <EffectArray Operation="Subtract" Reference="Unit,AP_RoachWarren,CostResource[Minerals]" Value="25"/>
         <EffectArray Operation="Subtract" Reference="Unit,AP_BanelingNest,CostResource[Minerals]" Value="25"/>
         <EffectArray Operation="Subtract" Reference="Unit,AP_HydraliskDen,CostResource[Minerals]" Value="25"/>


### PR DESCRIPTION
Tested that things don't cost minerals with twin drones and creep stomach. Didn't test the case without twin drones.