### PR TITLE
Fixing scourge incubation to not activate on morph

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -6939,7 +6939,14 @@
     <CBehaviorBuff id="AP_CorruptorScourgeIncubation">
         <InfoFlags index="Hidden" value="1"/>
         <Modification>
-            <DeathResponse Chance="1" Effect="AP_CorruptorScourgeIncubationSwitch"/>
+            <DeathResponse Chance="1" Effect="AP_CorruptorScourgeIncubationSwitch">
+                <Type index="Remove" value="0"/>
+                <Type index="Morph" value="0"/>
+                <Type index="UnderConstruction" value="0"/>
+                <Type index="Salvage" value="0"/>
+                <Type index="Cancel" value="0"/>
+                <Type index="TrainingComplete" value="0"/>
+            </DeathResponse>
         </Modification>
         <DisableValidatorArray value="AP_HaveCorruptorScourgeIncubation"/>
         <EditorCategories value="AbilityorEffectType:Units"/>


### PR DESCRIPTION
Tested on test map with scourge incubation + broodlord + viper upgrades active
-Built some corruptors
-Killed one; it correctly spawned scourges
-Morphed the others; none of them spawned scourges (as intended)