### PR TITLE
sc2: Fixed devastator turret build icon name and updated anti-armour upgrade name

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -951,7 +951,7 @@ Button/Name/AP_DefilerSCBWPredatoryConsumption=Predatory Consumption
 Button/Name/AP_DeploySpiderMines=Deploy Spider Mines
 Button/Name/AP_DeploySpiderMinesRaven=Deploy Spider Mines
 Button/Name/AP_DestroyerChargingBeam=Reforged Bloodshard Core
-Button/Name/AP_BuildDevastatorTurret=Build Devastation Turret
+Button/Name/AP_BuildDevastatorTurret=Build Devastator Turret
 Button/Name/AP_DevastatorTurretSlow=Concussive Grenades
 Button/Name/AP_DevourerAoEDamage=Corrosive Spray
 Button/Name/AP_DevourerSCBW=Morph to Devourer
@@ -1734,7 +1734,7 @@ Button/Name/AP_OverlordSpeed=Pneumatized Carapace
 Button/Name/AP_OverlordSightUpgrade=Antennae
 Button/Name/AP_MorphToOverseer=Morph to Overseer
 Button/Name/AP_OracleEnergyUpgrade=Bosonic Core
-Button/Name/AP_DevastatorTurretPunisherGrenades=Punisher Grenades
+Button/Name/AP_DevastatorTurretPunisherGrenades=Anti-Armor Munitions
 Button/Name/AP_FleetwideJump=Tactical Jump
 Button/Tooltip/AP_250mmStrikeCannons=Stuns target unit. Deals <d ref="Effect,AP_250mmStrikeCannonsCreatePersistent,PeriodCount * Effect,AP_250mmStrikeCannonsDamage,Amount"/> damage over <d ref="Effect,AP_250mmStrikeCannonsCreatePersistent,PeriodCount * Effect,AP_250mmStrikeCannonsCreatePersistent,PeriodicPeriodArray[0]"/> seconds.
 Button/Tooltip/AP_330mmBarrageCannons=Stuns all enemies in a small area. Deals <d ref="Effect,AP_330mmBarrageCannonsPersistent,PeriodCount * Effect,AP_330mmBarrageCannonsDamage,Amount"/> damage over <d ref="Effect,AP_330mmBarrageCannonsPersistent,PeriodCount * Effect,AP_330mmBarrageCannonsPersistent,PeriodicPeriodArray[0]"/> seconds in a larger area.


### PR DESCRIPTION
* Fixed an issue where Devastator Turret was called Devastation Turret in the build button
* Updated anti-armor upgrade name to Anti-Armor Munitions to avoid the confusion of having both Concussive Grenades and Punisher Grenades