### PR TITLE
sc2: Fixing incorrect item link in fast delivery trigger

### DIFF
--- a/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
@@ -4235,7 +4235,7 @@ void libABFE498B_gf_AP_Triggers_Terran_unlockFastDelivery (int lp_player) {
 
     // Implementation
     lv_upgradeLevels = TechTreeUpgradeCount(lp_player, "AP_FastDelivery", c_techCountQueuedOrBetter);
-    libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_MercenaryMunitions", 1);
+    libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_FastDelivery", 1);
     if ((lv_upgradeLevels == 0)) {
         lv_index = 0;
         for ( ; ( (auto92A9B087_ai >= 0 && lv_index <= auto92A9B087_ae) || (auto92A9B087_ai < 0 && lv_index >= auto92A9B087_ae) ) ; lv_index += auto92A9B087_ai ) {

--- a/Mods/ArchipelagoTriggers.SC2Mod/Triggers
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Triggers
@@ -33682,7 +33682,7 @@
         </Element>
         <Element Type="Param" Id="AB60765D">
             <ParameterDef Type="ParamDef" Library="Ntve" Id="7E5035EE"/>
-            <Value>AP_MercenaryMunitions</Value>
+            <Value>AP_FastDelivery</Value>
             <ValueType Type="gamelink"/>
             <ValueGameType Type="Upgrade"/>
         </Element>


### PR DESCRIPTION
Not sure I fixed this right and didn't test it, this is just what appeased the asserts I have on the icon repository repo and seemed to make sense if I was reading the code right.