### PR TITLE
sc2: Fixing a bug where unlockScorcher was never called

### DIFF
--- a/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
@@ -1196,7 +1196,7 @@ void libABFE498B_gf_AP_Triggers_unlockProtossUnits2 (int lp_player, int lp_bitAr
         libABFE498B_gf_AP_Triggers_Protoss_unlockOracle, // 8
         libABFE498B_gf_AP_Triggers_Protoss_unlockStalwart, // 9
         libABFE498B_gf_AP_Triggers_Protoss_unlockWarpRay, // 10
-        ap_triggers_PlayerConsumer_sig, // 11
+        libABFE498B_gf_AP_Triggers_Protoss_unlockScorcher, // 11
         ap_triggers_PlayerConsumer_sig, // 12
         ap_triggers_PlayerConsumer_sig, // 13
         ap_triggers_PlayerConsumer_sig, // 14

--- a/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
@@ -6533,7 +6533,7 @@ void libABFE498B_gf_AP_Triggers_Protoss_unlockWarpRay (int lp_player) {
 void libABFE498B_gf_AP_Triggers_Protoss_unlockScorcher (int lp_player) {
     // Automatic Variable Declarations
     // Implementation
-    if ((libABFE498B_gv_aP_Triggers_Protoss_has_WarpRay[lp_player] == false)) {
+    if ((libABFE498B_gv_aP_Triggers_Protoss_has_Scorcher[lp_player] == false)) {
         libABFE498B_gv_aP_Triggers_Protoss_has_Scorcher[lp_player] = true;
         libABFE498B_gf_AP_Triggers_Protoss_unlockStargate(lp_player);
         TechTreeUnitAllow(lp_player, "AP_VoidRayPurifier", true);

--- a/Mods/ArchipelagoTriggers.SC2Mod/Triggers
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Triggers
@@ -56485,7 +56485,7 @@
         </Element>
         <Element Type="Param" Id="328C3937">
             <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
-            <Variable Type="Variable" Library="ABFE498B" Id="EB6BCE88"/>
+            <Variable Type="Variable" Library="ABFE498B" Id="D7F775C4"/>
             <Array Type="Param" Library="ABFE498B" Id="6E81466F"/>
         </Element>
         <Element Type="Param" Id="6E81466F">

--- a/Mods/ArchipelagoTriggers.SC2Mod/Triggers
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Triggers
@@ -3934,7 +3934,7 @@
                     libABFE498B_gf_AP_Triggers_Protoss_unlockOracle, // 8
                     libABFE498B_gf_AP_Triggers_Protoss_unlockStalwart, // 9
                     libABFE498B_gf_AP_Triggers_Protoss_unlockWarpRay, // 10
-                    ap_triggers_PlayerConsumer_sig, // 11
+                    libABFE498B_gf_AP_Triggers_Protoss_unlockScorcher, // 11
                     ap_triggers_PlayerConsumer_sig, // 12
                     ap_triggers_PlayerConsumer_sig, // 13
                     ap_triggers_PlayerConsumer_sig, // 14


### PR DESCRIPTION
Looks like we forgot to call the unlock() function in the give tech function.