### PR TITLE
Fixing malignant creep for non-HotS missions

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -5007,9 +5007,9 @@
         <!--Start value="Footprint4x4CreepSourceGrown"/>
         <Birth value="Footprint4x4CreepSourceStart"/>
         <Grown value="Footprint4x4CreepSourceGrown"/-->
-        <Start value="Footprint4x4CreepSourceGrownUpgraded"/>
+        <Start value="AP_Footprint4x4CreepSourceGrownUpgraded"/>
         <Birth value="Footprint4x4CreepSourceStart"/>
-        <Grown value="Footprint4x4CreepSourceGrownUpgraded"/>
+        <Grown value="AP_Footprint4x4CreepSourceGrownUpgraded"/>
     </CBehaviorCreepSource>
     <CBehaviorBuff id="AP_QueenBurstHeal">
         <Alignment value="Positive"/>
@@ -7125,4 +7125,13 @@
         <InfoFlags index="Hidden" value="1"/>
         <Duration value="0.6"/>
     </CBehaviorBuff>
+    <CBehaviorCreepSource id="AP_makeCreep4x4">
+        <EditorCategories value="Race:Zerg,AbilityorEffectType:Structures"/>
+        <Birth value="Footprint4x4CreepSourceStart"/>
+        <Start value="Footprint4x4CreepSourceGrown"/>
+        <Grown value="Footprint4x4CreepSourceGrown"/>
+        <InfoFlags index="Hidden" value="1"/>
+        <Period value="0.75"/>
+        <Requirements value="AP_NotHaveK5CreepBonuses"/>
+    </CBehaviorCreepSource>
 </Catalog>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/FootprintData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/FootprintData.xml
@@ -179,4 +179,75 @@
             <Borders value="0,4,2;1,0,2;2,3,2;3,7,2;4,5,2;5,2,2;6,1,2;7,6,2"/>
         </Shape>
     </CFootprint>
+    <CFootprint id="AP_Footprint4x4CreepSourceGrownUpgraded">
+        <Layers index="Check" Area="-13,-13,14,14">
+            <Sets Character="o">
+                <Negative index="NoCreep" value="1"/>
+            </Sets>
+            <Rows value="..........................."/>
+            <Rows value="..........................."/>
+            <Rows value="..........................."/>
+            <Rows value="..........................."/>
+            <Rows value="..........................."/>
+            <Rows value="..........................."/>
+            <Rows value="........ooooo.............."/>
+            <Rows value="......ooooooooo............"/>
+            <Rows value="....ooooooooooooo.........."/>
+            <Rows value="...ooooooooooooooo........."/>
+            <Rows value="..ooooooooooooooooo........"/>
+            <Rows value="..ooooooooooooooooo........"/>
+            <Rows value=".ooooooooooooooooooo......."/>
+            <Rows value=".ooooooooooooooooooo......."/>
+            <Rows value="ooooooooooooooooooooo......"/>
+            <Rows value="ooooooooooooooooooooo......"/>
+            <Rows value="ooooooooooooooooooooo......"/>
+            <Rows value="ooooooooooooooooooooo......"/>
+            <Rows value="ooooooooooooooooooooo......"/>
+            <Rows value=".ooooooooooooooooooo......."/>
+            <Rows value=".ooooooooooooooooooo......."/>
+            <Rows value="..ooooooooooooooooo........"/>
+            <Rows value="..ooooooooooooooooo........"/>
+            <Rows value="...ooooooooooooooo........."/>
+            <Rows value="....ooooooooooooo.........."/>
+            <Rows value="......ooooooooo............"/>
+            <Rows value="........ooooo.............."/>
+        </Layers>
+        <Layers index="Place" Area="-13,-13,14,14">
+            <Sets Character="o">
+                <Positive index="Creep" value="1"/>
+            </Sets>
+            <Rows value="........ooooooooooo........"/>
+            <Rows value="......ooooooooooooooo......"/>
+            <Rows value="....ooooooooooooooooooo...."/>
+            <Rows value="...ooooooooooooooooooooo..."/>
+            <Rows value="..ooooooooooooooooooooooo.."/>
+            <Rows value="..ooooooooooooooooooooooo.."/>
+            <Rows value=".ooooooooooooooooooooooooo."/>
+            <Rows value=".ooooooooooooooooooooooooo."/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value="ooooooooooooooooooooooooooo"/>
+            <Rows value=".ooooooooooooooooooooooooo."/>
+            <Rows value=".ooooooooooooooooooooooooo."/>
+            <Rows value="..ooooooooooooooooooooooo.."/>
+            <Rows value="..ooooooooooooooooooooooo.."/>
+            <Rows value="...ooooooooooooooooooooo..."/>
+            <Rows value="....ooooooooooooooooooo...."/>
+            <Rows value="......ooooooooooooooo......"/>
+            <Rows value="........ooooooooooo........"/>
+        </Layers>
+        <Shape>
+            <Radius value="7.75"/>
+            <Offsets value="-13.5,-13.5;13.5,-13.5;-13.5,13.5;13.5,13.5"/>
+            <Borders value="0,2,2;1,0,2;2,3,2;3,1,2"/>
+        </Shape>
+    </CFootprint>
 </Catalog>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -8232,7 +8232,7 @@
         <AbilArray Link="BuildInProgress"/>
         <AbilArray Link="AP_BurrowCreepTumorDown"/>
         <AbilArray Link="AP_CreepTumorUsed"/>
-        <BehaviorArray Link="makeCreep4x4"/>
+        <BehaviorArray Link="AP_makeCreep4x4"/>
         <!--        <BehaviorArray Link="QueenofVenomCreepTumorSearch"/>-->
         <BehaviorArray Link="AP_makeCreep4x4Enhanced"/>
         <BehaviorArray Link="AP_CreepFrenzy13CreepTumor"/>
@@ -8290,7 +8290,7 @@
         <AbilArray Link="AP_CreepTumorBuild"/>
         <AbilArray Link="BuildInProgress"/>
         <AbilArray Link="AP_CreepTumorUsed"/>
-        <BehaviorArray Link="makeCreep4x4"/>
+        <BehaviorArray Link="AP_makeCreep4x4"/>
         <BehaviorArray Link="AP_makeCreep4x4Enhanced"/>
         <BehaviorArray Link="AP_CreepFrenzy13CreepTumor"/>
         <CardLayouts>
@@ -8347,7 +8347,7 @@
         <TurningRate value="719.4726"/>
         <Sight value="11"/>
         <AttackTargetPriority value="19"/>
-        <BehaviorArray Link="makeCreep4x4"/>
+        <BehaviorArray Link="AP_makeCreep4x4"/>
         <!--        <BehaviorArray Link="QueenofVenomCreepTumorSearch"/>-->
         <BehaviorArray Link="AP_makeCreep4x4Enhanced"/>
         <BehaviorArray Link="AP_CreepFrenzy13CreepTumor"/>
@@ -8404,7 +8404,7 @@
         <AttackTargetPriority value="11"/>
         <AbilArray Link="BuildInProgress"/>
         <AbilArray Link="AP_BurrowCreepTumorDown"/>
-        <BehaviorArray Link="makeCreep4x4"/>
+        <BehaviorArray Link="AP_makeCreep4x4"/>
         <CardLayouts>
             <LayoutButtons Face="CancelBuilding" Type="AbilCmd" AbilCmd="BuildInProgress,Cancel" Row="2" Column="4"/>
         </CardLayouts>


### PR DESCRIPTION
Two minor fixes based on dependencies that hadn't been ported from the SwarmCampaign mod:
- Gave AP creep tumors the HotS version of base creep spread, with a shorter period and a validator that disables itself when AP_K5CreepBonuses is applied
- Imported the enhanced creep spread footprint from SwarmCampaign and pointed the Malignant Creep behavior at it