### PR TITLE
sc2: Buffing up pre-war council dragoons a little -- +1 range, +0.1 speed

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -8535,7 +8535,7 @@
         <ShieldRegenDelay value="10"/>
         <ShieldRegenRate value="2"/>
         <ShieldArmorName value="Unit/ShieldArmorName/ProtossPlasmaShields"/>
-        <Speed value="2"/>
+        <Speed value="2.1"/>
         <Acceleration value="1000"/>
         <Sight value="10"/>
         <Food value="-2"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -11191,10 +11191,10 @@
         <Icon value="Assets\Textures\btn-upgrade-protoss-fenix-zealotsuit-armorplate.dds"/>
         <Alert value="ResearchComplete"/>
         <Race value="Prot"/>
-        <EffectArray Reference="Weapon,AP_Dragoon,Range" Value="2"/>
-        <EffectArray Reference="Weapon,AP_Dragoon,MinScanRange" Value="2"/>
+        <EffectArray Reference="Weapon,AP_Dragoon,Range" Value="1"/>
+        <EffectArray Reference="Weapon,AP_Dragoon,MinScanRange" Value="1"/>
         <EffectArray Operation="Subtract" Reference="Unit,AP_Dragoon,Radius" Value="0.175"/>
-        <EffectArray Reference="Unit,AP_Dragoon,Speed" Value="0.25"/>
+        <EffectArray Reference="Unit,AP_Dragoon,Speed" Value="0.15"/>
         <EditorCategories value="Race:Protoss,UpgradeType:SpellResearch"/>
         <AffectedUnitArray value="AP_Dragoon"/>
     </CUpgrade>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -2805,7 +2805,7 @@
         <Icon value="Assets\Textures\btn-upgrade-protoss-groundweaponslevel0.dds"/>
         <DisplayEffect value="AP_DragoonDamage"/>
         <TargetFilters value="Visible;Missile,Stasis,Dead,Hidden,Invulnerable"/>
-        <Range value="5"/>
+        <Range value="6"/>
         <Period value="2"/>
         <Effect value="AP_DragoonLM"/>
     </CWeaponLegacy>


### PR DESCRIPTION
This follows a balance discussion today in the test-games discord thread. Giving pre-war council dragoons a little more speed and +1 range, which ensures Phalanx Suit isn't just a strictly better singularity charge, and makes them more usable while maintaining the bw jank feel.