### PR TITLE
Adding massive-unit forcefield shatter

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -11011,4 +11011,15 @@
         <!-- Should fix Mind control-related issues -->
         <MaxCount value="2"/>
     </CAbilArmMagazine>
+    <CAbilEffectTarget id="AP_Shatter">
+        <Flags index="AutoCast" value="1"/>
+        <Flags index="AutoCastOn" value="1"/>
+        <Flags index="ReExecutable" value="1"/>
+        <Effect index="0" value="Suicide"/>
+        <CmdButtonArray index="Execute" DefaultButtonFace="Shatter"/>
+        <Range value="0.1"/>
+        <AutoCastRange value="1"/>
+        <AutoCastFilters value="Ground,Massive;Structure,Missile,Destructible,Stasis,Dead,Hidden,Hallucination"/>
+        <Arc value="360"/>
+    </CAbilEffectTarget>
 </Catalog>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -15849,8 +15849,9 @@
         <Collide index="Colossus" value="1"/>
         <Collide index="ForceField" value="1"/>
         <Collide index="Small" value="1"/>
-        <LifeStart value="200"/>
-        <LifeMax value="200"/>
+        <LifeStart value="15"/>
+        <LifeMax value="15"/>
+        <AbilArray Link="AP_Shatter"/>
         <Radius value="1.5"/>
         <SeparationRadius value="0"/>
         <InnerRadius value="0.5"/>

--- a/Mods/ArchipelagoPlayerWoL.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayerWoL.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -1,5 +1,9 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Catalog>
+    <CUnit id="ForceField">
+        <AbilArray Link="AP_Shatter"/>
+        <!-- Do not give this unit a footprint because that can allow units to walk into unpathable areas -->
+    </CUnit>
     <CUnit id="TechReactor">
         <!-- Override -->
         <!-- Add-on stealing -->


### PR DESCRIPTION
As of HotS, massive units could shatter force fields by moving into them, so that functionality has been added to AP forcefields, as well as the vanilla forcefield in the WoL submod.

Tested on Zerg smash+grab; an ultralisk could walk right through the end of the first bridge. Also tested Ravager bile; it could already smash forcefields so nothing has been changed on that end.