### PR TITLE
Several bugfixes

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -10194,7 +10194,7 @@
         <!--            <Button DefaultButtonFace="AP_NydusNetwork" State="Restricted" Requirements="AP_HaveLair"/>-->
         <!--        </InfoArray>-->
         <InfoArray index="Build11" Unit="AP_BanelingNest" Time="30">
-            <Button DefaultButtonFace="AP_BanelingNest" State="Restricted" Requirements="AP_HaveSpawningPool"/>
+            <Button DefaultButtonFace="AP_BanelingNest" State="Restricted" Requirements="AP_HaveHatchery"/>
         </InfoArray>
         <InfoArray index="Build13" Time="70"/>
         <InfoArray index="Build14" Unit="AP_RoachWarren" Time="40">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -5868,6 +5868,7 @@
         <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
         <RemoveValidatorArray value="AP_NotFullLife"/>
         <RemoveValidatorArray value="NotHidden"/>
+        <RemoveValidatorArray value="AP_TargetNotUntargetable"/>
         <RemoveValidatorArray value="AP_NotStasis"/>
         <InitialEffect value="AP_SOARepairBeamSwitch"/>
     </CBehaviorBuff>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -14552,12 +14552,21 @@
         <ValidatorArray value="AP_NotArchon"/>
         <ValidatorArray value="AP_NotDarkArchon"/>
         <ValidatorArray value="AP_SoARepairBeamBioMechTraits"/>
+        <ValidatorArray value="AP_TargetNotUntargetable"/>
+        <ValidatorArray value="AP_NotStasis"/>
         <EditorCategories value="Race:Protoss"/>
         <Behavior value="AP_SOARepairBeam"/>
     </CEffectApplyBehavior>
+    <CEffectRemoveBehavior id="AP_SOARepairBeamRB">
+        <EditorCategories value="Race:Protoss"/>
+        <BehaviorLink value="AP_SOARepairBeam"/>
+    </CEffectRemoveBehavior>
     <CEffectCreateHealer id="AP_SOARepairBeamHeal">
         <Flags index="Channeled" value="0"/>
         <RechargeVitalRate value="5"/>
+        <ValidatorArray value="AP_TargetNotUntargetable"/>
+        <ValidatorArray value="AP_NotStasis"/>
+        <FinalEffect value="AP_SOARepairBeamRB"/>
     </CEffectCreateHealer>
     <CEffectCreateHealer id="AP_SOARepairBeamHealStructure">
         <Flags index="Channeled" value="0"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -24769,6 +24769,7 @@
         </CardLayouts>
         <Radius value="0.25"/>
         <SeparationRadius value="0.25"/>
+        <MinimapRadius value="0"/>
         <ScoreMake value="25"/>
         <ScoreKill value="25"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>


### PR DESCRIPTION
- Baneling Nest now requires Hatchery instead of Spawning Pool, because it's entirely possible to unlock banelings without having access to spawning pools
- Dawnbringer lasers no longer appear on the minimap
- Reconstruction Beam no longer double-targets units who use tactical jump
- Units previously targeted by Reconstruction Beam, who somehow lost their healing effect, will no longer permanently occupy a non-healing Repair Beam; losing the healer will now remove the beam as well