### PR TITLE
fix Jackson's revenge range display with advanced optics

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -11087,6 +11087,8 @@
         <EffectArray Reference="Weapon,AP_DRCannonsG,MinScanRange" Value="1"/>
         <EffectArray Reference="Weapon,AP_DRCannonsA,Range" Value="1"/>
         <EffectArray Reference="Weapon,AP_DRCannonsA,MinScanRange" Value="1"/>
+        <EffectArray Reference="Weapon,AP_DRBattlecruiserFakeG,Range" Value="1"/>
+        <EffectArray Reference="Weapon,AP_DRBattlecruiserFakeA,Range" Value="1"/>
         <EffectArray Reference="Weapon,AP_DRAllPurposeCannons,Range" Value="1"/>
         <EffectArray Reference="Weapon,AP_DRAllPurposeCannons,MinScanRange" Value="1"/>
         <EffectArray Reference="Weapon,AP_DRAllPurposeLaserBattery,Range" Value="1"/>


### PR DESCRIPTION
To fix https://github.com/Ziktofel/Archipelago/issues/232

Actual weapon range was previously working, but Jackson's Revenge uses a dummy weapon for icons that needed to have the range upgrade reflected.

I tested in game to make sure it didn't change the actual range or anything.