### PR TITLE
Fix Terran version of Haven's Fall

### DIFF
--- a/Maps/ArchipelagoCampaign/WoL/ap_havens_fall.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/WoL/ap_havens_fall.SC2Map/MapScript.galaxy
@@ -1364,7 +1364,6 @@ bool gt_ArchInit_Func (bool testConds, bool runActions) {
     lib5BD4895D_gf_AP_Core_MapConfig_setPlayerFaction(gv_p01_USER, lib5BD4895D_gv_aP_Core_Faction_RAYNORS_RAIDERS);
     lib5BD4895D_gf_AP_Core_MapConfig_setMapInit(gt_Initialization);
     libABFE498B_gf_AP_Triggers_MapConfig_setDifficultySetup(gt_onDifficultyCasual, gt_onDifficultyNormal, gt_onDifficultyHard, gt_onDifficultyBrutal);
-    libABFE498B_gv_aP_Triggers_Option_overridePlayerRace = "Zerg";
     lib5BD4895D_gf_AP_Core_initObjectivePanel();
     return true;
 }

--- a/Maps/ArchipelagoCampaign/WoL/ap_havens_fall.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/WoL/ap_havens_fall.SC2Map/Triggers
@@ -1669,7 +1669,6 @@
         <Action Type="FunctionCall" Id="B5E070C7"/>
         <Action Type="FunctionCall" Id="EE0374C4"/>
         <Action Type="FunctionCall" Id="BE676D01"/>
-        <Action Type="FunctionCall" Id="DA7C09EF"/>
         <Action Type="FunctionCall" Id="78883446"/>
     </Element>
     <Element Type="FunctionCall" Id="B839FDD9">
@@ -1761,21 +1760,6 @@
         <ParameterDef Type="ParamDef" Library="ABFE498B" Id="F2891C81"/>
         <ValueType Type="trigger"/>
         <ValueElement Type="Trigger" Id="BEEA8B5D"/>
-    </Element>
-    <Element Type="FunctionCall" Id="DA7C09EF">
-        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000136"/>
-        <Parameter Type="Param" Id="664EB671"/>
-        <Parameter Type="Param" Id="4EBE71A8"/>
-    </Element>
-    <Element Type="Param" Id="664EB671">
-        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000219"/>
-        <Variable Type="Variable" Library="ABFE498B" Id="97D80BC5"/>
-    </Element>
-    <Element Type="Param" Id="4EBE71A8">
-        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000220"/>
-        <Value>Zerg</Value>
-        <ValueType Type="gamelink"/>
-        <ValueGameType Type="Race"/>
     </Element>
     <Element Type="FunctionCall" Id="78883446">
         <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="58737B0B"/>


### PR DESCRIPTION
currently, if you load the terran version of haven's fall, you get the zerg version of the map instead.  This is due to an override in player race, presumably for testing purposes.  This change just removes that override.

I tested by loading in to all three variants of the mission after generating the map, all three races worked.