### PR TITLE
Fixing morphling, and tyrannozor issues

### DIFF
--- a/Maps/ArchipelagoCampaign/HotS/ap_enemy_within.SC2Map/Base.SC2Data/GameData/UnitData.xml
+++ b/Maps/ArchipelagoCampaign/HotS/ap_enemy_within.SC2Map/Base.SC2Data/GameData/UnitData.xml
@@ -18,6 +18,7 @@
         </CardLayouts>
         <CardLayouts index="2">
             <LayoutButtons index="0" AbilCmd="AP_MorphlingToPrimalIgniterMerge,SelectedUnits"/>
+            <LayoutButtons index="1" removed="1"/>
         </CardLayouts>
     </CUnit>
     <CUnit id="Anteplott">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -7756,7 +7756,7 @@
         <CardLayouts CardId="MPr">
             <LayoutButtons Face="AP_MorphlingToPrimalIgniterMerge" Type="AbilCmd" AbilCmd="AP_MorphlingToPrimalIgniterMerge,0" Row="1" Column="1"/>
             <LayoutButtons Face="AP_MorphlingToTyrannozorMerge" Type="AbilCmd" AbilCmd="AP_MorphlingToTyrannozorMerge,0" Row="2" Column="3"/>
-            <LayoutButtons Face="AP_MorphlingToTyrannozorMerge" Type="AbilCmd" AbilCmd="AP_MorphlingToTyrannozorMergeDummy,0" Row="2" Column="2"/>
+            <LayoutButtons Face="AP_MorphlingToTyrannozorMerge" Type="AbilCmd" AbilCmd="AP_MorphlingToTyrannozorMergeDummy,0" Row="2" Column="3"/>
             <LayoutButtons Face="Cancel" Type="CancelSubmenu" Row="2" Column="4"/>
         </CardLayouts>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
@@ -25131,7 +25131,7 @@
         <SeparationRadius value="1"/>
         <InnerRadius value="0.75"/>
         <CargoSize value="8"/>
-        <SubgroupPriority value="174"/>
+        <SubgroupPriority value="9"/>
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectFamily:FactionPrimal,ObjectType:Unit"/>
         <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>

--- a/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
@@ -5663,6 +5663,7 @@ void libABFE498B_gf_AP_Triggers_Zerg_SIBunkerCargo (int lp_player) {
 void libABFE498B_gf_AP_Triggers_Zerg_unlockTyrannozor (int lp_player) {
     // Automatic Variable Declarations
     // Implementation
+    libABFE498B_gf_AP_Triggers_Zerg_unlockHive(lp_player);
     TechTreeUnitAllow(lp_player, "AP_UltraliskCavern", true);
     TechTreeAbilityAllow(lp_player, AbilityCommand("AP_TyrannozorMerge", 0), true);
     if ((libABFE498B_gv_aP_Triggers_Option_enableMorphling == true)) {
@@ -5696,6 +5697,7 @@ void libABFE498B_gf_AP_Triggers_Zerg_unlockLurker (int lp_player) {
 
     if ((libABFE498B_gv_aP_Triggers_Option_enableMorphling == true)) {
         libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_EnableMorphling", 1);
+        TechTreeAbilityAllow(lp_player, AbilityCommand("AP_MorphlingToLurker", 0), true);
     }
 
 }
@@ -5712,6 +5714,7 @@ void libABFE498B_gf_AP_Triggers_Zerg_unlockImpaler (int lp_player) {
 
     if ((libABFE498B_gv_aP_Triggers_Option_enableMorphling == true)) {
         libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_EnableMorphling", 1);
+        TechTreeAbilityAllow(lp_player, AbilityCommand("AP_MorphlingToImpaler", 0), true);
     }
 
 }
@@ -5752,6 +5755,7 @@ void libABFE498B_gf_AP_Triggers_Zerg_unlockRavager (int lp_player) {
     // Automatic Variable Declarations
     // Implementation
     libABFE498B_gf_AP_Triggers_Zerg_unlockLair(lp_player);
+    TechTreeUnitAllow(lp_player, "AP_RoachWarren", true);
     TechTreeAbilityAllow(lp_player, AbilityCommand("AP_MorphToRavager", 0), true);
     if ((libABFE498B_gv_aP_Triggers_Option_enableMorphling == true)) {
         libNtve_gf_SetUpgradeLevelForPlayer(lp_player, "AP_EnableMorphling", 1);
@@ -6287,6 +6291,8 @@ void libABFE498B_gf_AP_Triggers_clearZergTech (int lp_player) {
     TechTreeAbilityAllow(lp_player, AbilityCommand("AP_SIBarracksTrain", 0), false);
     TechTreeAbilityAllow(lp_player, AbilityCommand("AP_MorphlingToTyrannozorMerge", 0), false);
     TechTreeAbilityAllow(lp_player, AbilityCommand("AP_TyrannozorMerge", 0), false);
+    TechTreeAbilityAllow(lp_player, AbilityCommand("AP_MorphlingToImpaler", 0), false);
+    TechTreeAbilityAllow(lp_player, AbilityCommand("AP_MorphlingToLurker", 0), false);
     TechTreeUnitAllow(lp_player, "AP_InfestedMedic", false);
     TechTreeUnitAllow(lp_player, "AP_InfestedSiegeTank", false);
     TechTreeUnitAllow(lp_player, "AP_InfestedBanshee", false);

--- a/Mods/ArchipelagoTriggers.SC2Mod/Triggers
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Triggers
@@ -45058,6 +45058,7 @@
             <Identifier>AP_Triggers_Zerg_unlockTyrannozor</Identifier>
             <FlagAction/>
             <Parameter Type="ParamDef" Library="ABFE498B" Id="192C7F8E"/>
+            <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="A4E25B17"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="5560F4A7"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="3DA3F025"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="3AB44669"/>
@@ -45071,6 +45072,14 @@
         <Element Type="Param" Id="239CC6AD">
             <Value>0</Value>
             <ValueType Type="int"/>
+        </Element>
+        <Element Type="FunctionCall" Id="A4E25B17">
+            <FunctionDef Type="FunctionDef" Library="ABFE498B" Id="B7CFB995"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="47F295AB"/>
+        </Element>
+        <Element Type="Param" Id="47F295AB">
+            <ParameterDef Type="ParamDef" Library="ABFE498B" Id="B9BA73BB"/>
+            <Parameter Type="ParamDef" Library="ABFE498B" Id="192C7F8E"/>
         </Element>
         <Element Type="FunctionCall" Id="5560F4A7">
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="51A273F5"/>
@@ -45441,6 +45450,7 @@
         <Element Type="FunctionCall" Id="24852EB8">
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000137"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="1B841E37"/>
+            <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="93EC6531"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="0D02DE47"/>
         </Element>
         <Element Type="FunctionCall" Id="1B841E37">
@@ -45464,6 +45474,26 @@
             <Value>AP_EnableMorphling</Value>
             <ValueType Type="gamelink"/>
             <ValueGameType Type="Upgrade"/>
+        </Element>
+        <Element Type="FunctionCall" Id="93EC6531">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="0F7C3248"/>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="EEBBFAA9"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="C6B3DBD1"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="75EEA8C1"/>
+        </Element>
+        <Element Type="Param" Id="EEBBFAA9">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="BFF56EB0"/>
+            <Parameter Type="ParamDef" Library="ABFE498B" Id="EC65FDCB"/>
+        </Element>
+        <Element Type="Param" Id="C6B3DBD1">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="09B7BAEA"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000106"/>
+        </Element>
+        <Element Type="Param" Id="75EEA8C1">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="9B01128C"/>
+            <Value>AP_MorphlingToLurker</Value>
+            <ValueType Type="abilcmd"/>
         </Element>
         <Element Type="FunctionCall" Id="0D02DE47">
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
@@ -45623,6 +45653,7 @@
         <Element Type="FunctionCall" Id="0426D5BB">
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000137"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="E8ACDE11"/>
+            <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="0CEF1E51"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="2D8E111E"/>
         </Element>
         <Element Type="FunctionCall" Id="E8ACDE11">
@@ -45646,6 +45677,26 @@
             <Value>AP_EnableMorphling</Value>
             <ValueType Type="gamelink"/>
             <ValueGameType Type="Upgrade"/>
+        </Element>
+        <Element Type="FunctionCall" Id="0CEF1E51">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="0F7C3248"/>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="4DCAD28B"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="48548BC8"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="0B479DCE"/>
+        </Element>
+        <Element Type="Param" Id="4DCAD28B">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="BFF56EB0"/>
+            <Parameter Type="ParamDef" Library="ABFE498B" Id="0F39508B"/>
+        </Element>
+        <Element Type="Param" Id="48548BC8">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="09B7BAEA"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000106"/>
+        </Element>
+        <Element Type="Param" Id="0B479DCE">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="9B01128C"/>
+            <Value>AP_MorphlingToImpaler</Value>
+            <ValueType Type="abilcmd"/>
         </Element>
         <Element Type="FunctionCall" Id="2D8E111E">
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
@@ -46035,6 +46086,7 @@
             <FlagAction/>
             <Parameter Type="ParamDef" Library="ABFE498B" Id="4BD1322F"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="4AC9CE47"/>
+            <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="2B711E54"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="3D9C6D4C"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="8502B7BB"/>
         </Element>
@@ -46054,6 +46106,26 @@
         </Element>
         <Element Type="Param" Id="B9B2F58B">
             <ParameterDef Type="ParamDef" Library="ABFE498B" Id="DF88F744"/>
+            <Parameter Type="ParamDef" Library="ABFE498B" Id="4BD1322F"/>
+        </Element>
+        <Element Type="FunctionCall" Id="2B711E54">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="51A273F5"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="FC52736D"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="35D3927D"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="23A8925D"/>
+        </Element>
+        <Element Type="Param" Id="FC52736D">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="C26556EA"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000106"/>
+        </Element>
+        <Element Type="Param" Id="35D3927D">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="BC66D9AD"/>
+            <Value>AP_RoachWarren</Value>
+            <ValueType Type="gamelink"/>
+            <ValueGameType Type="Unit"/>
+        </Element>
+        <Element Type="Param" Id="23A8925D">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="B15D29C1"/>
             <Parameter Type="ParamDef" Library="ABFE498B" Id="4BD1322F"/>
         </Element>
         <Element Type="FunctionCall" Id="3D9C6D4C">
@@ -51041,6 +51113,8 @@
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="4B6B87DB"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="709D9D10"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="91A05A7A"/>
+            <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="1255D929"/>
+            <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="857BEFAA"/>
             <FunctionCall Type="Comment" Library="ABFE498B" Id="A934B4B3"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="2516DC61"/>
             <FunctionCall Type="FunctionCall" Library="ABFE498B" Id="E6C428FF"/>
@@ -51553,6 +51627,44 @@
         <Element Type="Param" Id="BE87BDC3">
             <ParameterDef Type="ParamDef" Library="Ntve" Id="9B01128C"/>
             <Value>AP_TyrannozorMerge</Value>
+            <ValueType Type="abilcmd"/>
+        </Element>
+        <Element Type="FunctionCall" Id="1255D929">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="0F7C3248"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="2478BB00"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="34E40A24"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="1CEFE87E"/>
+        </Element>
+        <Element Type="Param" Id="2478BB00">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="BFF56EB0"/>
+            <Parameter Type="ParamDef" Library="ABFE498B" Id="422B4FD0"/>
+        </Element>
+        <Element Type="Param" Id="34E40A24">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="09B7BAEA"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000107"/>
+        </Element>
+        <Element Type="Param" Id="1CEFE87E">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="9B01128C"/>
+            <Value>AP_MorphlingToImpaler</Value>
+            <ValueType Type="abilcmd"/>
+        </Element>
+        <Element Type="FunctionCall" Id="857BEFAA">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="0F7C3248"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="4AB2ECDD"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="E0B32E17"/>
+            <Parameter Type="Param" Library="ABFE498B" Id="949903E3"/>
+        </Element>
+        <Element Type="Param" Id="4AB2ECDD">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="BFF56EB0"/>
+            <Parameter Type="ParamDef" Library="ABFE498B" Id="422B4FD0"/>
+        </Element>
+        <Element Type="Param" Id="E0B32E17">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="09B7BAEA"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000107"/>
+        </Element>
+        <Element Type="Param" Id="949903E3">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="9B01128C"/>
+            <Value>AP_MorphlingToLurker</Value>
             <ValueType Type="abilcmd"/>
         </Element>
         <Element Type="Comment" Id="A934B4B3">


### PR DESCRIPTION
Fixes a few bugs,
https://github.com/Ziktofel/Archipelago-SC2-data/issues/237
being able to build lurkers and impalers via morphlings on enemy within without being unlocked (added them to the remove zerg tech trigger, and unlocking adds their trigger)
not being able to able to build tyrannozors in enemy within due to no ultralisk cavern (I removed the ability to create them at all, they can't fit through vents, and ultralisks are already disabled presumably for the same reason).
fix tyrannozor subgroup priority being too high
moved dummy button to overlap with main tyrannozor merge location, didn't cause any issues, but might be confusing for future modders working with morphling.