### PR TITLE
Add bunker check completion to victory on The Outlaws

### DIFF
--- a/Maps/ArchipelagoCampaign/WoL/ap_the_outlaws.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/WoL/ap_the_outlaws.SC2Map/MapScript.galaxy
@@ -3971,6 +3971,7 @@ bool gt_VictoryDominionOutpostCompleted_Func (bool testConds, bool runActions) {
     TriggerEnable(TriggerGetCurrent(), false);
     gv_gameOver = true;
     TriggerExecute(gt_ObjectiveDestroytheDominionBaseComplete, true, true);
+    TriggerExecute(gt_ObjectiveBunkerComplete, true, false);
     libCamp_gf_RunMissionVictorySequence(gt_VictoryQ);
     return true;
 }

--- a/Maps/ArchipelagoCampaign/WoL/ap_the_outlaws.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/WoL/ap_the_outlaws.SC2Map/Triggers
@@ -31703,6 +31703,7 @@
         <Action Type="FunctionCall" Id="D32E9C4F"/>
         <Action Type="Comment" Id="E877385A"/>
         <Action Type="FunctionCall" Id="B632903D"/>
+        <Action Type="FunctionCall" Id="7FBA3B2A"/>
         <Action Type="Comment" Id="F2636D72"/>
         <Action Type="FunctionCall" Id="66175154"/>
     </Element>
@@ -31853,6 +31854,25 @@
         <ParameterDef Type="ParamDef" Library="Ntve" Id="00000182"/>
         <ValueType Type="trigger"/>
         <ValueElement Type="Trigger" Id="175FE6EB"/>
+    </Element>
+    <Element Type="FunctionCall" Id="7FBA3B2A">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000116"/>
+        <Parameter Type="Param" Id="8192E114"/>
+        <Parameter Type="Param" Id="8B3D151B"/>
+        <Parameter Type="Param" Id="1FC59CE8"/>
+    </Element>
+    <Element Type="Param" Id="8192E114">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000183"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="00000065"/>
+    </Element>
+    <Element Type="Param" Id="8B3D151B">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000184"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="00000068"/>
+    </Element>
+    <Element Type="Param" Id="1FC59CE8">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000182"/>
+        <ValueType Type="trigger"/>
+        <ValueElement Type="Trigger" Id="73D916D8"/>
     </Element>
     <Element Type="Comment" Id="F2636D72">
         <Comment>


### PR DESCRIPTION
per discord report, when destroying the bunker as the last building on The Outlaws, you usually can't get the clear bunker check since the game ends before you can kill the bunker's units.  Simplest solution is to grant the bunker check on victory.