### PR TITLE
sc2: non-war council Zealots now have basic model

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -29849,13 +29849,19 @@
         <On Terms="Upgrade.AP_CinematicMode.Remove; ValidateUnit AP_CasterHasVoidZealotWhirlwind" Send="HostSiteOpsSet ::Host AP_ZealotWhirlwindRotator"/>
         <On Terms="Signal.*.SOATargetingOn; ValidateUnit AP_CasterHasVoidZealotWhirlwind" Send="HostSiteOpsSet ::Host"/>
         <On Terms="Signal.*.SOATargetingOff; ValidateUnit AP_CasterHasVoidZealotWhirlwind" Send="HostSiteOpsSet ::Host AP_ZealotWhirlwindRotator"/>
+        <!-- Note: Don't swap the model at actor creation, as that overrides the warp-in model -->
+        <On Terms="UnitBirth; ValidatePlayer AP_HaveZealotWhirlwind" Send="ModelSwap AP_ZealotAiur"/>
+        <On Terms="Upgrade.AP_VoidZealotWhirlwind.Add" Send="ModelSwap AP_ZealotAiur"/>
+        <On Terms="UnitDeathCustomize; ValidatePlayer AP_HaveZealotWhirlwind" Send="DeathCustomize AiurZealot"/>
+        <Model value="Zealot"/>
         <ModelFlags index="OutlineEmitter" value="1"/>
-        <BuildModel value="AP_ZealotAiurWarpIn"/>
-        <DeathArray index="Normal" ModelLink="AP_ZealotAiurDeath" SoundLink="Zealot_DeathFX"/>
+        <BuildModel value="ZealotWarpIn"/>
+        <DeathArray index="Normal" ModelLink="ZealotDeath" SoundLink="Zealot_DeathFX"/>
         <DeathCustoms ModelLink="HallucinationDeath" SoundLink="Sentry_HallucinationDeathSmall" Name="Hallucination"/>
-        <PlacementModel value="AP_ZealotAiurPlacement"/>
+        <DeathCustoms ModelLink="AP_ZealotAiurDeath" SoundLink="Zealot_DeathFX" Name="AiurZealot"/>
+        <PlacementModel value="ZealotPlacement"/>
         <PlacementSound value="Protoss_BuildingPlacementSmall"/>
-        <PortraitModel value="AP_ZealotAiurPortrait"/>
+        <PortraitModel value="ZealotPortrait"/>
         <TerrainSquibs>
             <MovementDistance value="0.150000,0.150000"/>
             <IdlePeriod value="0.100000,0.250000"/>
@@ -29867,10 +29873,6 @@
         <WalkAnimMoveSpeed value="2.25"/>
         <BarOffset value="45"/>
         <BarWidth value="42"/>
-        <GroupIcon>
-            <Image value="Assets\Textures\wireframe-protoss-zealotelite.dds"/>
-        </GroupIcon>
-        <HeroIcon value="Assets\Textures\btn-unit-protoss-zealot-aiur.dds"/>
         <LifeArmorIcon value="Assets\Textures\btn-upgrade-protoss-groundarmorlevel0.dds"/>
         <SoundArray index="Birth" value="Zealot_Birth"/>
         <SoundArray index="Ready" value="Zealot_Ready"/>
@@ -29879,14 +29881,18 @@
         <SoundArray index="Yes" value="Zealot_Yes"/>
         <SoundArray index="Attack" value="Zealot_Attack"/>
         <SoundArray index="Pissed" value="Zealot_Pissed"/>
-        <UnitIcon value="Assets\Textures\btn-unit-protoss-zealot-aiur.dds"/>
+        <UnitIcon value="Assets\Textures\btn-unit-protoss-zealot.dds"/>
+        <HeroIcon value="Assets\Textures\btn-unit-protoss-zealot.dds"/>
+        <GroupIcon>
+            <Image value="Assets\Textures\btn-unit-protoss-zealot.dds"/>
+        </GroupIcon>
         <Wireframe>
-            <Image value="Assets\Textures\wireframe-protoss-zealot-aiur.dds"/>
+            <Image value="Assets\Textures\wireframe-protoss-zealot.dds"/>
         </Wireframe>
         <WireframeShield>
-            <Image value="Assets\Textures\wireframe-protoss-zealot-aiur-shield01.dds"/>
-            <Image value="Assets\Textures\wireframe-protoss-zealot-aiur-shield02.dds"/>
-            <Image value="Assets\Textures\wireframe-protoss-zealot-aiur-shield03.dds"/>
+            <Image value="Assets\Textures\wireframe-protoss-zealot-shield01.dds"/>
+            <Image value="Assets\Textures\wireframe-protoss-zealot-shield02.dds"/>
+            <Image value="Assets\Textures\wireframe-protoss-zealot-shield03.dds"/>
         </WireframeShield>
     </CActorUnit>
     <CActorAction id="AP_ZealotAiurAttack" parent="GenericAttack" effectAttack="AP_ZealotAiurWeapon">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -3607,8 +3607,8 @@
         <Universal value="1"/>
     </CButton>
     <CButton id="AP_ZealotAiur">
-        <Icon value="Assets\Textures\btn-unit-protoss-zealot-aiur.dds"/>
-        <AlertIcon value="Assets\Textures\btn-unit-protoss-zealot-aiur.dds"/>
+        <Icon value="Assets\Textures\btn-unit-protoss-zealot.dds"/>
+        <AlertIcon value="Assets\Textures\btn-unit-protoss-zealot.dds"/>
         <Hotkey value="Button/Hotkey/AP_Zealot"/>
         <EditorCategories value="Race:Protoss"/>
         <HotkeyAlias value="Zealot"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -11195,7 +11195,6 @@
         <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,BuildModel" Value="AP_ZealotAiurWarpIn"/>
         <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,PlacementModel" Value="AP_ZealotAiurPlacement"/>
         <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,PortraitModel" Value="AP_ZealotAiurPortrait"/>
-        <EffectArray Operation="Set" Reference="Weapon,AP_SolariteReaper,DisplayName" Value="Weapon/Name/AP_SolariteReaper"/>
         <EditorCategories value="Race:Protoss,UpgradeType:Talents"/>
         <AffectedUnitArray value="AP_ZealotAiur"/>
     </CUpgrade>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -11186,8 +11186,18 @@
     </CUpgrade>
     <CUpgrade id="AP_UnavailableInThisMission"/>
     <CUpgrade id="AP_VoidZealotWhirlwind">
-        <Flags index="UpgradeCheat" value="0"/>
+        <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,UnitIcon" Value="Assets\Textures\btn-unit-protoss-zealot-aiur.dds"/>
+        <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,GroupIcon.Image[0]" Value="Assets\Textures\wireframe-protoss-zealotelite.dds"/>
+        <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,Wireframe.Image[0]" Value="Assets\Textures\wireframe-protoss-zealot-aiur.dds"/>
+        <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,WireframeShield.Image[0]" Value="Assets\Textures\wireframe-protoss-zealot-aiur-shield01.dds"/>
+        <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,WireframeShield.Image[1]" Value="Assets\Textures\wireframe-protoss-zealot-aiur-shield02.dds"/>
+        <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,WireframeShield.Image[2]" Value="Assets\Textures\wireframe-protoss-zealot-aiur-shield03.dds"/>
+        <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,BuildModel" Value="AP_ZealotAiurWarpIn"/>
+        <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,PlacementModel" Value="AP_ZealotAiurPlacement"/>
+        <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,PortraitModel" Value="AP_ZealotAiurPortrait"/>
+        <EffectArray Operation="Set" Reference="Weapon,AP_SolariteReaper,DisplayName" Value="Weapon/Name/AP_SolariteReaper"/>
         <EditorCategories value="Race:Protoss,UpgradeType:Talents"/>
+        <AffectedUnitArray value="AP_ZealotAiur"/>
     </CUpgrade>
     <CUpgrade id="AP_ResourceEfficiencyCenturion">
         <EffectArray Operation="Subtract" Reference="Unit,AP_ZealotShakuras,CostResource[Vespene]" Value="50"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -11195,6 +11195,8 @@
         <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,BuildModel" Value="AP_ZealotAiurWarpIn"/>
         <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,PlacementModel" Value="AP_ZealotAiurPlacement"/>
         <EffectArray Operation="Set" Reference="Actor,AP_ZealotAiur,PortraitModel" Value="AP_ZealotAiurPortrait"/>
+        <EffectArray Operation="Set" Reference="Button,AP_ZealotAiur,Icon" Value="Assets\Textures\btn-unit-protoss-zealot-aiur.dds"/>
+        <EffectArray Operation="Set" Reference="Button,AP_ZealotAiur,AlertIcon" Value="Assets\Textures\btn-unit-protoss-zealot-aiur.dds"/>
         <EditorCategories value="Race:Protoss,UpgradeType:Talents"/>
         <AffectedUnitArray value="AP_ZealotAiur"/>
     </CUpgrade>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -2678,6 +2678,11 @@
         <CombineArray index="0" value="AP_CasterHasEnergyIfAvailableAndNotDead"/>
         <CombineArray value="AP_NotAbducted"/>
     </CValidatorCombine>
+    <CValidatorPlayerRequirement id="AP_HaveZealotWhirlwind">
+        <ResultNoPlayer value="Error"/>
+        <Find value="1"/>
+        <Value value="AP_HaveVoidZealotWhirlwind"/>
+    </CValidatorPlayerRequirement>
     <CValidatorPlayerRequirement id="AP_HaveVoidPhoenixDoubleGraviton">
         <ResultNoPlayer value="Error"/>
         <Find value="1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -2578,7 +2578,6 @@
         <Effect value="AP_SporeCrawler"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="AP_SolariteReaper">
-        <DisplayName value="Weapon/Name/AP_PsiBlades"/>
         <EditorCategories value="Race:Protoss"/>
         <Options index="Melee" value="1"/>
         <Icon value="Assets\Textures\btn-upgrade-protoss-groundweaponslevel0.dds"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -2578,6 +2578,7 @@
         <Effect value="AP_SporeCrawler"/>
     </CWeaponLegacy>
     <CWeaponLegacy id="AP_SolariteReaper">
+        <DisplayName value="Weapon/Name/AP_PsiBlades"/>
         <EditorCategories value="Race:Protoss"/>
         <Options index="Melee" value="1"/>
         <Icon value="Assets\Textures\btn-upgrade-protoss-groundweaponslevel0.dds"/>


### PR DESCRIPTION
upgrade gives whirlyboi model

Testing took longer than expected. Turns out protoss units have some extra considerations as they have an existing model swap when going from warping in -> completed.

I did not change the weapon name, and don't intend to. The display name is not an upgradeable field, so it would involve making a whole new weapon, which then means tracking down all upgrades / references to that weapon and maintaining them, and there's risk of bugs... I don't think it's worth it for a name few people will read (unless we want to use the old 2x8 weapon, as that's already live / maintained for the other zealot variants).

### Without upgrade
![image](https://github.com/user-attachments/assets/ab2f945b-8b51-4c5a-8911-cbd6ef01d906)
![image](https://github.com/user-attachments/assets/7c966104-617a-4a95-a764-65777c531a09)
![image](https://github.com/user-attachments/assets/f1c76f58-d993-4a13-989d-f4f436f370dc)
![image](https://github.com/user-attachments/assets/9845541d-f073-458e-9de3-5fbd364e044a)

### With upgrade
![image](https://github.com/user-attachments/assets/41fd3a2b-ff55-49f3-b05f-42e3f79c0747)
![image](https://github.com/user-attachments/assets/0d53b961-2990-46fe-8c8c-768536723476)
![image](https://github.com/user-attachments/assets/cdbe29ac-ac61-41f3-b2e1-a4d887dbd42a)
![image](https://github.com/user-attachments/assets/c401a43d-0542-4a76-bbeb-10fa34e6dc06)
