### PR TITLE
sc2: Moving Brynhild fighter/assault mode button positions to match viking

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -3574,8 +3574,8 @@
             <LayoutButtons Face="AP_ValkyrieShapedHull" Type="Passive" Requirements="AP_HaveValkyrieShapedHull" Row="1" Column="2"/>
             <LayoutButtons Face="AP_NovaMultiTaskMAFServos" Type="Passive" Requirements="AP_HaveMultiTaskMAFServosViking" Row="1" Column="4"/>
             <LayoutButtons Face="AP_ValkyrieAntiGravityDrive" Type="Passive" Requirements="AP_HaveValkyrieAntiGravityDrive" Row="1" Column="3"/>
-            <LayoutButtons Face="AP_ValkyrieSpeedBoost" Type="AbilCmd" AbilCmd="AP_ValkyrieSpeedBoost,0" Row="2" Column="0"/>
-            <LayoutButtons Face="AP_BrynhildAssaultMode" Type="AbilCmd" AbilCmd="AP_BrynhildAssaultMode,0" Row="2" Column="2"/>
+            <LayoutButtons Face="AP_BrynhildAssaultMode" Type="AbilCmd" AbilCmd="AP_BrynhildAssaultMode,0" Row="2" Column="1"/>
+            <LayoutButtons Face="AP_ValkyrieSpeedBoost" Type="AbilCmd" AbilCmd="AP_ValkyrieSpeedBoost,0" Row="2" Column="2"/>
         </CardLayouts>
         <Radius value="0.625"/>
         <SeparationRadius value="0.625"/>
@@ -3651,9 +3651,9 @@
                 <Column value="1"/>
             </LayoutButtons>
             <LayoutButtons Face="AP_ValkyrieShapedHull" Type="Passive" Requirements="AP_HaveValkyrieShapedHull" Row="1" Column="2"/>
-            <LayoutButtons Face="AP_NovaMultiTaskMAFServos" Type="Passive" Requirements="AP_HaveMultiTaskMAFServosViking" Row="1" Column="4"/>
             <LayoutButtons Face="AP_HHVikingPiercingAttacks" Type="Passive" Requirements="AP_HaveHHVikingPiercingAttack" Row="1" Column="3"/>
-            <LayoutButtons Face="AP_BrynhildFighterMode" Type="AbilCmd" AbilCmd="AP_BrynhildFighterMode,0" Row="2" Column="1"/>
+            <LayoutButtons Face="AP_NovaMultiTaskMAFServos" Type="Passive" Requirements="AP_HaveMultiTaskMAFServosViking" Row="1" Column="4"/>
+            <LayoutButtons Face="AP_BrynhildFighterMode" Type="AbilCmd" AbilCmd="AP_BrynhildFighterMode,0" Row="2" Column="0"/>
         </CardLayouts>
         <Radius value="0.6875"/>
         <SeparationRadius value="0.65"/>


### PR DESCRIPTION
Following discussion in the discord. This is a case where buttons can't be 100% consistent, because Brynhilds have afterburners and transform mode, both of which are expected in slot 2,0. It makes more sense for transform mode to take priority as it's the more impactful ability, so moved it to 2,0 and 2,1, and moved afterburners to 2,2.

![image](https://github.com/user-attachments/assets/3152e295-516d-474f-9be0-35cd77906725)
![image](https://github.com/user-attachments/assets/e29d46f4-5557-42be-a22c-05a02369d714)
![image](https://github.com/user-attachments/assets/761841b3-7898-430e-a79d-b60625a4f73c)
![image](https://github.com/user-attachments/assets/f68d1a9e-6093-47ef-a891-3c37e5c56296)
