### PR TITLE
sc2: Making dig bases check only happen outside cinematics to fix spurious send on reaching the drill

### DIFF
--- a/Maps/ArchipelagoCampaign/WoL/ap_the_dig.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/WoL/ap_the_dig.SC2Map/MapScript.galaxy
@@ -5348,6 +5348,10 @@ bool gt_MasteryNorthwestBaseDestroyed_Func (bool testConds, bool runActions) {
             return false;
         }
 
+        if (!((gv_inCinematic == false))) {
+            return false;
+        }
+
         if (!((UnitCount(null, gv_p5_NW_PROTOSSLeft, RegionEntireMap(), UnitFilter((1 << c_targetFilterPreventDefeat), 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0) == 0))) {
             return false;
         }
@@ -5386,6 +5390,10 @@ bool gt_MasteryNortheastBaseDestroyed_Func (bool testConds, bool runActions) {
             return false;
         }
 
+        if (!((gv_inCinematic == false))) {
+            return false;
+        }
+
         if (!((UnitCount(null, gv_p2_NE_PROTOSSMiddle, RegionEntireMap(), UnitFilter((1 << c_targetFilterPreventDefeat), 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0) == 0))) {
             return false;
         }
@@ -5421,6 +5429,10 @@ bool gt_MasteryEasternBaseDestroyed_Func (bool testConds, bool runActions) {
     // Conditions
     if (testConds) {
         if (!((TriggerIsEnabled(TriggerGetCurrent()) == true))) {
+            return false;
+        }
+
+        if (!((gv_inCinematic == false))) {
             return false;
         }
 

--- a/Maps/ArchipelagoCampaign/WoL/ap_the_dig.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/WoL/ap_the_dig.SC2Map/Triggers
@@ -48839,6 +48839,7 @@
     <Element Type="Trigger" Id="44B02A89">
         <Event Type="FunctionCall" Id="99629CC6"/>
         <Condition Type="FunctionCall" Id="79739880"/>
+        <Condition Type="FunctionCall" Id="7B732347"/>
         <Condition Type="FunctionCall" Id="C93AEF15"/>
         <Action Type="FunctionCall" Id="967463B9"/>
         <Action Type="FunctionCall" Id="62285541"/>
@@ -48888,6 +48889,25 @@
     <Element Type="Param" Id="B64B6EE9">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
         <Value>true</Value>
+        <ValueType Type="bool"/>
+    </Element>
+    <Element Type="FunctionCall" Id="7B732347">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <Parameter Type="Param" Id="5C06F90A"/>
+        <Parameter Type="Param" Id="AF576B78"/>
+        <Parameter Type="Param" Id="B40283F9"/>
+    </Element>
+    <Element Type="Param" Id="5C06F90A">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <Variable Type="Variable" Id="0B701ADD"/>
+    </Element>
+    <Element Type="Param" Id="AF576B78">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="B40283F9">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>false</Value>
         <ValueType Type="bool"/>
     </Element>
     <Element Type="FunctionCall" Id="C93AEF15">
@@ -49039,6 +49059,7 @@
     <Element Type="Trigger" Id="CAA614C4">
         <Event Type="FunctionCall" Id="0939E18D"/>
         <Condition Type="FunctionCall" Id="6DF50D22"/>
+        <Condition Type="FunctionCall" Id="9679B97F"/>
         <Condition Type="FunctionCall" Id="64D5F683"/>
         <Action Type="FunctionCall" Id="2AEDED0D"/>
         <Action Type="FunctionCall" Id="17F20E6A"/>
@@ -49088,6 +49109,25 @@
     <Element Type="Param" Id="0CF64D8E">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
         <Value>true</Value>
+        <ValueType Type="bool"/>
+    </Element>
+    <Element Type="FunctionCall" Id="9679B97F">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <Parameter Type="Param" Id="3C4D724C"/>
+        <Parameter Type="Param" Id="51125D04"/>
+        <Parameter Type="Param" Id="FF8BAC3E"/>
+    </Element>
+    <Element Type="Param" Id="3C4D724C">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <Variable Type="Variable" Id="0B701ADD"/>
+    </Element>
+    <Element Type="Param" Id="51125D04">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="FF8BAC3E">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>false</Value>
         <ValueType Type="bool"/>
     </Element>
     <Element Type="FunctionCall" Id="64D5F683">
@@ -49239,6 +49279,7 @@
     <Element Type="Trigger" Id="C4DA695D">
         <Event Type="FunctionCall" Id="312CE6ED"/>
         <Condition Type="FunctionCall" Id="EFB6E84F"/>
+        <Condition Type="FunctionCall" Id="6A64F812"/>
         <Condition Type="FunctionCall" Id="4AA55AF9"/>
         <Action Type="FunctionCall" Id="912732D4"/>
         <Action Type="FunctionCall" Id="4252EC0E"/>
@@ -49288,6 +49329,25 @@
     <Element Type="Param" Id="3994FE6E">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
         <Value>true</Value>
+        <ValueType Type="bool"/>
+    </Element>
+    <Element Type="FunctionCall" Id="6A64F812">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <Parameter Type="Param" Id="20448E8C"/>
+        <Parameter Type="Param" Id="478B7CCC"/>
+        <Parameter Type="Param" Id="F9DE1109"/>
+    </Element>
+    <Element Type="Param" Id="20448E8C">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <Variable Type="Variable" Id="0B701ADD"/>
+    </Element>
+    <Element Type="Param" Id="478B7CCC">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="F9DE1109">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>false</Value>
         <ValueType Type="bool"/>
     </Element>
     <Element Type="FunctionCall" Id="4AA55AF9">


### PR DESCRIPTION
Reported by Alice Voltaire in the discord a few minutes ago. Looks like factions aren't checked for having units while cutscenes are running.

![image](https://github.com/user-attachments/assets/00c05640-b0df-4e23-8f28-d02f80174ed1)
![image](https://github.com/user-attachments/assets/f739def3-d853-4cd4-9400-8ef34598a8dd)
