### PR TITLE
sc2: Making separate protoss units select separately under ctrl+click

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -12492,7 +12492,6 @@
         <SubgroupPriority value="6"/>
         <MinimapRadius value="0.75"/>
         <LeaderAlias value="Phoenix"/>
-        <SelectAlias value="Phoenix"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsAir"/>
         <GlossaryPriority value="125"/>
@@ -12570,7 +12569,6 @@
         <TacticalAI value="Phoenix"/>
         <AIEvalFactor value="0.7"/>
         <LeaderAlias value="Phoenix"/>
-        <SelectAlias value="Phoenix"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsAir"/>
         <GlossaryPriority value="140"/>
         <GlossaryStrongArray value="Banshee"/>
@@ -13161,6 +13159,7 @@
             <LayoutButtons Face="AP_DisruptorDispersion" Type="Passive" Requirements="AP_HaveVoidImmortalWeaponSplash" Row="1" Column="2"/>
             <LayoutButtons Face="AP_StalwartDualityCharge" Type="Passive" Requirements="AP_HaveStalwartDualityCharge" Row="2" Column="1"/>
         </CardLayouts>
+        <SelectAlias value="AP_ImmortalPurifier"/>
     </CUnit>
     <CUnit id="AP_ImmortalBarrier" parent="AP_Immortal">
         <AbilArray Link="AP_ImmortalBarrierBase"/>
@@ -13330,7 +13329,6 @@
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Immortal"/>
-        <SelectAlias value="Immortal"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <GlossaryPriority value="120"/>
         <GlossaryStrongArray value="SiegeTankSieged"/>
@@ -13429,7 +13427,6 @@
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Immortal"/>
-        <SelectAlias value="Immortal"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <GlossaryPriority value="120"/>
         <GlossaryStrongArray value="SiegeTankSieged"/>
@@ -13696,7 +13693,6 @@
         <MinimapRadius value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
         <TacticalAI value="Colossus"/>
-        <SelectAlias value="Colossus"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <GlossaryPriority value="130"/>
         <GlossaryStrongArray value="Marine"/>
@@ -14041,7 +14037,6 @@
         <GlossaryWeakArray value="Observer"/>
         <HotkeyCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <AIEvaluateAlias value="DarkTemplar"/>
-        <SelectAlias value="DarkTemplar"/>
         <ReviveInfoBase>
             <Charge Link="DarkTemplar/Revive"/>
             <Cooldown Link="DarkTemplar/Revive"/>
@@ -14228,7 +14223,6 @@
         <GlossaryWeakArray value="Observer"/>
         <HotkeyCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <AIEvaluateAlias value="DarkTemplar"/>
-        <SelectAlias value="DarkTemplar"/>
         <ReviveInfoBase>
             <Charge Link="DarkTemplar/Revive"/>
             <Cooldown Link="DarkTemplar/Revive"/>
@@ -14562,7 +14556,6 @@
         <KillDisplay value="Always"/>
         <RankDisplay value="Always"/>
         <AIEvaluateAlias value="HighTemplar"/>
-        <SelectAlias value="HighTemplar"/>
         <TauntDuration index="Cheer" value="5"/>
         <TauntDuration index="Dance" value="5"/>
         <ReviveInfoBase>
@@ -14675,7 +14668,6 @@
         <KillDisplay value="Always"/>
         <RankDisplay value="Always"/>
         <AIEvaluateAlias value="HighTemplar"/>
-        <SelectAlias value="HighTemplar"/>
         <TauntDuration index="Cheer" value="5"/>
         <TauntDuration index="Dance" value="5"/>
         <ReviveInfoBase>
@@ -20354,7 +20346,6 @@
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
         <LeaderAlias value="AP_Stalker"/>
-        <SelectAlias value="Stalker"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <GlossaryPriority value="30"/>
         <GlossaryStrongArray value="Reaper"/>
@@ -20893,7 +20884,6 @@
         <MinimapRadius value="0.625"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Stalker"/>
-        <SelectAlias value="Stalker"/>
         <LeaderAlias value="AP_Stalker"/>
         <GlossaryCategory value="Unit/Category/AP_ProtossUnitsGround"/>
         <GlossaryPriority value="30"/>
@@ -23084,7 +23074,6 @@
             <LayoutButtons Face="AP_DestroyerChargingBeam" Type="Passive" Requirements="AP_HaveDestroyerChargingBeam" Row="2" Column="1"/>
         </CardLayouts>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
-        <SelectAlias value="VoidRay"/>
     </CUnit>
     <CUnit id="AP_VoidRayAiur" parent="AP_VoidRayCampaignBase">
         <Food value="-3"/>
@@ -23093,7 +23082,6 @@
             <LayoutButtons Face="AP_PrismaticBeam" Type="Passive" Row="2" Column="0"/>
         </CardLayouts>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
-        <SelectAlias value="VoidRay"/>
     </CUnit>
     <CUnit id="AP_VoidRayPurifier" parent="AP_VoidRayCampaignBase">
         <WeaponArray Link="AP_VoidRayPurifierBeamLaunch" Turret="AP_VoidRayPurifier"/>
@@ -23109,7 +23097,6 @@
         </CardLayouts>
         <EquipmentArray Weapon="AP_VoidRayPurifierWeaponInfo"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Campaign"/>
-        <SelectAlias value="VoidRay"/>
     </CUnit>
     <CUnit id="AP_Viper">
         <DeathRevealRadius value="3"/>


### PR DESCRIPTION
Currently, there's an inconsistent and undesirable behaviour where ctrl+clicking some protoss units will include some of their variants. e.g. ctrl+click on high templar would also select signifiers. This is undesirable for casters with particular abilities or units that are different enough to warrant different macro.

In the interest of consistency, I've separated out all groups; the only remaining groups should be "primary" variant with base and vanilla versions of the unit, which should only matter when mind-control is involved.

Tested by giving myself all units, making a box-art army, and ctrl+clicking every unit type to make sure only that precise unit type was selected.