### PR TITLE
sc2: Making message box nondraggable so it doesnt eat box selections

### DIFF
--- a/Mods/ArchipelagoCore.SC2Mod/Base.SC2Data/ui/Layout/ap_Chatbox.SC2Layout
+++ b/Mods/ArchipelagoCore.SC2Mod/Base.SC2Data/ui/Layout/ap_Chatbox.SC2Layout
@@ -11,7 +11,6 @@
     </Frame>
 
     <Frame type="ScrollableFrame" name="ScrollableTemplate">
-        <AcceptsMouse val="True"/>
         <Frame type="Frame" name="ContainerFrame"/>
         <Frame type="ScrollBar" name="ScrollBar">
             <Anchor side="Top" relative="$parent" pos="Min" offset="0"/>
@@ -79,14 +78,13 @@
 
     <Frame type="Frame" name="GameUI/UIContainer/FullscreenUpperContainer" file="GameUI">
         
-        <Frame type="Control" name="ap_Chatbox" template="ap_Chatbox/DraggableFrameTemplate">
+        <Frame type="Frame" name="ap_Chatbox">
             <!-- ap_Chatbox is the main frame containing the rest. its area is used for the header label -->
             <Anchor side="Top" relative="$parent" pos="Min" offset="#Border"/>
             <Anchor side="Left" relative="$parent" pos="Min" offset="#Border"/>
             <Height val="75"/>
             <Width val="500"/>
             <Handle val="ap_Chatbox"/>
-            <DragConstraintFrame val="$parent"/>
             <RenderPriority val="1000"/>
 
             <Visible val="False"/>


### PR DESCRIPTION
A fairly small change. Resizing and the scrollbar both still work. All regions behind the message box still accept drag selections.

![selectable_message_box](https://github.com/user-attachments/assets/eca546c7-a4fc-4c34-abda-c22a224786ca)
