### PR TITLE
small fixes and balance

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -11499,7 +11499,7 @@
         <Cost>
             <Vital index="Energy" value="125"/>
         </Cost>
-        <TargetFilters value="Air,Visible;Self,Player,Ally,Neutral,Structure,Heroic,Stasis,Invulnerable"/>
+        <TargetFilters value="Air,Visible;Self,Player,Ally,Neutral,Structure,Stasis,Invulnerable"/>
         <Range value="8"/>
         <CmdButtonArray index="Execute" DefaultButtonFace="AP_ParasiticBomb" Requirements="AP_HaveViperParasiticBomb"/>
     </CAbilEffectTarget>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AccumulatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AccumulatorData.xml
@@ -83,4 +83,9 @@
         <BonusPerLevel value="6.75"/>
         <PreviousValueFactor value="1"/>
     </CAccumulatorVeterancyLevel>
+    <CAccumulatorVitals id="AP_UnitMaxShields">
+        <Ratio value="1"/>
+        <VitalType value="Shields"/>
+        <ModificationType value="PerUnitMaxVital"/>
+    </CAccumulatorVitals>
 </Catalog>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -24756,7 +24756,7 @@
         <Food value="-2"/>
         <CostCategory value="Army"/>
         <CostResource index="Minerals" value="150"/>
-        <CostResource index="Vespene" value="200"/>
+        <CostResource index="Vespene" value="150"/>
         <BuildTime value="37.5"/>
         <AbilArray Link="attack"/>
         <AbilArray Link="move"/>
@@ -26187,10 +26187,7 @@
         <FlagArray index="UseLineOfSight" value="1"/>
         <FlagArray index="ArmySelect" value="1"/>
         <PlaneArray index="Ground" value="1"/>
-        <Collide index="Colossus" value="1"/>
         <Collide index="Structure" value="1"/>
-        <Collide index="LocustForceField" value="1"/>
-        <Attributes index="Light" value="1"/>
         <Attributes index="Biological" value="1"/>
         <Attributes index="Heroic" value="1"/>
         <LifeStart value="250"/>
@@ -26213,7 +26210,6 @@
         <AbilArray Link="move"/>
         <AbilArray Link="attack"/>
         <AbilArray Link="AP_LeapAttack"/>
-        <!--BehaviorArray Link="Detector11"/--> <!-- doesn't need to be a detector-->
         <BehaviorArray Link="AP_MalignantCreepFix"/>
         <BehaviorArray Link="AP_HunterlingJump"/>
         <CardLayouts>
@@ -26243,7 +26239,7 @@
         <TauntDuration index="Dance" value="5"/>
         <Mover value="CliffJumper"/>
         <WeaponArray Link="AP_HunterlingClaws"/>
-        <LifeArmor value="1"/>
+        <LifeArmor value="2"/>
         <Food value="-1"/>
     </CUnit>
     <CUnit id="AP_HunterlingPlaceholder" parent="PLACEHOLDER">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -14863,8 +14863,9 @@
         <AffectedUnitArray value="AP_GuardianSCBW"/>
     </CUpgrade>
     <CUpgrade id="AP_GuardianAirAttack">
-        <EffectArray Operation="Set" Reference="Weapon,AP_GuardianSCBWWeaponAir,Options[Disabled]" Value="0"/>
-        <EffectArray Operation="Set" Reference="Weapon,AP_GuardianSCBWWeaponAir,Options[Hidden]" Value="0"/>
+        <EffectArray Operation="Subtract" Reference="Weapon,AP_GuardianSCBWWeaponAir,Options[Hidden]" Value="1"/>
+        <EffectArray Operation="Subtract" Reference="Weapon,AP_GuardianSCBWWeaponAir,Options[Disabled]" Value="1"/>
+        <AffectedUnitArray value="AP_GuardianSCBW"/>
     </CUpgrade>
     <CUpgrade id="AP_GuardianAttackDamage">
         <EffectArray Operation="Set" Reference="Effect,AP_GuardianSCBWWeapon@LM,ImpactEffect" Value="AP_GuardianSCBWWeapon@DamageUpgraded"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -2163,7 +2163,7 @@ Button/Tooltip/AP_AdeptPiercingAttack=Increases Adept attack speed.
 Button/Tooltip/AP_AdeptShieldUpgrade=Increases the <c val="ffff8a">Adept's</c> shields by 50.
 Button/Tooltip/AP_AdvancedAISystems=Science Vessel can Nano-Repair two targets at once.
 Button/Tooltip/AP_AdvancedConstruction=Multiple SCVs can build a structure, reducing its construction time.
-Button/Tooltip/AP_AdvancedDefensiveMatrix=Surrounds the Battlecruiser with a shield that can absorb 200 damage. Passive.<n/><n/>Can spend energy to instantly heal shields.
+Button/Tooltip/AP_AdvancedDefensiveMatrix=Spend Energy to fully restore shields to the Battlecruiser.<n/><n/>Surrounds the Battlecruiser with a shield that can absorb <d ref="$RunAccumulators:AP_UnitMaxShields$"/> damage. <c val="ffff8a">Passive.</c>
 Button/Tooltip/AP_AdvancedHealingAI=The Medivac can heal two targets at once.
 Button/Tooltip/AP_AdvancedWeaponryRaven=Adds a Hunter-Seeker Missile weapon that automatically attacks enemy units and does not cost energy.
 Button/Tooltip/AP_AerodynamicGlaveShape=Increases Mutalisk attack range by 2.
@@ -2924,7 +2924,7 @@ Button/Tooltip/AP_NukeCalldown=Calls down a Nuclear Strike at a target location.
 Button/Tooltip/AP_NukeCalldownMengsk=Calls down a Tactical Missile Strike at a target location. Tactical Missiles take <d ref="Effect,AP_GhostMengskNukeCP,InitialDelay + Effect,AP_GhostMengskNukeCP,ExpireDelay + Effect,GhostMengskNukeDetonateCP,InitialDelay"/> seconds to land, but they deal up to <d ref="Effect,AP_GhostMengskNukeDamage,Amount"/> (+<d ref="Effect,AP_GhostMengskNukeDamage,AttributeBonus[Structure]"/> vs. structures) damage to enemies in a small radius.<n/><n/>Purchase charges at the Royal Academy.
 Button/Tooltip/AP_NukeMengskArm=Arms the Silo with a Tactical Missile.<n/><n/>Tactical Missiles take <d ref="Effect,AP_GhostMengskNukeCP,InitialDelay + Effect,AP_GhostMengskNukeCP,ExpireDelay + Effect,AP_GhostMengskNukeDetonateCP,InitialDelay"/> seconds to land, but they deal up to <d ref="Effect,AP_GhostMengskNukeDamage,Amount"/> (+<d ref="Effect,AP_GhostMengskNukeDamage,AttributeBonus[Structure]"/> vs. structures) damage in a small radius.<n/><n/>Use an Emperor's Shadow to designate the target.
 Button/Tooltip/AP_NydusNetwork=<c val="ffff8a">Enables:</c><n/>- Nydus Worm <n/>- Echidna Worm
-Button/Tooltip/AP_NydusRecall=Recalls the Worm to the Nydus Network, removing it and returning 100% of its mineral and gas value (after cost reductions). Salvage takes <d time="3"/> to finish. Warning: once Salvage is triggered, it cannot be canceled.
+Button/Tooltip/AP_NydusRecall=Recalls the Worm to the Nydus Network, removing it and returning 100% of its mineral and gas value (after cost reductions). Nydus Recall takes <d time="3"/> to finish. Warning: once Nydus Recall is triggered, it cannot be canceled.
 Button/Tooltip/AP_NydusWorm=Friendly ground units can use a Nydus Worm to instantly travel to any other Nydus Worm or Nydus Network owned by the player.
 Button/Tooltip/AP_NydusWormJormungandrStrain=Removes emerge time for Nydus Worms and Echidna Worms, and allows them to be salvaged, returning the cost spent on them.
 Button/Tooltip/AP_NydusWormRavenousAppetite=Allows Nydus Worms and Nydus Networks to unload and load units nearly instantly.


### PR DESCRIPTION
Makes the following changes:
fixes primal adaptation doesn't work midmission for existing units (guardian AA)
reduces guardian cost by 50 gas.
hunterling +1 armor, remove colossus collision, not light anymore.
rg bc advanced defensive matrix text didn't scale, also clarified language.
allow parasitic bomb on heroic for vipers
nydus recall text, removed reference to salvage, which sounds odd for zerg, and doesn't match the ability name.
