### PR TITLE
sc2: Giving yggdrasil 8 transport slots baseline; 16 with ventral sacs

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -10665,6 +10665,28 @@
         <Flags index="CargoDeath" value="1"/>
         <AbilSetId value="ULdM"/>
     </CAbilTransport>
+    <CAbilTransport id="AP_YggdrasilTransport">
+        <EditorCategories value="Race:Zerg,AbilityorEffectType:Units"/>
+        <MaxCargoCount value="8"/>
+        <MaxCargoSize value="8"/>
+        <TotalCargoSpace value="8"/>
+        <LoadTransportBehavior value="OverlordTransport"/>
+        <UnloadPeriod value="1"/>
+        <CmdButtonArray index="Load" DefaultButtonFace="OverlordTransportLoad"/>
+        <CmdButtonArray index="UnloadAll">
+            <Flags index="Hidden" value="1"/>
+            <Flags index="ToSelection" value="1"/>
+        </CmdButtonArray>
+        <CmdButtonArray index="UnloadAt" DefaultButtonFace="OverlordTransportUnload"/>
+        <CmdButtonArray index="UnloadUnit">
+            <Flags index="Hidden" value="1"/>
+        </CmdButtonArray>
+        <CmdButtonArray index="LoadAll">
+            <Flags index="Hidden" value="1"/>
+        </CmdButtonArray>
+        <Flags index="CargoDeath" value="1"/>
+        <AbilSetId value="ULdM"/>
+    </CAbilTransport>
     <CAbilTrain id="AP_TrainQueen">
         <EditorCategories value="Race:Zerg,AbilityorEffectType:Structures"/>
         <Activity value="UI/Spawning"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -29448,11 +29448,10 @@
         <KillXP value="20"/>
         <AbilArray Link="stop"/>
         <AbilArray Link="move"/>
-        <AbilArray Link="AP_OverlordTransport"/>
+        <AbilArray Link="AP_YggdrasilTransport"/>
         <AbilArray Link="AP_YggdrasilGenerateCreep"/>
         <AbilArray Link="AP_YggdrasilAssimilate"/>
         <AbilArray Link="AP_YggdrasilBuild"/>
-        <BehaviorArray Link="AP_OverlordPreventTransport"/>
         <CardLayouts>
             <LayoutButtons Face="Move" Type="AbilCmd" AbilCmd="move,Move" Row="0" Column="0"/>
             <LayoutButtons Face="Stop" Type="AbilCmd" AbilCmd="stop,Stop" Row="0" Column="1"/>
@@ -29460,8 +29459,8 @@
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
             <LayoutButtons Face="AcquireMove" Type="AbilCmd" AbilCmd="move,AcquireMove" Row="0" Column="4"/>
             <LayoutButtons Face="MovePatrol" Type="AbilCmd" AbilCmd="move,Patrol" Row="0" Column="3"/>
-            <LayoutButtons Face="OverlordTransportLoad" Type="AbilCmd" AbilCmd="AP_OverlordTransport,Load" Row="2" Column="2"/>
-            <LayoutButtons Face="OverlordTransportUnload" Type="AbilCmd" AbilCmd="AP_OverlordTransport,UnloadAt" Row="2" Column="3"/>
+            <LayoutButtons Face="OverlordTransportLoad" Type="AbilCmd" AbilCmd="AP_YggdrasilTransport,Load" Row="2" Column="2"/>
+            <LayoutButtons Face="OverlordTransportUnload" Type="AbilCmd" AbilCmd="AP_YggdrasilTransport,UnloadAt" Row="2" Column="3"/>
             <LayoutButtons Face="AP_K5ImprovedOverlords" Type="Passive" Requirements="AP_HaveK5ImprovedOverlords" Row="1" Column="4"/>
             <LayoutButtons Face="AP_OverlordSpeed" Type="Passive" Requirements="AP_HaveOverlordSpeed" Row="1" Column="3"/>
             <LayoutButtons Face="AP_OverlordSightUpgrade" Type="Passive" Requirements="AP_HaveOverlordSightUpgrade" Row="1" Column="2"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -11206,6 +11206,9 @@
     </CUpgrade>
     <CUpgrade id="AP_overlordtransport">
         <Icon value="Assets\Textures\btn-upgrade-zerg-ventralsacs.dds"/>
+        <EffectArray Reference="Abil,AP_YggdrasilTransport,MaxCargoCount" Value="8"/>
+        <EffectArray Reference="Abil,AP_YggdrasilTransport,MaxCargoSize" Value="8"/>
+        <EffectArray Reference="Abil,AP_YggdrasilTransport,TotalCargoSpace" Value="8"/>
         <Alert value="ResearchComplete"/>
         <Race value="Zerg"/>
         <ScoreAmount value="400"/>


### PR DESCRIPTION
Giving yggdrasils transport ability while still being affected by ventral sacs. Tested by getting them, lifting/dropping without ventral sacs, then using `/send` to get ventral sacs and verifying that yggdrasils with cargo still had the cargo, could carry more, and could carry up to 16.

![Screenshot2024-11-24 02_55_55](https://github.com/user-attachments/assets/d6b4e399-b83b-411a-abde-3734fb3932d1)
![Screenshot2024-11-24 02_56_32](https://github.com/user-attachments/assets/d3eb9454-ba9f-4708-9d6f-8fcc66653c01)
