### PR TITLE
Trireme bomber adjustment

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -17968,9 +17968,8 @@
         <PeriodicValidator value="CasterNotDead"/>
         <PeriodicEffectArray value="AP_CarrierPurifierBomberLM"/>
         <PeriodicPeriodArray value="0"/>
-        <PeriodicPeriodArray value="0.125"/>
-        <PeriodicPeriodArray value="0.125"/>
-        <PeriodicPeriodArray value="0.125"/>
+        <PeriodicPeriodArray value="0.5"/>
+        <PeriodicPeriodArray value="0.5"/>
         <PeriodicOffsetArray value="0,-0.1,-3"/>
     </CEffectCreatePersistent>
     <CEffectLaunchMissile id="AP_CarrierPurifierBomberLM">
@@ -17991,7 +17990,9 @@
         <Amount value="9"/>
         <Death value="Blast"/>
         <SearchFilters value="Ground;Self,Player,Ally,Neutral,Missile,Stasis,Dead,Hidden,Invulnerable"/>
-        <AreaArray Radius="0.5" Fraction="1"/>
+        <AreaArray Radius="0.25" Fraction="1"/>
+        <AreaArray Radius="0.5" Fraction="0.5"/>
+        <AreaArray Radius="1" Fraction="0.25"/>
         <ExcludeArray Value="Target"/>
     </CEffectDamage>
     <CEffectDamage id="AP_CarrierPurifierBomberFriendlyDamage" parent="DU_WEAP">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -18002,7 +18002,7 @@
         <Amount value="3"/>
         <Death value="Blast"/>
         <SearchFilters value="Ground;Self,Enemy,Missile,Stasis,Dead,Hidden,Invulnerable"/>
-        <AreaArray Radius="0.5" Fraction="1"/>
+        <AreaArray Radius="0.25" Fraction="1"/>
         <ExcludeArray Value="Target"/>
     </CEffectDamage>
     <CEffectCreatePersistent id="AP_CarrierPurifierPrismaticBeam">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ModelData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ModelData.xml
@@ -15597,6 +15597,8 @@
     <CModel id="AP_CarrierPurifierBomberAttackImpact" parent="ImpactFX">
         <Model value="Assets\Effects\Protoss\Carrier_Purifier_Coop_Bomber_Missile_Impact\Carrier_Purifier_Coop_Bomber_Missile_Impact.m3"/>
         <EditorCategories value="Race:Protoss"/>
+        <ScaleMax value="0.600000,0.600000,0.600000"/>
+        <ScaleMin value="0.600000,0.600000,0.600000"/>
     </CModel>
     <CModel id="AP_CarrierPurifierBomberDeath" parent="UnitDeath" Race="Protoss">
         <Model value="Assets\Units\Protoss\Bomber_Purifier_Collection_Death\Bomber_Purifier_Collection_Death.m3"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/MoverData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/MoverData.xml
@@ -2116,9 +2116,11 @@
     </CMoverMissile>
     <CMoverMissile id="AP_CarrierPurifierBomber">
         <MotionPhases>
-            <Driver value="Guidance"/>
+            <Driver value="Throw"/>
             <Acceleration value="3200"/>
-            <MaxSpeed value="3"/>
+            <MaxSpeed value="5"/>
+            <Gravity value="1"/>
+            <ThrowVector value="0,0,-1"/>
             <ClearanceAcceleration value="75"/>
             <ArrivalTestType value="3D"/>
             <Outro value="-1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/SoundData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/SoundData.xml
@@ -11457,7 +11457,7 @@
         <DupeMuteCount value="3"/>
         <DupePrioritization value="Oldest"/>
         <Pitch value="-2.000000,0.000000"/>
-        <Volume value="-6.000000,-4.000000"/>
+        <Volume value="-12.000000,-9.000000"/>
     </CSound>
     <CSound id="AP_CarrierPurifierBomber_AttackImpact" parent="Combat">
         <EditorCategories value="Race:Protoss"/>
@@ -11473,7 +11473,7 @@
         <DupeMuteCount value="3"/>
         <DupePrioritization value="Oldest"/>
         <Pitch value="-6.000000,-3.000000"/>
-        <Volume value="-8.000000,-6.000000"/>
+        <Volume value="-15.000000,-12.000000"/>
     </CSound>
     <CSound id="AP_CarrierPurifierBomber_MissileLaunch" parent="Combat">
         <EditorCategories value="Race:Protoss"/>
@@ -11489,7 +11489,7 @@
         <DupeMuteCount value="3"/>
         <DupePrioritization value="Oldest"/>
         <Pitch value="-1.000000,3.000000"/>
-        <Volume value="-6.000000,-4.000000"/>
+        <Volume value="-12.000000,-9.000000"/>
         <DupeDestroyCount value="8"/>
     </CSound>
     <CSound id="AP_CarrierPurifier_WeaponEnd" parent="Combat">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -12353,6 +12353,7 @@
         <ShieldArmorName value="Unit/ShieldArmorName/ProtossPlasmaShields"/>
         <Mover value="Fly"/>
         <Speed value="5.5"/>
+        <SpeedMinimum value="4"/>
         <Acceleration value="1000"/>
         <StationaryTurningRate value="999.8437"/>
         <TurningRate value="999.8437"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -3170,9 +3170,11 @@
         <Icon value="Assets\Textures\btn-unit-collection-purifier-bomber.dds"/>
         <TargetFilters value="Ground,Visible;Missile,Stasis,Dead,Hidden,Invulnerable"/>
         <DisplayAttackCount value="3"/>
-        <Range value="0.1"/>
+        <Range value="0.75"/>
+        <RangeSlop value="3"/>
+        <Arc value="360"/>
+        <LoiterInnerRadius value="3"/>
         <TeleportResetRange value="0"/>
-        <Arc value="19.6875"/>
         <Period value="3"/>
         <DisplayEffect value="AP_CarrierPurifierBomberDamage"/>
         <Effect value="AP_CarrierPurifierBomberCP"/>


### PR DESCRIPTION
Goal of changes: Make the Trireme bombers feel a little more like they're doing actual bombing runs; adjust their damage profile slightly vs smaller units (slightly weaker vs smaller stationary units, but able to deal a non-zero amount of damage vs small moving units). Also make the visual/audio effects a little more gentle to reflect the reduced impact of individual bombs.

Superficial changes (because the effects were previously scaled for the co-op version iirc, so they were built around a much bigger impact):
- Radius of explosion VFX reduced to 60% of normal
- Volume of launch and explosion SFX reduced slightly

Changes to bomber drone:
- Added minimum speed of 4 (so they'd quit stopping in midair, which means they randomly concentrate their bombs on one location)
- Increased LoiterInnerRadius 2->3 so they move a little further before turning
- Increased weapon range 0.1->0.75 so they start dropping bombs slightly ahead of their target
- A few tweaks to rangeslop and arc so they don't constantly try to retarget

Changes to bombs:
- Period between drops increased 0.125->0.5 (spreads out damage a bit)
- Damage radius profile changed: 
-- Full damage at 0.5 radius -> Full damage at 0.25 radius, half damage at 0.5 radius, quarter damage at 1 radius (so you do a small amount of damage more frequently, but direct hits still hurt just as much)
- Mover changed from "Guidance" to "Throw" with increased speed (so the bomb just drops, and it drops much faster)

Observations in testing:
- Still basically the same vs structures, though _slightly_ weaker vs 2x2 structures, and slightly stronger vs tightly grouped structures
- Much weaker vs, say, individual zerglings minding their own business; now much more effective at destroying grouped units however, and now less ineffective vs fast-moving units (they deal chip damage rather than nothing)