### PR TITLE
sc2: Updating several hotkey and glossary categories for infested and royal guard units

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -7465,6 +7465,7 @@
         <TacticalAI value="Factory"/>
         <TechAliasArray value="Alias_Factory"/>
         <GlossaryPriority value="32"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
     </CUnit>
     <CUnit id="AP_FactoryMengskFlying">
@@ -7634,6 +7635,7 @@
         <MinimapRadius value="1.5"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:Melee"/>
         <GlossaryPriority value="31"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <TechTreeUnlockedUnitArray value=""/>
     </CUnit>
@@ -19385,6 +19387,7 @@
         <TacticalAI value="Starport"/>
         <TechAliasArray value="Alias_Starport"/>
         <GlossaryPriority value="33"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <TechTreeProducedUnitArray value="AP_VikingFighter"/>
         <TechTreeProducedUnitArray value="AP_Medivac"/>
@@ -22672,7 +22675,9 @@
         <SubgroupPriority value="3"/>
         <MinimapRadius value="1.75"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:FactionInfested"/>
-        <HotkeyCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <GlossaryPriority value="245"/>
     </CUnit>
     <CUnit id="AP_SIInfestedBunker" parent="AP_SIInfestedBunkerRootableAnywhere">
         <AbilArray index="8" removed="1"/>
@@ -22751,7 +22756,8 @@
         <EditorCategories value="ObjectType:Unit,ObjectFamily:FactionInfested"/>
         <HotkeyAlias value="AP_SIInfestedBunker"/>
         <EquipmentArray Weapon="AP_InfestedBunkerFakeUprootedMelee"/>
-        <HotkeyCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <KillDisplay value="Always"/>
     </CUnit>
     <CUnit id="AP_SICocoon">
@@ -22893,9 +22899,9 @@
         <SubgroupPriority value="4"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:FactionInfested"/>
-        <GlossaryCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <GlossaryPriority value="10"/>
-        <HotkeyCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
             <ChanceArray index="Idle" value="33"/>
@@ -22968,8 +22974,9 @@
         <EditorCategories value="ObjectType:Structure,ObjectFamily:FactionInfested"/>
         <LeaderAlias value="SIBarracks"/>
         <TechAliasArray value="Alias_SIBarracks"/>
-        <GlossaryCategory value="Unit/Category/AP_InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
+        <GlossaryPriority value="245"/>
     </CUnit>
     <CUnit id="AP_SIBarracksFlying">
         <Name value="Unit/Name/AP_SIBarracks"/>
@@ -23025,7 +23032,7 @@
         <HotkeyAlias value="AP_SIBarracks"/>
         <TechAliasArray value="Alias_SIBarracks"/>
         <GlossaryAlias value="AP_SIBarracks"/>
-        <HotkeyCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
     </CUnit>
     <CUnit id="TechLab">
         <!-- Override -->
@@ -25788,8 +25795,8 @@
         <Attributes index="Light" value="1"/>
         <Attributes index="Biological" value="1"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:FactionInfested"/>
-        <GlossaryCategory value="Unit/Category/AP_InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
             <ChanceArray index="Idle" value="33"/>
@@ -25843,7 +25850,7 @@
         <EditorCategories value="ObjectType:Unit,ObjectFamily:FactionInfested"/>
         <LeaderAlias value="AP_SIInfestedMarine"/>
         <HotkeyAlias value="AP_SIInfestedMarine"/>
-        <HotkeyCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <SelectAlias value="AP_SIInfestedMarine"/>
         <AIEvaluateAlias value="AP_SIInfestedMarine"/>
         <Food value="-1"/>
@@ -25902,8 +25909,8 @@
         <SubgroupPriority value="10"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:FactionInfested"/>
-        <GlossaryCategory value="Unit/Category/AP_InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
             <ChanceArray index="Idle" value="33"/>
@@ -25957,7 +25964,7 @@
         <LeaderAlias value="AP_SIInfestedTrooper"/>
         <HotkeyAlias value="AP_SIInfestedTrooper"/>
         <SelectAlias value="AP_SIInfestedTrooper"/>
-        <HotkeyCategory value="Unit/Category/AP_InfestedTerranUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <AIEvaluateAlias value="AP_SIInfestedTrooper"/>
     </CUnit>
     <CUnit id="AP_VoidRayPurifierBeam">
@@ -26638,9 +26645,9 @@
         <AIEvalFactor value="0.9"/>
         <Mass value="0.6"/>
         <TechAliasArray value="Alias_BattlecruiserClass"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="210"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsAir"/>
+        <HotkeyCategory value="Unit/Category/AP_TerranUnitsAir"/>
         <AIEvaluateAlias value="Battlecruiser"/>
         <ReviveInfoBase>
             <Charge Link="Battlecruiser/Revive"/>
@@ -26729,9 +26736,9 @@
         <MinimapRadius value="1.625"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:FactionInfested"/>
         <TechAliasArray value="Alias_InfestedFactory"/>
-        <GlossaryPriority value="32"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryPriority value="245"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
     </CUnit>
     <CUnit id="AP_SIFactoryFlying">
         <Name value="Unit/Name/AP_SIFactory"/>
@@ -26787,8 +26794,10 @@
         <LeaderAlias value="Factory"/>
         <HotkeyAlias value="Factory"/>
         <TechAliasArray value="Alias_InfestedFactory"/>
-        <GlossaryAlias value="Factory"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
+        <GlossaryAlias value="AP_SIFactory"/>
+        <HotkeyAlias value="AP_SIFactory"/>
         <InnerRadius value="1"/>
         <SpeedMultiplierCreep value="2"/>
     </CUnit>
@@ -26861,9 +26870,9 @@
         <MinimapRadius value="1.625"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:FactionInfested"/>
         <TechAliasArray value="Alias_InfestedStarport"/>
-        <GlossaryPriority value="33"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryPriority value="245"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
     </CUnit>
     <CUnit id="AP_SIStarportFlying">
         <Name value="Unit/Name/AP_SIStarport"/>
@@ -26918,9 +26927,10 @@
         <EditorCategories value="ObjectType:Structure,ObjectFamily:FactionInfested"/>
         <LeaderAlias value="AP_SIStarport"/>
         <HotkeyAlias value="AP_SIStarport"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <TechAliasArray value="Alias_InfestedStarport"/>
         <GlossaryAlias value="AP_SIStarport"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
         <InnerRadius value="1"/>
         <SpeedMultiplierCreep value="2"/>
     </CUnit>
@@ -26982,9 +26992,9 @@
         </CardLayouts>
         <AddedOnArray UnitLink="AP_SIFactory" BehaviorLink="AP_SIFactoryTechLab"/>
         <AddedOnArray UnitLink="AP_SIStarport" BehaviorLink="AP_SIStarportTechLab"/>
-        <GlossaryPriority value="26"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryPriority value="245"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value=""/>
     </CUnit>
     <CUnit id="AP_SIFactoryTechLab" parent="AP_SITechLab">
         <Mob value="None"/>
@@ -27082,12 +27092,13 @@
         <TacticalAI value="SiegeTank"/>
         <AIEvalFactor value="1.5"/>
         <LeaderAlias value="AP_StukovInfestedSiegeTank"/>
+        <GlossaryAlias value="AP_StukovInfestedSiegeTank"/>
         <HotkeyAlias value="AP_StukovInfestedSiegeTank"/>
         <SelectAlias value="AP_StukovInfestedSiegeTank"/>
         <SubgroupAlias value="AP_StukovInfestedSiegeTank"/>
         <TechAliasArray value="Alias_SiegeTank"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
             <ChanceArray index="Idle" value="33"/>
@@ -27170,8 +27181,10 @@
         <GlossaryStrongArray value="Marauder"/>
         <GlossaryWeakArray value="Banshee"/>
         <GlossaryWeakArray value="LiberatorAG"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
+        <GlossaryAlias value="AP_StukovInfestedSiegeTank"/>
+        <HotkeyAlias value="AP_StukovInfestedSiegeTank"/>
         <AIEvaluateAlias value="SiegeTankSieged"/>
         <LifeRegenRate value="0.2734"/>
     </CUnit>
@@ -27286,7 +27299,7 @@
         <GlossaryWeakArray value="Hellion"/>
         <GlossaryWeakArray value="Banshee"/>
         <GlossaryWeakArray value="HERC"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
     </CUnit>
     <CUnit id="AP_SIVolatileInfestedBurrowed">
         <DeathRevealRadius value="3"/>
@@ -27401,8 +27414,8 @@
         <GlossaryWeakArray value="Zergling"/>
         <GlossaryWeakArray value="Zealot"/>
         <GlossaryWeakArray value="Marauder"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <LifeRegenRate value="0.2734"/>
     </CUnit>
     <CUnit id="AP_StukovInfestedDiamondSlimePuddle">
@@ -27534,8 +27547,8 @@
         <GlossaryStrongArray value="Marauder"/>
         <GlossaryWeakArray value="Liberator"/>
         <GlossaryWeakArray value="Goliath"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <AIEvaluateAlias value="Banshee"/>
         <LifeRegenRate value="0.2734"/>
     </CUnit>
@@ -27664,7 +27677,7 @@
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:FactionInfested"/>
         <TacticalAIThink value="AIThinkSILiberator"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
         <GlossaryPriority value="160"/>
         <GlossaryStrongArray value="Mutalisk"/>
         <GlossaryStrongArray value="VoidRay"/>
@@ -27672,7 +27685,7 @@
         <GlossaryWeakArray value="SporeCrawler"/>
         <GlossaryWeakArray value="PhotonCannon"/>
         <GlossaryWeakArray value="MissileTurret"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <TurningRate value="1499.9414"/>
         <LifeRegenRate value="0.2734"/>
     </CUnit>
@@ -27855,7 +27868,7 @@
         <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="155"/>
         <GlossaryAlias value="AP_VikingMengskFighter"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <Fidget>
             <ChanceArray index="Anim" value="15"/>
             <ChanceArray index="Idle" value="55"/>
@@ -27941,9 +27954,9 @@
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TechAliasArray value="Alias_Viking"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsAir"/>
+        <HotkeyCategory value="Unit/Category/AP_TerranUnitsAir"/>
         <GlossaryPriority value="150"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
     </CUnit>
     <CUnit id="AP_VikingMengskFighterWeapon" parent="MISSILE_HALFLIFE">
         <Race value="Terr"/>
@@ -28045,9 +28058,9 @@
         <TacticalAI value="SiegeTank"/>
         <TacticalAIThink value="AIThinkSiegeTank"/>
         <AIEvalFactor value="1.5"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="130"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsGround"/>
+        <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <AIEvaluateAlias value="SiegeTank"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
@@ -28146,7 +28159,6 @@
         <TacticalAI value="SiegeTankSieged"/>
         <TacticalAIThink value="AIThinkSiegeTankSieged"/>
         <AIEvalFactor value="1.5"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="135"/>
         <GlossaryStrongArray value="Marine"/>
         <GlossaryStrongArray value="Hydralisk"/>
@@ -28154,7 +28166,8 @@
         <GlossaryWeakArray value="Banshee"/>
         <GlossaryWeakArray value="Mutalisk"/>
         <GlossaryWeakArray value="Immortal"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsGround"/>
+        <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <AIEvaluateAlias value="SiegeTankSieged"/>
         <ReviveInfoBase>
             <Charge Link="SiegeTankSieged/Revive"/>
@@ -28265,9 +28278,9 @@
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Thor"/>
         <TacticalAIThink value="AIThinkThor"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="140"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsGround"/>
+        <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <AIEvaluateAlias value="Thor"/>
         <Fidget>
             <ChanceArray index="Anim" value="10"/>
@@ -28374,9 +28387,8 @@
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Thor"/>
         <TacticalAIThink value="AIThinkThor"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="140"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
+        <GlossaryAlias value="AP_ThorMengsk"/>
         <LeaderAlias value="AP_ThorMengsk"/>
         <HotkeyAlias value="AP_ThorMengsk"/>
         <SelectAlias value="AP_ThorMengsk"/>
@@ -28473,9 +28485,8 @@
         <SelectAlias value="AP_ThorMengsk"/>
         <SubgroupAlias value="AP_ThorMengsk"/>
         <TechAliasArray value="Alias_Thor"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
+        <GlossaryAlias value="AP_ThorMengsk"/>
         <GlossaryPriority value="140"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
         <AIEvaluateAlias value="Thor"/>
         <Fidget>
             <ChanceArray index="Anim" value="10"/>
@@ -28582,9 +28593,9 @@
         <SubgroupPriority value="18"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <TacticalAI value="Marauder"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="60"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsGround"/>
+        <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <AIEvaluateAlias value="Marauder"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
@@ -28723,7 +28734,6 @@
         <TacticalAI value="Ghost"/>
         <TacticalAIThink value="AIThinkGhost"/>
         <AIEvalFactor value="1.2"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="70"/>
         <GlossaryStrongArray value="Raven"/>
         <GlossaryStrongArray value="Infestor"/>
@@ -28731,7 +28741,8 @@
         <GlossaryWeakArray value="Marauder"/>
         <GlossaryWeakArray value="Zergling"/>
         <GlossaryWeakArray value="Stalker"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsGround"/>
+        <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <AIEvaluateAlias value="Ghost"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
@@ -28801,7 +28812,6 @@
             <LayoutButtons Face="AP_AdvancedConstruction" Type="Passive" Requirements="AP_HaveAdvancedConstruction" Row="1" Column="3"/>
             <LayoutButtons Face="AP_TrooperMengskWeaponDrop" Type="Passive" Requirements="AP_HaveTrooperMengskWeaponDrop" Row="1" Column="4"/>
             <LayoutButtons Face="Halt" Type="AbilCmd" AbilCmd="AP_TrooperMengskBuild,30" Row="2" Column="4"/>
-
         </CardLayouts>
         <CardLayouts CardId="0002">
             <LayoutButtons Face="AP_TrooperMengskBuildThor" Type="AbilCmd" AbilCmd="AP_TrooperMengskBuild,Build24" Row="1" Column="1"/>
@@ -28823,9 +28833,9 @@
         <SubgroupPriority value="18"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="21"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_TerranUnitsGround"/>
+        <HotkeyCategory value="Unit/Category/AP_TerranUnitsGround"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
             <ChanceArray index="Idle" value="33"/>
@@ -28907,9 +28917,7 @@
         <SubgroupPriority value="18"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="21"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
             <ChanceArray index="Idle" value="33"/>
@@ -28919,6 +28927,7 @@
         <TauntDuration index="Dance" value="5"/>
         <AcquireLeashRadius value="500"/>
         <LeaderAlias value="AP_TrooperMengsk"/>
+        <GlossaryAlias value="AP_TrooperMengsk"/>
         <HotkeyAlias value="AP_TrooperMengsk"/>
         <SubgroupAlias value="AP_TrooperMengsk"/>
     </CUnit>
@@ -28996,9 +29005,7 @@
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:Melee"/>
         <AIEvalFactor value="1.2"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="70"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
             <ChanceArray index="Idle" value="33"/>
@@ -29006,6 +29013,7 @@
         </Fidget>
         <AcquireLeashRadius value="500"/>
         <LeaderAlias value="AP_TrooperMengsk"/>
+        <GlossaryAlias value="AP_TrooperMengsk"/>
         <HotkeyAlias value="AP_TrooperMengsk"/>
         <SubgroupAlias value="AP_TrooperMengsk"/>
     </CUnit>
@@ -29080,9 +29088,7 @@
         <SubgroupPriority value="18"/>
         <MinimapRadius value="0.375"/>
         <EditorCategories value="ObjectType:Unit,ObjectFamily:FactionRaider"/>
-        <GlossaryCategory value="Unit/Category/TerranUnits"/>
         <GlossaryPriority value="40"/>
-        <HotkeyCategory value="Unit/Category/MengskUnits"/>
         <Fidget>
             <ChanceArray index="Anim" value="33"/>
             <ChanceArray index="Idle" value="33"/>
@@ -29091,6 +29097,7 @@
         <LifeArmor value="1"/>
         <AcquireLeashRadius value="500"/>
         <LeaderAlias value="AP_TrooperMengsk"/>
+        <GlossaryAlias value="AP_TrooperMengsk"/>
         <HotkeyAlias value="AP_TrooperMengsk"/>
         <SubgroupAlias value="AP_TrooperMengsk"/>
     </CUnit>
@@ -29206,6 +29213,7 @@
             <LayoutButtons Face="AP_NovaUnitLockdown" Type="Passive" Requirements="AP_HaveGoliathMengskVeterancyLevel4" Row="1" Column="4"/>
             <LayoutButtons Face="AP_GoliathMengskVeterancy" Type="Passive" Row="2" Column="4"/>
         </CardLayouts>
+        <HotkeyAlias value="AP_GoliathMengsk"/>
     </CUnit>
     <CUnit id="AP_MedicMengsk" parent="AP_Medic">
         <Name value="Unit/Name/AP_MedicMengsk"/>
@@ -29274,6 +29282,8 @@
         </CardLayouts>
         <LeaderAlias value="AP_LiberatorMengsk"/>
         <SelectAlias value="AP_LiberatorMengsk"/>
+        <GlossaryAlias value="AP_LiberatorMengsk"/>
+        <HotkeyAlias value="AP_LiberatorMengsk"/>
         <SubgroupAlias value="AP_LiberatorMengsk"/>
     </CUnit>
     <CUnit id="AP_LiberatorMengskAG" parent="AP_LiberatorAG">
@@ -29307,6 +29317,8 @@
         </CardLayouts>
         <LeaderAlias value="AP_LiberatorMengsk"/>
         <SelectAlias value="AP_LiberatorMengsk"/>
+        <GlossaryAlias value="AP_LiberatorMengsk"/>
+        <HotkeyAlias value="AP_LiberatorMengsk"/>
         <SubgroupAlias value="AP_LiberatorMengsk"/>
     </CUnit>
     <CUnit id="AP_WraithMengsk" parent="AP_Wraith">
@@ -29347,6 +29359,7 @@
         <SelectAlias value="AP_WraithMengsk"/>
         <SubgroupAlias value="AP_WraithMengsk"/>
         <HotkeyAlias value="AP_WraithMengsk"/>
+        <GlossaryAlias value="AP_WraithMengsk"/>
     </CUnit>
     <CUnit id="AP_GuardianExplosiveSporesWeapon" parent="MISSILE">
         <Mover value="AP_GuardianExplosiveSpores"/>
@@ -29402,6 +29415,7 @@
             <LayoutButtons Face="AP_BansheeMengskNightAssaultOff" Type="AbilCmd" AbilCmd="AP_BansheeMengskNightAssault,Off" Row="1" Column="1"/>
         </CardLayouts>
         <HotkeyAlias value="AP_BansheeMengsk"/>
+        <GlossaryAlias value="AP_BansheeMengsk"/>
     </CUnit>
     <CUnit id="AP_SIStukovRallyBeaconPsiEmitterPoint" parent="DESTRUCTIBLE">
         <Race value="Zerg"/>
@@ -29494,15 +29508,15 @@
         <SubgroupPriority value="19"/>
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:FactionInfested"/>
-        <GlossaryPriority value="310"/>
+        <GlossaryPriority value="245"/>
         <GlossaryStrongArray value="Banshee"/>
         <GlossaryStrongArray value="Mutalisk"/>
         <GlossaryStrongArray value="VoidRay"/>
         <GlossaryWeakArray value="Marine"/>
         <GlossaryWeakArray value="Zergling"/>
         <GlossaryWeakArray value="Zealot"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <AIEvaluateAlias value="MissileTurret"/>
         <LifeRegenRate value="0.2734"/>
     </CUnit>
@@ -29567,7 +29581,7 @@
         <MinimapRadius value="0.75"/>
         <EditorCategories value="ObjectType:Structure,ObjectFamily:FactionInfested"/>
         <HotkeyAlias value="AP_SIMissileTurret"/>
-        <GlossaryPriority value="310"/>
+        <GlossaryPriority value="245"/>
         <GlossaryStrongArray value="Banshee"/>
         <GlossaryStrongArray value="Mutalisk"/>
         <GlossaryStrongArray value="VoidRay"/>
@@ -29575,8 +29589,8 @@
         <GlossaryWeakArray value="Zergling"/>
         <GlossaryWeakArray value="Zealot"/>
         <GlossaryAlias value="AP_SIMissileTurret"/>
-        <GlossaryCategory value="Unit/Category/InfestedTerranUnits"/>
-        <HotkeyCategory value="Unit/Category/InfestedTerranUnits"/>
+        <GlossaryCategory value="Unit/Category/AP_ZergUnits"/>
+        <HotkeyCategory value="Unit/Category/AP_ZergUnits"/>
         <AIEvaluateAlias value="MissileTurret"/>
     </CUnit>
     <CUnit id="AP_SILongboltMissileWeapon" parent="MISSILE_HALFLIFE">


### PR DESCRIPTION
Got all the Royal Guard units showing up in the correct category, and updated all zerg infested structures and units to the zerg category. The zerg category is so full at this point that it desperately needs a split, but I'm leaving that for another day.

![image](https://github.com/user-attachments/assets/4e9ead6e-0b8a-42d8-802b-28c6f287111d)
![image](https://github.com/user-attachments/assets/a4d450f8-d4e3-4734-ac79-3d60e104ad99)
![image](https://github.com/user-attachments/assets/7e2eeb0f-1753-4e7b-b1ac-74ed463b5347)

The two no-icon buildings in the zerg tab are infested missile turret and bunker. I'm not sure why they don't get icons; I looked around and didn't find anything out of place in actor data, and the rootable anywhere variants probably aren't an issue or I'd expect spine and spore to display the same problem.