### PR TITLE
fix zerg merc drop pod sound

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -83,6 +83,11 @@
         <Inherits index="TeamColor" value="1"/>
     </CActorModel>
     <CActorModel default="1" id="AP_ZergMercDropModelBase" parent="AP_MercDropModelBase">
+        <Remove Terms="ActorCreation" Send="Create AP_MercCalldownDrop"/>
+        <Remove Terms="TimerExpired; TimerName DelayDropPod" Send="Create AP_MercCalldownImpact"/>
+        <Remove Terms="AnimDone; AnimName Birth" Send="Create DropPodUnload"/>
+        <On Terms="ActorCreation" Send="Create AP_ZergDropPod_Drop"/>
+        <On Terms="TimerExpired; TimerName DelayDropPod" Send="Create AP_ZergDropPodImpact"/>
         <Model value="AP_ZergDropPod"/>
     </CActorModel>
     <CActorAction default="1" id="AP_MarauderAttackBase" parent="GenericAttackNoCreateBase">


### PR DESCRIPTION
Replaces the Terran drop pod sounds for the drop pods on hiring Zerg mercenaries with appropriate Zerg drop pod sounds