### PR TITLE
Mm/royal guard upgrades

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -8049,8 +8049,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
-                <ShieldArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="200"/>
             </Modification>
         </VeterancyLevelArray>
@@ -8059,8 +8057,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
-                <ShieldArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="200"/>
             </Modification>
         </VeterancyLevelArray>
@@ -8352,7 +8348,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="70"/>
             </Modification>
         </VeterancyLevelArray>
@@ -8361,7 +8356,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="70"/>
             </Modification>
         </VeterancyLevelArray>
@@ -8436,7 +8430,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="90"/>
             </Modification>
         </VeterancyLevelArray>
@@ -8445,7 +8438,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="90"/>
             </Modification>
         </VeterancyLevelArray>
@@ -8537,7 +8529,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="150"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>
@@ -8548,7 +8539,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="150"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>
@@ -8636,7 +8626,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="75"/>
             </Modification>
         </VeterancyLevelArray>
@@ -8645,7 +8634,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="75"/>
             </Modification>
         </VeterancyLevelArray>
@@ -8766,7 +8754,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="50"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>
@@ -8777,7 +8764,6 @@
 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="50"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>
@@ -8923,7 +8909,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="25"/>
             </Modification>
         </VeterancyLevelArray>
@@ -8932,7 +8917,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="25"/>
             </Modification>
         </VeterancyLevelArray>
@@ -9027,7 +9011,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="70"/>
             </Modification>
         </VeterancyLevelArray>
@@ -9036,7 +9019,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="70"/>
             </Modification>
         </VeterancyLevelArray>
@@ -9085,7 +9067,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="30"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>
@@ -9096,7 +9077,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="30"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>
@@ -9129,7 +9109,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="100"/>
             </Modification>
         </VeterancyLevelArray>
@@ -9138,7 +9117,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="100"/>
             </Modification>
         </VeterancyLevelArray>
@@ -9316,7 +9294,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="70"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>
@@ -9327,7 +9304,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="70"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>
@@ -9431,7 +9407,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="70"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>
@@ -9442,7 +9417,6 @@
                 <!--                <DamageDealtFraction index="Melee" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Ranged" value="0.25"/>-->
                 <!--                <DamageDealtFraction index="Splash" value="0.25"/>-->
-                <LifeArmorBonus value="1"/>
                 <VitalMaxArray index="Life" value="70"/>
                 <VitalMaxArray index="Energy" value="50"/>
                 <VitalRegenArray index="Energy" value="0.5"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -146,17 +146,11 @@
         <!-- Aegis Guard -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_MarauderMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_MarauderMengsk,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyMarauderMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyMarauderMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyMarauderMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <!-- Emperor's Shadow -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_GhostMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_GhostMengsk,LifeStart" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_GhostMengskResourceEfficiency,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_GhostMengskResourceEfficiency,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyGhostMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyGhostMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyGhostMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <!-- Dominion Trooper -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_TrooperMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_TrooperMengsk,LifeStart" Value="1.05"/>
@@ -169,15 +163,9 @@
         <!-- Son of Korhal -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_MarineMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_MarineMengsk,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyMarineMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyMarineMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyMarineMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <!-- Field Response Theta -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_MedicMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_MedicMengsk,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyMedicMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyMedicMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyMedicMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <EditorCategories value="Race:Terran,UpgradeType:ArmorBonus"/>
     </CUpgrade>
     <CUpgrade default="1" id="AP_BaseTerranInfantryWeapons">
@@ -250,35 +238,35 @@
         <EffectArray Reference="Weapon,AP_PunisherGrenadesMengskL2,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_PunisherGrenadesMengskL3,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_PunisherGrenadesMengskL4,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskU,Amount" Value="2"/>
-        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskU,AttributeBonus[Armored]" Value="2"/>
-        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL2,Amount" Value="2.5"/>
-        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL2,AttributeBonus[Armored]" Value="2.5"/>
-        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL3,Amount" Value="3"/>
-        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL3,AttributeBonus[Armored]" Value="3"/>
-        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL4,Amount" Value="3.5"/>
-        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL4,AttributeBonus[Armored]" Value="3.5"/>
+        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskU,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskU,AttributeBonus[Armored]" Value="1"/>
+        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL2,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL2,AttributeBonus[Armored]" Value="1"/>
+        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL3,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL3,AttributeBonus[Armored]" Value="1"/>
+        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL4,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_PunisherGrenadesMengskUL4,AttributeBonus[Armored]" Value="1"/>
         <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamage,Amount" Value="0.4"/>
         <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamage,AttributeBonus[Armored]" Value="0.4"/>
-        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL2,Amount" Value="0.5"/>
-        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL2,AttributeBonus[Armored]" Value="0.5"/>
-        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL3,Amount" Value="0.6"/>
-        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL3,AttributeBonus[Armored]" Value="0.6"/>
-        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL4,Amount" Value="0.7"/>
-        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL4,AttributeBonus[Armored]" Value="0.7"/>
+        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL2,Amount" Value="0.4"/>
+        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL2,AttributeBonus[Armored]" Value="0.4"/>
+        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL3,Amount" Value="0.4"/>
+        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL3,AttributeBonus[Armored]" Value="0.4"/>
+        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL4,Amount" Value="0.4"/>
+        <EffectArray Reference="Effect,AP_MarauderMengskShrapnelDamageL4,AttributeBonus[Armored]" Value="0.4"/>
         <!-- Emperor's Shadow -->
         <EffectArray Reference="Weapon,AP_C10CanisterRifleMengsk,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_C10CanisterRifleMengskL2,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_C10CanisterRifleMengskL3,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_C10CanisterRifleMengskL4,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_C10CanisterRifleMengsk,Amount" Value="2"/>
+        <EffectArray Reference="Effect,AP_C10CanisterRifleMengsk,Amount" Value="1"/>
         <EffectArray Reference="Effect,AP_C10CanisterRifleMengsk,AttributeBonus[Light]" Value="1"/>
-        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL2,Amount" Value="2.5"/>
-        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL2,AttributeBonus[Light]" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL3,Amount" Value="3"/>
-        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL3,AttributeBonus[Light]" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL4,Amount" Value="3.5"/>
-        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL4,AttributeBonus[Light]" Value="1.75"/>
+        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL2,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL2,AttributeBonus[Light]" Value="1"/>
+        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL3,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL3,AttributeBonus[Light]" Value=""/>
+        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL4,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_C10CanisterRifleMengskL4,AttributeBonus[Light]" Value="1"/>
         <!-- Dominion Trooper -->
         <EffectArray Reference="Weapon,AP_TrooperMengsk,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_TrooperMengskImproved,Level" Value="1"/>
@@ -294,8 +282,6 @@
         <EffectArray Reference="Weapon,AP_GaussRifleMengskLongRange,Level" Value="1"/>
         <EffectArray Reference="Effect,AP_GaussRifleMengsk,Amount" Value="1"/>
         <EffectArray Reference="Effect,AP_GaussRifleMengskSplash,Amount" Value="1"/>
-        <EffectArray Operation="Subtract" Reference="Accumulator,AP_GaussRifleMengsk,Amount[0]" Value="0.25"/>
-        <EffectArray Reference="Accumulator,AP_GaussRifleMengsk,BonusPerLevel" Value="0.25"/>
     </CUpgrade>
     <CUpgrade default="1" id="AP_BaseTerranInfantryWeaponsUltraCapacitors" parent="AP_BaseTerranInfantryWeapons">
         <Name value="Upgrade/Name/AP_BaseTerranInfantryWeaponsUltraCapacitors"/>
@@ -488,37 +474,22 @@
         <!-- Pride of Augustgrad -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_BattlecruiserMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_BattlecruiserMengsk,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyBattlecruiserMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyBattlecruiserMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyBattlecruiserMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <!-- Sky Fury -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_VikingMengskAssault,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_VikingMengskAssault,LifeStart" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_VikingMengskFighter,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_VikingMengskFighter,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyVikingMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyVikingMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyVikingMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <!-- Emperor's Guardian -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_LiberatorMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_LiberatorMengsk,LifeStart" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_LiberatorMengskAG,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_LiberatorMengskAG,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyLiberatorMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyLiberatorMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyLiberatorMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <!-- Night Hawk -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_WraithMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_WraithMengsk,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyWraithMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyWraithMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyWraithMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <!-- Night Hawk -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_BansheeMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_BansheeMengsk,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyBansheeMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyBansheeMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyBansheeMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
     </CUpgrade>
     <CUpgrade default="1" id="AP_BaseTerranShipWeapons">
         <Name value="Upgrade/Name/AP_BaseTerranShipWeapons"/>
@@ -918,9 +889,6 @@
         <EffectArray Operation="Multiply" Reference="Unit,AP_SiegeTankMengskSieged,LifeStart" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_SiegeTankMengskSiegedTransportable,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_SiegeTankMengskSiegedTransportable,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancySiegeTankMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancySiegeTankMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancySiegeTankMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <!-- Blackhammer -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_ThorMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_ThorMengsk,LifeStart" Value="1.05"/>
@@ -928,15 +896,9 @@
         <EffectArray Operation="Multiply" Reference="Unit,AP_ThorMengskAP,LifeStart" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_ThorMengskSieged,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_ThorMengskSieged,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyThorMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyThorMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyThorMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
         <!-- Bulwark Company -->
         <EffectArray Operation="Multiply" Reference="Unit,AP_GoliathMengsk,LifeMax" Value="1.05"/>
         <EffectArray Operation="Multiply" Reference="Unit,AP_GoliathMengsk,LifeStart" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyGoliathMengsk,VeterancyLevelArray[1].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyGoliathMengsk,VeterancyLevelArray[2].Modification.VitalMaxArray[Life]" Value="1.05"/>
-        <EffectArray Operation="Multiply" Reference="Behavior,AP_MengskVeterancyGoliathMengsk,VeterancyLevelArray[3].Modification.VitalMaxArray[Life]" Value="1.05"/>
     </CUpgrade>
     <CUpgrade default="1" id="AP_BaseTerranVehicleWeapons">
         <Name value="Upgrade/Name/AP_BaseTerranVehicleWeapons"/>
@@ -1031,64 +993,64 @@
         <EffectArray Reference="Weapon,AP_SiegeTankMengskL3,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_SiegeTankMengskL4,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_90mmCannonsMengskLookAt,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskDamage,Amount" Value="3"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskDamage,AttributeBonus[Armored]" Value="1"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL2,Amount" Value="3.75"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL2,AttributeBonus[Armored]" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL3,Amount" Value="4.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL3,AttributeBonus[Armored]" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL4,Amount" Value="5.25"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL4,AttributeBonus[Armored]" Value="1.75"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskDamage,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskDamage,AttributeBonus[Armored]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL2,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL2,AttributeBonus[Armored]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL3,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL3,AttributeBonus[Armored]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL4,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskDamageL4,AttributeBonus[Armored]" Value="0.5"/>
         <EffectArray Reference="Weapon,AP_SiegeTankMengskSieged,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_SiegeTankMengskSiegedL2,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_SiegeTankMengskSiegedL3,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_SiegeTankMengskSiegedL4,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlast,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastL4,Amount" Value="17.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastEnemyDamage,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastEnemyDamageL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastEnemyDamageL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastEnemyDamageL4,Amount" Value="17.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEDirected,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEDirectedL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEDirectedL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEDirectedL4,Amount" Value="17.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedBlast,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedBlastL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedBlastL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedBlastL4,Amount" Value="17.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDirected,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDirectedL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDirectedL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDirectedL4,Amount" Value="17.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedEnemyDamage,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedEnemyDamageL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedEnemyDamageL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedEnemyDamageL4,Amount" Value="17.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedFriendlyDamage,Amount" Value="2"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDummy,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDummyL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDummyL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDummyL4,Amount" Value="17.5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlast,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastL4,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastEnemyDamage,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastEnemyDamageL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastEnemyDamageL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEBlastEnemyDamageL4,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEDirected,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEDirectedL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEDirectedL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedImprovedAoEDirectedL4,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedBlast,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedBlastL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedBlastL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedBlastL4,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDirected,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDirectedL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDirectedL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDirectedL4,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedEnemyDamage,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedEnemyDamageL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedEnemyDamageL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedEnemyDamageL4,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedFriendlyDamage,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDummy,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDummyL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDummyL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_SiegeTankMengskSiegedDummyL4,Amount" Value="5"/>
         <EffectArray Reference="Weapon,AP_MedivacMengskSiegeTankAirlift,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEDirected,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEDirectedL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEDirectedL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEDirectedL4,Amount" Value="17.5"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEBlast,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEBlastL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEBlastL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEBlastL4,Amount" Value="17.5"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftBlast,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftBlastL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftBlastL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftBlastL4,Amount" Value="17.5"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftDirected,Amount" Value="10"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftDirectedL2,Amount" Value="12.5"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftDirectedL3,Amount" Value="15"/>
-        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftDirectedL4,Amount" Value="17.5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEDirected,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEDirectedL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEDirectedL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEDirectedL4,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEBlast,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEBlastL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEBlastL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftImprovedAoEBlastL4,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftBlast,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftBlastL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftBlastL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftBlastL4,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftDirected,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftDirectedL2,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftDirectedL3,Amount" Value="5"/>
+        <EffectArray Reference="Effect,AP_MedivacMengskSiegeTankAirliftDirectedL4,Amount" Value="5"/>
         <!-- Blackhammer -->
         <EffectArray Reference="Weapon,AP_ThorMengskBaseModeL1Fake,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_ThorMengskBaseModeL2Fake,Level" Value="1"/>
@@ -1108,31 +1070,27 @@
         <EffectArray Reference="Weapon,AP_LanceMissileLaunchersMengskL2,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_LanceMissileLaunchersMengskL3,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_LanceMissileLaunchersMengskL4,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_ThorMengskSiegedDamage,Amount" Value="1"/>
-        <EffectArray Operation="Subtract" Reference="Accumulator,AP_ThorMengskSiegedDamage,Amount[0]" Value="0.25"/>
-        <EffectArray Reference="Accumulator,AP_ThorMengskSiegedDamage,BonusPerLevel" Value="0.25"/>
-        <EffectArray Reference="Effect,AP_ThorsHammerMengskDamage,Amount" Value="5"/>
-        <EffectArray Operation="Subtract" Reference="Accumulator,AP_ThorsHammerMengskDamage,Amount[0]" Value="1.25"/>
-        <EffectArray Reference="Accumulator,AP_ThorsHammerMengskDamage,BonusPerLevel" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_ThorsHammerMengskDamageL2Dummy,Amount" Value="6.25"/>
-        <EffectArray Reference="Effect,AP_ThorsHammerMengskDamageL3Dummy,Amount" Value="7.5"/>
-        <EffectArray Reference="Effect,AP_ThorsHammerMengskDamageL4Dummy,Amount" Value="8.75"/>
-        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamage,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamage,AttributeBonus[Light]" Value="1"/>
-        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL2,Amount" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL2,AttributeBonus[Light]" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL3,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL3,AttributeBonus[Light]" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL4,Amount" Value="1.75"/>
-        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL4,AttributeBonus[Light]" Value="1.75"/>
-        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamage,Amount" Value="3"/>
-        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamage,AttributeBonus[Massive]" Value="1"/>
-        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL2,Amount" Value="3.75"/>
-        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL2,AttributeBonus[Massive]" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL3,Amount" Value="4.5"/>
-        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL3,AttributeBonus[Massive]" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL4,Amount" Value="5.25"/>
-        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL4,AttributeBonus[Massive]" Value="1.75"/>
+        <EffectArray Reference="Effect,AP_ThorMengskSiegedDamage,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_ThorsHammerMengskDamage,Amount" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_ThorsHammerMengskDamageL2Dummy,Amount" Value="3"/>
+        <EffectArray Reference="Effect,AP_ThorsHammerMengskDamageL3Dummy,Amount" Value="3"/>
+        <EffectArray Reference="Effect,AP_ThorsHammerMengskDamageL4Dummy,Amount" Value="3"/>
+        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamage,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamage,AttributeBonus[Light]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL2,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL2,AttributeBonus[Light]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL3,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL3,AttributeBonus[Light]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL4,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_JavelinMissileLaunchersMengskDamageL4,AttributeBonus[Light]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamage,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamage,AttributeBonus[Massive]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL2,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL2,AttributeBonus[Massive]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL3,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL3,AttributeBonus[Massive]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL4,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_LanceMissileLaunchersMengskDamageL4,AttributeBonus[Massive]" Value="0.5"/>
         <!-- Bulwark Company -->
         <EffectArray Reference="Weapon,AP_GoliathMengskL1Fake,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_GoliathMengskL2Fake,Level" Value="1"/>
@@ -1146,20 +1104,18 @@
         <EffectArray Reference="Weapon,AP_GoliathMengskAUpgraded,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_GoliathMengskG,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_GoliathMengskGUpgraded,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskAU,Amount" Value="2"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskAU,AttributeBonus[Armored]" Value="1"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskAUL2,Amount" Value="3.75"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskAUL3,Amount" Value="4.5"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskAUL4,Amount" Value="5.25"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskG,Amount" Value="3"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskGDummy,Amount" Value="3"/>
-        <EffectArray Operation="Subtract" Reference="Accumulator,AP_GoliathMengskGDummy,Amount[0]" Value="0.75"/>
-        <EffectArray Reference="Accumulator,AP_GoliathMengskGDummy,BonusPerLevel" Value="0.75"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskGL2,Amount" Value="3.75"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskGL3,Amount" Value="4.5"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskGL3Splash,Amount" Value="4.5"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskGL4,Amount" Value="5.25"/>
-        <EffectArray Reference="Effect,AP_GoliathMengskGL4Splash,Amount" Value="5.25"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskAU,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskAU,AttributeBonus[Armored]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskAUL2,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskAUL3,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskAUL4,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskG,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskGDummy,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskGL2,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskGL3,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskGL3Splash,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskGL4,Amount" Value="1.5"/>
+        <EffectArray Reference="Effect,AP_GoliathMengskGL4Splash,Amount" Value="1.5"/>
     </CUpgrade>
     <CUpgrade default="1" id="AP_BaseTerranVehicleWeaponsUltraCapacitors" parent="AP_BaseTerranVehicleWeapons">
         <Name value="Upgrade/Name/AP_BaseTerranVehicleWeaponsUltraCapacitors"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -630,14 +630,14 @@
         <EffectArray Reference="Weapon,AP_ATSLaserBatteryMengskL2Fake,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_ATSLaserBatteryMengskL3Fake,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_ATSLaserBatteryMengskL4Fake,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_ATALaserBatteryMengskU,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_ATALaserBatteryMengskUL2,Amount" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_ATALaserBatteryMengskUL3,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_ATALaserBatteryMengskUL4,Amount" Value="1.75"/>
-        <EffectArray Reference="Effect,AP_ATSLaserBatteryMengskU,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_ATSLaserBatteryMengskUL2,Amount" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_ATSLaserBatteryMengskUL3,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_ATSLaserBatteryMengskUL4,Amount" Value="1.75"/>
+        <EffectArray Reference="Effect,AP_ATALaserBatteryMengskU,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_ATALaserBatteryMengskUL2,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_ATALaserBatteryMengskUL3,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_ATALaserBatteryMengskUL4,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_ATSLaserBatteryMengskU,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_ATSLaserBatteryMengskUL2,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_ATSLaserBatteryMengskUL3,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_ATSLaserBatteryMengskUL4,Amount" Value="0.5"/>
         <!-- Sky Fury -->
         <EffectArray Reference="Weapon,AP_VikingMengskAir,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_VikingMengskAirMassive,Level" Value="1"/>
@@ -647,53 +647,49 @@
         <EffectArray Reference="Weapon,AP_VikingMengskGroundMassive,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_VikingMengskGroundMassiveL3,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_VikingMengskGroundMassiveL4,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_TwinGatlingCannonsMengsk,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_TwinGatlingCannonsMengskSplash,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamage,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamage,AttributeBonus[Massive]" Value="5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplash,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplash,AttributeBonus[Massive]" Value="5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummy,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummy,AttributeBonus[Massive]" Value="5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL2,Amount" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL2,AttributeBonus[Massive]" Value="6.25"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL2,Amount" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL2,AttributeBonus[Massive]" Value="6.25"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL2,Amount" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL2,AttributeBonus[Massive]" Value="6.25"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL3,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL3,AttributeBonus[Massive]" Value="7.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL3,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL3,AttributeBonus[Massive]" Value="7.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL3,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL3,AttributeBonus[Massive]" Value="7.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL4,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL4,AttributeBonus[Massive]" Value="8.75"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL4,Amount" Value="1.75"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL4,AttributeBonus[Massive]" Value="8.75"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL4,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL4,AttributeBonus[Massive]" Value="8.75"/>
-        <EffectArray Reference="Effect,AP_LanzerTorpedoesMengskDamage,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_LanzerTorpedoesMengskDamage,AttributeBonus[Armored]" Value="1"/>
-        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamage,Amount" Value="2"/>
-        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamage,AttributeBonus[Massive]" Value="5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL2,Amount" Value="2.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL2,AttributeBonus[Massive]" Value="6.25"/>
-        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL3,Amount" Value="3"/>
-        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL3,AttributeBonus[Massive]" Value="7.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL4,Amount" Value="3.5"/>
-        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL4,AttributeBonus[Massive]" Value="8.75"/>
+        <EffectArray Reference="Effect,AP_TwinGatlingCannonsMengsk,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_TwinGatlingCannonsMengskSplash,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamage,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamage,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplash,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplash,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummy,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummy,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL2,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL2,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL2,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL2,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL2,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL2,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL3,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL3,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL3,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL3,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL3,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL3,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL4,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageL4,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL4,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageSplashL4,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL4,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskGroundMassiveDamageDummyL4,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_LanzerTorpedoesMengskDamage,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_LanzerTorpedoesMengskDamage,AttributeBonus[Armored]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamage,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamage,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL2,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL2,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL3,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL3,AttributeBonus[Massive]" Value="2.5"/>
+        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL4,Amount" Value="1"/>
+        <EffectArray Reference="Effect,AP_VikingMengskAirMassiveDamageL4,AttributeBonus[Massive]" Value="2.5"/>
         <!-- Emperor's Guardian -->
         <EffectArray Reference="Weapon,AP_LiberatorMengskMissileLaunchers,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_LiberatorMengskMissileLaunchersMoreAttacks,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_LiberatorMengskMissileDamage,Amount" Value="1"/>
-        <EffectArray Operation="Subtract" Reference="Accumulator,AP_LiberatorMengskMissileDamage,Amount[0]" Value="0.25"/>
-        <EffectArray Reference="Accumulator,AP_LiberatorMengskMissileDamage,BonusPerLevel" Value="0.25"/>
+        <EffectArray Reference="Effect,AP_LiberatorMengskMissileDamage,Amount" Value="0.5"/>
         <EffectArray Reference="Weapon,AP_LiberatorMengskAGWeapon,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_LiberatorMengskAGWeaponAA,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_LiberatorMengskAGDamage,Amount" Value="13"/>
-        <EffectArray Operation="Subtract" Reference="Accumulator,AP_LiberatorMengskAGDamage,Amount[0]" Value="3.25"/>
-        <EffectArray Reference="Accumulator,AP_LiberatorMengskAGDamage,BonusPerLevel" Value="3.25"/>
+        <EffectArray Reference="Effect,AP_LiberatorMengskAGDamage,Amount" Value="6"/>
         <!-- Night Hawk -->
         <EffectArray Reference="Weapon,AP_WraithMengskL1Fake,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_WraithMengskL2Fake,Level" Value="1"/>
@@ -715,25 +711,21 @@
         <EffectArray Reference="Weapon,AP_WraithMengskAGL2,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_WraithMengskAGL3,Level" Value="1"/>
         <EffectArray Reference="Weapon,AP_WraithMengskAGL4,Level" Value="1"/>
-        <EffectArray Reference="Effect,AP_WraithMengskGU,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_WraithMengskGUL2,Amount" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_WraithMengskGUL3,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_WraithMengskGUL4,Amount" Value="1.75"/>
-        <EffectArray Reference="Effect,AP_WraithMengskAU,Amount" Value="1"/>
-        <EffectArray Reference="Effect,AP_WraithMengskAU,AttributeBonus[Armored]" Value="1"/>
-        <EffectArray Reference="Effect,AP_WraithMengskAUL2,Amount" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_WraithMengskAUL2,AttributeBonus[Armored]" Value="1.25"/>
-        <EffectArray Reference="Effect,AP_WraithMengskAUL3,Amount" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_WraithMengskAUL3,AttributeBonus[Armored]" Value="1.5"/>
-        <EffectArray Reference="Effect,AP_WraithMengskAUL4,Amount" Value="1.75"/>
-        <EffectArray Reference="Effect,AP_WraithMengskAUL4,AttributeBonus[Armored]" Value="1.75"/>
-        <EffectArray Reference="Effect,AP_WraithMengskAGU,Amount" Value="4"/>
-        <EffectArray Operation="Subtract" Reference="Accumulator,AP_WraithMengskAGU,Amount[0]" Value="1"/>
-        <EffectArray Reference="Accumulator,AP_WraithMengskAGU,BonusPerLevel" Value="1"/>
+        <EffectArray Reference="Effect,AP_WraithMengskGU,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskGUL2,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskGUL3,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskGUL4,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskAU,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskAU,AttributeBonus[Armored]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskAUL2,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskAUL2,AttributeBonus[Armored]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskAUL3,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskAUL3,AttributeBonus[Armored]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskAUL4,Amount" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskAUL4,AttributeBonus[Armored]" Value="0.5"/>
+        <EffectArray Reference="Effect,AP_WraithMengskAGU,Amount" Value="0.5"/>
         <!-- Night Wolf -->
-        <EffectArray Reference="Weapon,AP_BacklashRocketsMengsk,Level" Value="1"/>
-        <EffectArray Operation="Subtract" Reference="Accumulator,AP_DuskWingBansheeDamage,Amount[0]" Value="0.5"/>
-        <EffectArray Reference="Accumulator,AP_DuskWingBansheeDamage,BonusPerLevel" Value="0.5"/>
+        <EffectArray Reference="Weapon,AP_BacklashRocketsMengsk,Level" Value="0.5"/>
     </CUpgrade>
     <CUpgrade default="1" id="AP_BaseTerranShipWeaponsUltraCapacitors" parent="AP_BaseTerranShipWeapons">
         <Name value="Upgrade/Name/AP_BaseTerranShipWeaponsUltraCapacitors"/>
@@ -775,58 +767,6 @@
         <EffectArray Reference="Weapon,AP_BrynhildAssaultA,RateMultiplier" Value="0.05"/>
         <EffectArray Reference="Weapon,AP_BrynhildAssaultAUpgraded,RateMultiplier" Value="0.05"/>
         <EffectArray Reference="Weapon,AP_NovaRavenSeekerMissile,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATALaserBatteryMengsk,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATSLaserBatteryMengsk,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_BaseLaserBatteryMengskL1Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_BaseLaserBatteryMengskL2Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_BaseLaserBatteryMengskL3Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_BaseLaserBatteryMengskL4Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATXLaserBatteryMengsk,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATXLaserBatteryMengskL1Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATXLaserBatteryMengskL2Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATXLaserBatteryMengskL3Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATXLaserBatteryMengskL4Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATALaserBatteryMengskL1Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATALaserBatteryMengskL2Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATALaserBatteryMengskL3Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATALaserBatteryMengskL4Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATSLaserBatteryMengskL1Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATSLaserBatteryMengskL2Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATSLaserBatteryMengskL3Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_ATSLaserBatteryMengskL4Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_VikingMengskAir,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_VikingMengskAirMassive,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_VikingMengskAirMassiveL3,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_VikingMengskAirMassiveL4,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_VikingMengskGround,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_VikingMengskGroundMassive,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_VikingMengskGroundMassiveL3,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_VikingMengskGroundMassiveL4,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_LiberatorMengskAGWeapon,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_LiberatorMengskAGWeaponAA,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_LiberatorMengskMissileLaunchers,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_LiberatorMengskMissileLaunchersMoreAttacks,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskL1Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskL2Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskL3Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskL4Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskAL1Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskAL2Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskAL3Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskAL4Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskGL1Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskGL2Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskGL3Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskGL4Fake,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskA,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskALongRange,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskG,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskGLongRange,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskAGL1,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskAGL2,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskAGL3,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_WraithMengskAGL4,RateMultiplier" Value="0.05"/>
-        <EffectArray Reference="Weapon,AP_BacklashRocketsMengsk,RateMultiplier" Value="0.05"/>
     </CUpgrade>
     <CUpgrade default="1" id="AP_BaseTerranVehicleArmors">
         <Name value="Upgrade/Name/AP_BaseTerranVehicleArmors"/>


### PR DESCRIPTION
Progress so far following RG feedback and discussion in the discord:

* Mengsk RG don't benefit from +attack/armour upgrades, so the current upgrades are essentially double-dipping on power, for units that are already strong enough without
* Some upgrades _multiply_ the effects, which is just unnecessary
* Goals:
  * Remove multiplicative effects
  * Remove armour from leveling
  * Half damage bonus from attack ups

Another possible route would have Royal Guards don't benefit form w/a upgrades at all, similar to Mengsk.