### PR TITLE
sc2: Changing unseen button icon to not use emoticon texture from core

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -6987,7 +6987,7 @@
         <Icon value="Assets\Textures\abilityicon_spawnbanelings_square.dds"/>
     </CButton>
     <CButton id="AP_BanelingLaunchTrain">
-        <Icon value="Assets\Textures\ui_emoticons_baneling.dds"/>
+        <Icon value="Assets\Textures\abilityicon_spawnbanelings_square.dds"/>
     </CButton>
     <CButton id="AP_SummonMercRoach">
         <Icon value="Assets\Textures\btn-unit-collection-webby-roach.dds"/>


### PR DESCRIPTION
Quick fix to change an icon away from using an emoticon for a button. The button is hidden, so there should be no difference to the user.

Main reasoning is that the icon repo script is picking up this texture and then complaining about it. I'd rather just fix the reference here than add an exclusion.