### PR TITLE
sc2: Increasing Artanis's selection priorty to be above Kerrigan in Infinite Cycle

### DIFF
--- a/Mods/ArchipelagoPlayerLotV.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayerLotV.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -20,4 +20,9 @@
             <LayoutButtons Face="AP_SuperStimpackSmall" Type="AbilCmd" AbilCmd="AP_SuperStimpackMarine,0" Row="2" Column="0"/>
         </CardLayouts>
     </CUnit>
+    <CUnit id="ArtanisVoid">
+        <!-- Override -->
+        <!-- Set higher than AP_K5Kerrigan for vanilla relationship in Infinite Cycle -->
+        <SubgroupPriority value="100"/>
+    </CUnit>
 </Catalog>


### PR DESCRIPTION
This is to match vanilla behaviour. At the request of ChannelMiner on the discord. https://discord.com/channels/731205301247803413/980554570075873300/1317738689136300043

This PR is intended to affect live.

![image](https://github.com/user-attachments/assets/e1979c30-5d1f-4cb4-85a3-cc4f7a21e20e)

It's been long enough since I touched live that I'm not completely certain my test setup isn't contaminated by beta. The change is simple enough, though. Tested by generating and hosting on an old 0.5.0 client install I had lying around.