### PR TITLE
Minor fixes

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ModelData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ModelData.xml
@@ -11661,7 +11661,7 @@
         <EditorCategories value="Race:Protoss"/>
     </CModel>
     <CModel id="AP_ScoutMPDeath" parent="UnitDeath" Race="Protoss">
-        <Model value="Assets\Units\Protoss\DarkScoutDeath\DarkScoutDeath.m3"/>
+        <Model value="Assets\Units\Protoss\ScoutDeath\ScoutDeath.m3"/>
         <LowQualityModel value="ProtossMediumUnitDeathLow"/>
         <Occlusion value="Show"/>
         <Radius value="0.750000"/>

--- a/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
@@ -7067,6 +7067,7 @@ void libABFE498B_gf_AP_Triggers_clearZergTech (int lp_player) {
     TechTreeUnitAllow(lp_player, "AP_MercUltralisk", false);
     TechTreeUnitAllow(lp_player, "AP_Hunterling", false);
     TechTreeUnitAllow(lp_player, "AP_Yggdrasil", false);
+    TechTreeUnitAllow(lp_player, "AP_MercRoach", false);
     TechTreeAbilityAllow(lp_player, AbilityCommand("AP_UpgradeToLair", 0), false);
     TechTreeAbilityAllow(lp_player, AbilityCommand("AP_UpgradeToHive", 0), false);
     TechTreeUnitAllow(lp_player, "AP_SpawningPool", false);


### PR DESCRIPTION
* Fixed an issue where player scouts used the dark protoss death animation instead of the Aiur one.
* Fixed an issue where Thornshells were never locked, so the player could build them as soon as any other sc2-category merc was unlocked (necessary to unlock the submenu on the predator nest)

Tested scout death animations and verified it was the right one.

Thornshells I'm not testing as I already have them in my current playthrough. It matches the other unit lock functions by inspection.