### PR TITLE
Fix some trade bugs related to air units

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -220,6 +220,8 @@
         <InitialUnloadDelay value="0.5"/>
         <LoadPeriod value="0.25"/>
         <UnloadPeriod value="0.5"/>
+        <LoadCargoEffect value="AP_TradeStructureHideExtrasSet"/>
+        <UnloadCargoEffect value="AP_TradeStructureShowExtrasSet"/>
         <TargetFilters value="Visible;Ally,Neutral,Enemy,Heroic,Buried,Dead,Hidden,Hallucination,Summoned,HeroUnit"/>
         <LoadValidatorArray value="HasNoCargo"/>
         <LoadValidatorArray value="AP_NotIsMindControlled"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -2561,6 +2561,7 @@
     <CBehaviorBuff id="AP_ReleaseBombersWanderDelay">
         <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
         <DisableValidatorArray value="CasterHasNoOrders"/>
+        <RemoveValidatorArray value="AP_NotInterceptorHidden"/>
         <Period value="0.5"/>
         <PeriodicEffect value="AP_ReleaseBombersPatrolCP"/>
     </CBehaviorBuff>
@@ -2729,6 +2730,36 @@
         <Duration value="0.5"/>
         <Modification>
             <AbilLinkDisableArray value="attack"/>
+        </Modification>
+    </CBehaviorBuff>
+    <CBehaviorBuff id="AP_BroodlordStopBroodlings">
+        <InfoFlags index="Hidden" value="1"/>
+        <EditorCategories value="Race:Zerg,AbilityorEffectType:Units"/>
+        <Modification>
+            <AbilLinkDisableArray value="AP_BroodLordQueue2"/>
+        </Modification>
+    </CBehaviorBuff>
+    <CBehaviorBuff id="AP_BroodlingHidden">
+        <InfoFlags index="Hidden" value="1"/>
+        <EditorCategories value="Race:Zerg,AbilityorEffectType:Units"/>
+        <Modification>
+            <AbilLinkDisableArray value="attack"/>
+            <StateFlags index="NoDraw" value="1"/>
+        </Modification>
+    </CBehaviorBuff>
+    <CBehaviorBuff id="AP_CarrierAiurStopRepairDrones">
+        <InfoFlags index="Hidden" value="1"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Modification>
+            <AbilLinkDisableArray value="AP_CarrierRepairDroneHanger"/>
+        </Modification>
+    </CBehaviorBuff>
+    <CBehaviorBuff id="AP_InterceptorHidden">
+        <InfoFlags index="Hidden" value="1"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
+        <Modification>
+            <AbilLinkDisableArray value="attack"/>
+            <StateFlags index="NoDraw" value="1"/>
         </Modification>
     </CBehaviorBuff>
     <CBehaviorBuff id="AP_DisablingCloud">
@@ -3525,8 +3556,13 @@
         <DisableValidatorArray value="AP_NotStunnedorStasised"/>
         <DisableValidatorArray value="IsNotHallucination"/>
         <DisableValidatorArray value="NotHidden"/>
+        <DisableValidatorArray value="AP_NotArbiterMPCloakFieldDisabled"/>
         <Period value="0.2"/>
         <PeriodicEffect value="AP_ArbiterMPCloakingFieldSearch"/>
+    </CBehaviorBuff>
+    <CBehaviorBuff id="AP_ArbiterMPCloakFieldDisabled">
+        <InfoFlags index="Hidden" value="1"/>
+        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
     </CBehaviorBuff>
     <CBehaviorBuff id="AP_BansheeMengskCloakField" parent="AP_ArbiterMPCloakField">
         <RemoveValidatorArray value="CanSpendEnergy"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -3556,13 +3556,8 @@
         <DisableValidatorArray value="AP_NotStunnedorStasised"/>
         <DisableValidatorArray value="IsNotHallucination"/>
         <DisableValidatorArray value="NotHidden"/>
-        <DisableValidatorArray value="AP_NotArbiterMPCloakFieldDisabled"/>
         <Period value="0.2"/>
         <PeriodicEffect value="AP_ArbiterMPCloakingFieldSearch"/>
-    </CBehaviorBuff>
-    <CBehaviorBuff id="AP_ArbiterMPCloakFieldDisabled">
-        <InfoFlags index="Hidden" value="1"/>
-        <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
     </CBehaviorBuff>
     <CBehaviorBuff id="AP_BansheeMengskCloakField" parent="AP_ArbiterMPCloakField">
         <RemoveValidatorArray value="CanSpendEnergy"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -23376,13 +23376,11 @@
         <CaseArray Validator="AP_IsBroodlord" Effect="AP_BroodlordHideExtras"/>
         <CaseArray Validator="AP_IsCarrierAiur" Effect="AP_CarrierAiurStopRepairDronesAB" FallThrough="1"/>
         <CaseArray Validator="AP_LaunchesAnyInterceptor" Effect="AP_StopAndHideInterceptors"/>
-        <CaseArray Validator="AP_IsArbiterMP" Effect="AP_ArbiterMPCloakFieldDisabledAB"/>
     </CEffectSwitch>
     <CEffectSwitch id="AP_TradeStructureShowExtrasSet">
         <CaseArray Validator="AP_IsBroodlord" Effect="AP_BroodlordShowExtras"/>
         <CaseArray Validator="AP_IsCarrierAiur" Effect="AP_CarrierAiurStopRepairDronesRB" FallThrough="1"/>
         <CaseArray Validator="AP_LaunchesAnyInterceptor" Effect="AP_ShowInterceptorsIterateMagazine"/>
-        <CaseArray Validator="AP_IsArbiterMP" Effect="AP_ArbiterMPCloakFieldDisabledRB"/>
     </CEffectSwitch>
     <CEffectSet id="AP_BroodlordHideExtras">
         <EffectArray value="AP_BroodlordStopBroodlingsAB"/>
@@ -23439,11 +23437,5 @@
     </CEffectApplyBehavior>
     <CEffectRemoveBehavior id="AP_CarrierAiurStopRepairDronesRB">
         <BehaviorLink value="AP_CarrierAiurStopRepairDrones"/>
-    </CEffectRemoveBehavior>
-    <CEffectApplyBehavior id="AP_ArbiterMPCloakFieldDisabledAB">
-        <Behavior value="AP_ArbiterMPCloakFieldDisabled"/>
-    </CEffectApplyBehavior>
-    <CEffectRemoveBehavior id="AP_ArbiterMPCloakFieldDisabledRB">
-        <BehaviorLink value="AP_ArbiterMPCloakFieldDisabled"/>
     </CEffectRemoveBehavior>
 </Catalog>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -23372,4 +23372,78 @@
         <EffectArray value="AP_VoidRayAiurStackingSlowHalfRateAB"/>
         <EffectArray value="AP_VoidRayAiurChronoShearAB"/>
     </CEffectSet>
+    <CEffectSwitch id="AP_TradeStructureHideExtrasSet">
+        <CaseArray Validator="AP_IsBroodlord" Effect="AP_BroodlordHideExtras"/>
+        <CaseArray Validator="AP_IsCarrierAiur" Effect="AP_CarrierAiurStopRepairDronesAB" FallThrough="1"/>
+        <CaseArray Validator="AP_LaunchesAnyInterceptor" Effect="AP_StopAndHideInterceptors"/>
+        <CaseArray Validator="AP_IsArbiterMP" Effect="AP_ArbiterMPCloakFieldDisabledAB"/>
+    </CEffectSwitch>
+    <CEffectSwitch id="AP_TradeStructureShowExtrasSet">
+        <CaseArray Validator="AP_IsBroodlord" Effect="AP_BroodlordShowExtras"/>
+        <CaseArray Validator="AP_IsCarrierAiur" Effect="AP_CarrierAiurStopRepairDronesRB" FallThrough="1"/>
+        <CaseArray Validator="AP_LaunchesAnyInterceptor" Effect="AP_ShowInterceptorsIterateMagazine"/>
+        <CaseArray Validator="AP_IsArbiterMP" Effect="AP_ArbiterMPCloakFieldDisabledRB"/>
+    </CEffectSwitch>
+    <CEffectSet id="AP_BroodlordHideExtras">
+        <EffectArray value="AP_BroodlordStopBroodlingsAB"/>
+        <EffectArray value="AP_HideBroodlingsIterateMagazine"/>
+    </CEffectSet>
+    <CEffectEnumMagazine id="AP_HideBroodlingsIterateMagazine">
+        <EffectExternal value="AP_BroodlingHiddenAB"/>
+    </CEffectEnumMagazine>
+    <CEffectApplyBehavior id="AP_BroodlingHiddenAB">
+        <Behavior value="AP_BroodlingHidden"/>
+    </CEffectApplyBehavior>
+    <CEffectApplyBehavior id="AP_BroodlordStopBroodlingsAB">
+        <Behavior value="AP_BroodlordStopBroodlings"/>
+    </CEffectApplyBehavior>
+    <CEffectSet id="AP_BroodlordShowExtras">
+        <EffectArray value="AP_BroodlordStopBroodlingsRB"/>
+        <EffectArray value="AP_ShowBroodlingsIterateMagazine"/>
+    </CEffectSet>
+    <CEffectEnumMagazine id="AP_ShowBroodlingsIterateMagazine">
+        <EffectExternal value="AP_BroodlingHiddenRB"/>
+    </CEffectEnumMagazine>
+    <CEffectRemoveBehavior id="AP_BroodlingHiddenRB">
+        <BehaviorLink value="AP_BroodlingHidden"/>
+    </CEffectRemoveBehavior>
+    <CEffectRemoveBehavior id="AP_BroodlordStopBroodlingsRB">
+        <BehaviorLink value="AP_BroodlordStopBroodlings"/>
+    </CEffectRemoveBehavior>
+    <CEffectSet id="AP_StopAndHideInterceptors">
+        <EffectArray value="AP_StopInterceptorsIterateMagazine"/>
+        <EffectArray value="AP_HideInterceptorsIterateMagazine"/>
+    </CEffectSet>
+    <CEffectIssueOrder id="AP_StopInterceptorIssueOrder">
+        <Abil value="stop"/>
+    </CEffectIssueOrder>
+    <CEffectEnumMagazine id="AP_StopInterceptorsIterateMagazine">
+        <EffectExternal value="AP_StopInterceptorIssueOrder"/>
+    </CEffectEnumMagazine>
+    <CEffectEnumMagazine id="AP_HideInterceptorsIterateMagazine">
+        <EffectExternal value="AP_InterceptorHiddenAB"/>
+        <EffectInternal value="AP_InterceptorHiddenAB"/>
+    </CEffectEnumMagazine>
+    <CEffectApplyBehavior id="AP_InterceptorHiddenAB">
+        <Behavior value="AP_InterceptorHidden"/>
+    </CEffectApplyBehavior>
+    <CEffectEnumMagazine id="AP_ShowInterceptorsIterateMagazine">
+        <EffectExternal value="AP_InterceptorHiddenRB"/>
+        <EffectInternal value="AP_InterceptorHiddenRB"/>
+    </CEffectEnumMagazine>
+    <CEffectRemoveBehavior id="AP_InterceptorHiddenRB">
+        <BehaviorLink value="AP_InterceptorHidden"/>
+    </CEffectRemoveBehavior>
+    <CEffectApplyBehavior id="AP_CarrierAiurStopRepairDronesAB">
+        <Behavior value="AP_CarrierAiurStopRepairDrones"/>
+    </CEffectApplyBehavior>
+    <CEffectRemoveBehavior id="AP_CarrierAiurStopRepairDronesRB">
+        <BehaviorLink value="AP_CarrierAiurStopRepairDrones"/>
+    </CEffectRemoveBehavior>
+    <CEffectApplyBehavior id="AP_ArbiterMPCloakFieldDisabledAB">
+        <Behavior value="AP_ArbiterMPCloakFieldDisabled"/>
+    </CEffectApplyBehavior>
+    <CEffectRemoveBehavior id="AP_ArbiterMPCloakFieldDisabledRB">
+        <BehaviorLink value="AP_ArbiterMPCloakFieldDisabled"/>
+    </CEffectRemoveBehavior>
 </Catalog>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -888,6 +888,9 @@
         <Value value="AP_BroodLord"/>
         <Find value="0"/>
     </CValidatorUnitType>
+    <CValidatorUnitType id="AP_IsBroodlord">
+        <Value value="AP_BroodLord"/>
+    </CValidatorUnitType>
     <CValidatorUnitType id="AP_NotBroodlordCocoon">
         <WhichUnit Value="Caster"/>
         <Value value="AP_BroodLordCocoon"/>
@@ -3241,6 +3244,13 @@
         <Value value="AP_ArbiterMP"/>
         <Find value="0"/>
     </CValidatorUnitType>
+    <CValidatorUnitType id="AP_IsArbiterMP">
+        <Value value="AP_ArbiterMP"/>
+    </CValidatorUnitType>
+    <CValidatorUnitCompareBehaviorCount id="AP_NotArbiterMPCloakFieldDisabled">
+        <Value value="0"/>
+        <Behavior value="AP_ArbiterMPCloakFieldDisabled"/>
+    </CValidatorUnitCompareBehaviorCount>
     <CValidatorUnitCompareBehaviorCount id="AP_IsNotArbiterRecalling">
         <WhichUnit Value="Caster"/>
         <Behavior value="AP_ArbiterMPRecalling"/>
@@ -3810,6 +3820,24 @@
         <Value value="AP_CarrierAiur"/>
         <Find value="0"/>
     </CValidatorUnitType>
+    <CValidatorUnitType id="AP_IsCarrierAiur">
+        <Value value="AP_CarrierAiur"/>
+    </CValidatorUnitType>
+    <CValidatorUnitType id="AP_IsCarrier">
+        <Value value="AP_Carrier"/>
+    </CValidatorUnitType>
+    <CValidatorUnitType id="AP_IsCarrierPurifier">
+        <Value value="AP_CarrierPurifier"/>
+    </CValidatorUnitType>
+    <CValidatorCombine id="AP_LaunchesAnyInterceptor">
+        <Type value="Or"/>
+        <CombineArray value="AP_IsCarrier"/>
+        <CombineArray value="AP_IsCarrierAiur"/>
+        <CombineArray value="AP_IsCarrierPurifier"/>
+    </CValidatorCombine>
+    <CValidatorUnitCompareBehaviorCount id="AP_NotInterceptorHidden">
+        <Behavior value="AP_InterceptorHidden"/>
+    </CValidatorUnitCompareBehaviorCount>
     <CValidatorUnitCompareBehaviorCount id="AP_NotMaxVoidSentryChronoBeam">
         <Compare value="LT"/>
         <Value value="1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -3244,13 +3244,6 @@
         <Value value="AP_ArbiterMP"/>
         <Find value="0"/>
     </CValidatorUnitType>
-    <CValidatorUnitType id="AP_IsArbiterMP">
-        <Value value="AP_ArbiterMP"/>
-    </CValidatorUnitType>
-    <CValidatorUnitCompareBehaviorCount id="AP_NotArbiterMPCloakFieldDisabled">
-        <Value value="0"/>
-        <Behavior value="AP_ArbiterMPCloakFieldDisabled"/>
-    </CValidatorUnitCompareBehaviorCount>
     <CValidatorUnitCompareBehaviorCount id="AP_IsNotArbiterRecalling">
         <WhichUnit Value="Caster"/>
         <Behavior value="AP_ArbiterMPRecalling"/>

--- a/Mods/ArchipelagoTradeSystem.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoTradeSystem.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -128,6 +128,10 @@
         <!-- Override -->
         <CargoSize value="8"/>
     </CUnit>
+    <CUnit id="AP_MothershipTaldarim">
+        <!-- Override -->
+        <CargoSize value="8"/>
+    </CUnit>
     <CUnit id="AP_SIQueen">
         <!-- Override -->
         <CargoSize value="4"/>


### PR DESCRIPTION
This addresses the following issues:
- Motherships would sometimes not have a cargo size and thus be untradeable (reported by Mati and Snarky)
  - I'm not 100% sure what caused this, but I added a manual cargo size to the Mothership variant in question instead of relying on it to inherit from the parent unit.
- Brood Lords would spawn and shoot Broodlings while loaded into the trade structure (reported by Snarky)
  - They now hide their Broodlings and prevent them from attacking, and will not spawn any until they come back out of the trade structure.
- Carrier Repair Drones would still be active while the Carrier is loaded into the trade structure
  - Due to Carriers having two Magazine abilities I couldn't find a solution that both looks good and works, so Carriers now blow up their Repair Drones upon being loaded and respawn them when being unloaded over 0.2 seconds.
- Carrier and Trireme Interceptors with an active attack order would continue their attack order while the parent is loaded into the trade structure, and then awkwardly float above the trade structure after their target dies
  - Interceptors are now hidden and cancel their attack order when their parent is loaded. This looks a bit strange when the Carrier/Trireme is unloaded because the Interceptors need a moment to go back into their parent unit, but the gameplay feels more correct.

I tested these changes by generating a world with a Zerg and Protoss player, building the affected units, and loading/unloading them into the trade structure.