### PR TITLE
sc2: Aliasing hotkeys for orbital depots and orbital command to base buildings

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -939,7 +939,7 @@
         <AlertIcon value="Assets\Textures\btn-building-terran-supplydepot.dds"/>
         <Hotkey value="Button/Hotkey/SupplyDepot"/>
         <EditorCategories value="Race:Terran"/>
-        <HotkeyAlias value="SupplyDepot"/>
+        <HotkeyAlias value="AP_SupplyDepot"/>
     </CButton>
     <CButton id="AP_Firebat">
         <Icon value="Assets\Textures\btn-unit-terran-firebat.dds"/>
@@ -1180,6 +1180,7 @@
         <Icon value="Assets\Textures\btn-building-terran-surveillancestation.dds"/>
         <AlertIcon value="Assets\Textures\btn-building-terran-surveillancestation.dds"/>
         <EditorCategories value="Race:Terran"/>
+        <HotkeyAlias value="AP_CommandCenter"/>
     </CButton>
     <CButton id="AP_GatherMULE">
         <Icon value="Assets\Textures\btn-ability-terran-gather.dds"/>


### PR DESCRIPTION
This is following [a report from Zeppeli in main chat](https://discord.com/channels/731205301247803413/980554570075873300/1327367281981915166) that orbital command and orbital depots can't change their hotkeys. Tested this on beta:
![image](https://github.com/user-attachments/assets/e5b2eaaa-7051-44f8-bccc-1991286baf20)

~~This should probably be cherry-picked to live.~~ This is cherry-picked to live in #352 