### PR TITLE
sc2: Aliasing hotkeys for orbital depots and orbital command to base buildings

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -856,7 +856,7 @@
         <AlertIcon value="Assets\Textures\btn-building-terran-supplydepot.dds"/>
         <Hotkey value="Button/Hotkey/SupplyDepot"/>
         <EditorCategories value="Race:Terran"/>
-        <HotkeyAlias value="SupplyDepot"/>
+        <HotkeyAlias value="AP_SupplyDepot"/>
     </CButton>
     <CButton id="AP_Firebat">
         <Icon value="Assets\Textures\btn-unit-terran-firebat.dds"/>
@@ -1087,6 +1087,7 @@
         <Icon value="Assets\Textures\btn-building-terran-surveillancestation.dds"/>
         <AlertIcon value="Assets\Textures\btn-building-terran-surveillancestation.dds"/>
         <EditorCategories value="Race:Terran"/>
+        <HotkeyAlias value="AP_CommandCenter"/>
     </CButton>
     <CButton id="AP_GatherMULE">
         <Icon value="Assets\Textures\btn-ability-terran-gather.dds"/>


### PR DESCRIPTION
Cherry-pick of #351 to live. Didn't do additional testing, it's a simple change.