### PR TITLE
SC2: Add icon to Null Shroud + cleanup

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -7104,7 +7104,7 @@
         <HotkeySet value="Cloak"/>
     </CButton>
     <CButton id="AP_ScoutNerazimCloakUpgrade">
-        <Icon value="AP\Assets\Custom\Textures\btn-ability-terran-cloak-gold.dds"/>
+        <Icon value="Assets\Textures\btn-ability-hornerhan-wraith-permanentcloak.dds"/>
         <EditorCategories value="Race:Protoss"/>
         <HotkeySet value="Cloak"/>
     </CButton>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -30327,6 +30327,7 @@
             <LayoutButtons Face="AP_ScoutNerazimDecloak" Type="AbilCmd" AbilCmd="AP_ScoutNerazimCloak,Off" Row="2" Column="1"/>
             <LayoutButtons Face="AP_ScoutNerazimPhantomDash" Type="AbilCmd" AbilCmd="AP_ScoutNerazimPhantomDash,Execute" Row="2" Column="2"/>
             <LayoutButtons Face="AP_ScoutNerazimPilot" Type="AbilCmd" AbilCmd="AP_ScoutNerazimPilot,Load" Row="2" Column="3"/>
+            <LayoutButtons Face="AP_ScoutNerazimCloakUpgrade" Type="Passive" Requirements="AP_ScoutNerazimHaveSuperCloak" Row="1" Column="3"/>
         </CardLayouts>
         <Radius value="0.75"/>
         <SeparationRadius value="0.75"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -17143,11 +17143,9 @@
     </CUpgrade>
     <CUpgrade id="AP_ArchonSiphon">
         <EditorCategories value="Race:Protoss,UpgradeType:Talents"/>
-        <LeaderAlias value="AP_ArchonFloat"/>
     </CUpgrade>
     <CUpgrade id="AP_ArchonSuicide">
         <EditorCategories value="Race:Protoss,UpgradeType:Talents"/>
-        <LeaderAlias value="AP_ArchonFloat"/>
     </CUpgrade>
     <CUpgrade id="AP_ArchonWeaponUpgrade">
         <EffectArray Operation="Set" Reference="Weapon,AP_PsionicShockwave,Options[Hidden]" Value="1"/>
@@ -17643,17 +17641,14 @@
     <CUpgrade id="AP_VoidRayAiurChronoclysm"/>
     <CUpgrade id="AP_ScoutNerazimPhantomDash">
         <EditorCategories value="Race:Protoss"/>
-        <LeaderAlias value="AP_ScoutTaldarimVulcanBlaster"/>
     </CUpgrade>
     <CUpgrade id="AP_ScoutNerazimSuperCloak">
         <EditorCategories value="Race:Protoss"/>
-        <LeaderAlias value="AP_ScoutTaldarimVulcanBlaster"/>
         <EffectArray Operation="Set" Reference="Behavior,AP_ScoutNerazimCloak,Modification.VitalRegenArray[Energy]" Value="-0.562500"/>
-        <EffectArray Operation="Set" Reference="Button,AP_ScoutNerazimCloak,Tooltip" Value="Button/Tooltip/AP_ScoutNerazimCloakUpgrade"/>
+        <EffectArray Operation="Set" Reference="Button,AP_ScoutNerazimCloak,Tooltip" Value="Button/Tooltip/AP_ScoutNerazimNullShroud"/>
     </CUpgrade>
     <CUpgrade id="AP_ScoutNerazimPilot">
         <EditorCategories value="Race:Protoss"/>
-        <LeaderAlias value="AP_ScoutTaldarimVulcanBlaster"/>
     </CUpgrade>
     <CUpgrade id="AP_ScoutPurifierSideMissiles">
         <EffectArray Operation="Set" Reference="Effect,AP_ScoutPurifierAirWeapon,PeriodCount" Value="4"/>
@@ -17676,14 +17671,12 @@
     </CUpgrade>
     <CUpgrade id="AP_ScoutTaldarimImprovedMissiles">
         <EditorCategories value="Race:Protoss"/>
-        <LeaderAlias value="AP_ScoutTaldarimVulcanBlaster"/>
     </CUpgrade>
     <CUpgrade id="AP_ScoutTaldarimVulcanBlaster">
         <EditorCategories value="Race:Protoss"/>
     </CUpgrade>
     <CUpgrade id="AP_ScoutPurifierCoronaBeam">
         <EditorCategories value="Race:Protoss"/>
-        <LeaderAlias value="AP_ScoutTaldarimVulcanBlaster"/>
     </CUpgrade>
     <CUpgrade id="AP_ScoutTaldarimOptimizedLogistics">
         <EffectArray Operation="Subtract" Reference="Abil,AP_StargateTrain,InfoArray[Train17].Time" Value="40.000000"/>
@@ -17691,7 +17684,6 @@
         <EffectArray Operation="Subtract" Reference="Abil,AP_StargateWarpTrain,InfoArray[Train17].Charge.TimeUse" Value="32.000000"/>
         <EffectArray Operation="Subtract" Reference="Abil,AP_StargateWarpTrainRedirect,InfoArray[Train17].Charge.TimeUse" Value="32.000000"/>
         <EditorCategories value="Race:Protoss"/>
-        <LeaderAlias value="AP_ScoutTaldarimVulcanBlaster"/>
     </CUpgrade>
     <CUpgrade id="AP_HiveMindEmulatorProtoss">
         <Flags index="UpgradeCheat" value="0"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -1751,7 +1751,7 @@ Button/Name/AP_RuptureUpgrade=Rupture
 Button/Name/AP_SCVCliffJump=Construction Jump Jets
 Button/Name/AP_ScoutNerazim=Warp in Mist Wing
 Button/Name/AP_ScoutNerazimCloak=Cloak
-Button/Name/AP_ScoutNerazimCloakUpgrade=Cloak Upgrade
+Button/Name/AP_ScoutNerazimCloakUpgrade=Null Shroud
 Button/Name/AP_ScoutNerazimDecloak=Decloak
 Button/Name/AP_ScoutNerazimPhantomDash=Phantom Dash
 Button/Name/AP_ScoutNerazimPilot=Pilot
@@ -3334,7 +3334,8 @@ Button/Tooltip/AP_ScoutExpeditionaryHull=<c val="ffff8a">Scouts</c> gain +<d ref
 Button/Tooltip/AP_ScoutGraviticThrusters=<c val="ffff8a">Scouts</c> and its variants gain increased movement speed.
 Button/Tooltip/AP_ScoutNerazim=Nerazim Scout variant. Specialized stealth fighter.<n/>Has Cloak, Phantom Dash and Pilot (Transport) abilities.<n/><n/><c val="#ColorAttackInfo">Can attack ground and air units.</c>
 Button/Tooltip/AP_ScoutNerazimCloak=Cloaks the unit, preventing enemy units from seeing or attacking it. A cloaked unit will only be revealed by detectors or effects.<n/><n/><c val="f078ff">Drains <d ref="-1 * (Behavior,AP_ScoutNerazimCloak,Modification.VitalRegenArray[2] + Unit,AP_ScoutNerazim,EnergyRegenRate)" precision="1"/> energy per second.</c>
-Button/Tooltip/AP_ScoutNerazimCloakUpgrade=Cloaks the unit, preventing enemy units from seeing or attacking it. A cloaked unit will only be revealed by detectors or effects. <n/>The unit is undetectable for 5 seconds after cloaking.<n/><n/><c val="f078ff">Drains no energy per second, but prevents base energy regeneration.</c>
+Button/Tooltip/AP_ScoutNerazimCloakUpgrade=The Mist Wing is undetectable on activating cloak for 5 seconds. Cloak no longer drains energy while active.
+Button/Tooltip/AP_ScoutNerazimNullShroud=Cloaks the unit, preventing enemy units from seeing or attacking it. A cloaked unit will only be revealed by detectors or effects. <n/>The unit is undetectable for 5 seconds after cloaking.<n/><n/><c val="f078ff">Drains no energy per second, but prevents base energy regeneration.</c>
 Button/Tooltip/AP_ScoutNerazimDecloak=Decloaks the selected unit, making it visible to enemies.
 Button/Tooltip/AP_ScoutNerazimPhantomDash=Dash forward to quickly close distance. Deals 30 damage (+10 if you have a pilot) to units in the path, if cloaked.<n/><n/><c val="#ColorAttackInfo">Can attack ground and air units.</c>
 Button/Tooltip/AP_ScoutNerazimPilot=Load a unit to pilot the Mist Wing. A pilot provides +2 damage to all weapons, 10% attack speed and +1 armor for life and shields.<n/><n/><c val="#ColorAttackInfo">Can load 1 pilot at a time.</c>


### PR DESCRIPTION
Added an additional icon to Null Shroud, the Mist Wing cloak upgrade, mostly for the icon repository and web tracker.

Cleaned up unintended and unnecessary LeaderAlias entries for several upgrades.

Tested in player test map.