### PR TITLE
sc2: Updating colonist stats on raceswapped infested so they're not useless

### DIFF
--- a/Maps/ArchipelagoCampaign/HotS/ap_infested.SC2Map/Base.SC2Data/GameData/EffectData.xml
+++ b/Maps/ArchipelagoCampaign/HotS/ap_infested.SC2Map/Base.SC2Data/GameData/EffectData.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="us-ascii"?>
 <Catalog>
     <CEffectDamage id="MagnisHammerDamage"/>
+    <CEffectDamage id="ThrowMolotovDamage">
+        <!-- Override -->
+        <Amount value="11"/>
+    </CEffectDamage>
 </Catalog>

--- a/Maps/ArchipelagoCampaign/HotS/ap_infested.SC2Map/Base.SC2Data/GameData/UnitData.xml
+++ b/Maps/ArchipelagoCampaign/HotS/ap_infested.SC2Map/Base.SC2Data/GameData/UnitData.xml
@@ -72,9 +72,13 @@
     <CUnit id="Civilian">
         <!-- Override -->
         <FlagArray index="Untargetable" value="0"/>
+        <LifeStart value="35"/>
+        <LifeMax value="35"/>
     </CUnit>
     <CUnit id="CivilianFemale">
         <!-- Override -->
         <FlagArray index="Untargetable" value="0"/>
+        <LifeStart value="35"/>
+        <LifeMax value="35"/>
     </CUnit>
 </Catalog>

--- a/Maps/ArchipelagoCampaign/HotS/ap_infested.SC2Map/Base.SC2Data/GameData/WeaponData.xml
+++ b/Maps/ArchipelagoCampaign/HotS/ap_infested.SC2Map/Base.SC2Data/GameData/WeaponData.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<Catalog>
+    <CWeaponLegacy id="ThrowMolotov">
+        <!-- Override -->
+        <!-- Note: infested civilian does 8 damage @ 1.2 period, melee range -->
+        <!-- = 6.15 DPS -->
+        <Range value="3"/>
+        <Period value="2"/>
+        <RandomDelayMin value="0"/>
+        <RandomDelayMax value="1"/>
+    </CWeaponLegacy>
+    <CWeaponLegacy id="ThrowMolotovDummy">
+        <!-- Override -->
+        <Range value="3"/>
+        <Period value="2"/>
+        <RandomDelayMin value="0"/>
+        <RandomDelayMax value="1"/>
+    </CWeaponLegacy>
+</Catalog>


### PR DESCRIPTION
This is responding to feedback from multiple people. The colonists on raceswapped infested just felt bad:
* They had no DPS
* They outranged bunkers, meaning they didn't tank for you
* They generally didn't do anything

Updated their stats to be a little closer to infested colonists without duplicating it entirely:
infested civilian:
35 health
8 damage / 1.2s = 6.15 DPS
melee

vanilla civilian:
30 health
5 damage / 7 + (2~5)s = 0.417 ~ 0.55 DPS
7 range

Updated civilian:
35 health
11 damage / 2 + (0~1) = 3.67 ~ 5.5 DPS
3 range

![image](https://github.com/user-attachments/assets/24d53456-6f01-4c58-b78c-8aa9486d769a)

### Testing
Played through the start as Terran and Protoss. The civilians felt _much_ better -- they didn't carry the mission, and required support to make any progress vs tanks or bunkers, but they tanked and helped take down those obstacles with support / sniping. The health buff affected protoss because they start with ascendants with sacrifice, so it meant more energy.

### Design thoughts
I aimed for a DPS that was slightly lower than infested civilians for a few reasons:
* A bit of range probably meant a higher likelihood to connect and do chip damage before dying
* More range means more concaves / simultaneous attacks when not dying
* Higher attack at slower rate means DPS is less impacted by armour

That said, it was still a little on the low side. I think damage can be further bumped 11 -> 12 if people still find it too low.

### Other observations
Race-swapped infested is probably the buggiest / least polished mission I've seen so far. I've listed bugs in the feature freeze goal list. Suffice to say, there's lots of display bugs in tooltips and objective text which I have _not_ fixed in this PR.