### PR TITLE
sc2: Balance adjustments

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -14822,9 +14822,9 @@
         <EditorCategories value="UpgradeType:Talents"/>
     </CUpgrade>
     <CUpgrade id="AP_ResourceEfficiencyReaver">
-        <EffectArray Operation="Subtract" Reference="Unit,AP_Reaver,CostResource[Minerals]" Value="100"/>
-        <EffectArray Operation="Subtract" Reference="Unit,AP_Reaver,CostResource[Vespene]" Value="100"/>
-        <EffectArray Reference="Unit,AP_Reaver,Food" Value="2"/>
+        <EffectArray Operation="Subtract" Reference="Unit,AP_Reaver,CostResource[Minerals]" Value="50"/>
+        <EffectArray Operation="Subtract" Reference="Unit,AP_Reaver,CostResource[Vespene]" Value="25"/>
+        <EffectArray Reference="Unit,AP_Reaver,Food" Value="1"/>
     </CUpgrade>
     <CUpgrade id="AP_ReaverKhalaiReplicators">
         <EffectArray Operation="Set" Reference="Unit,AP_Scarab,CostResource[Minerals]" Value="0"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -14996,7 +14996,7 @@
         <EffectArray Reference="Behavior,AP_DarkTemplarShadowFuryController,PeriodCount" Value="2"/>
     </CUpgrade>
     <CUpgrade id="AP_BloodHunterBrutalEfficiency">
-        <EffectArray Operation="Subtract" Reference="Weapon,AP_DarkTemplarTaldarim,Period" Value="2.306"/>
+        <EffectArray Operation="Subtract" Reference="Weapon,AP_DarkTemplarTaldarim,Period" Value="1.694"/>
     </CUpgrade>
     <CUpgrade id="AP_HighImpactPsionicStorm">
         <EffectArray Reference="Effect,AP_HighArchonPsiStormDamage,Amount" Value="4"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -2037,7 +2037,7 @@
         <DisplayEffect value="AP_WarpBlades"/>
         <TargetFilters value="Ground,Visible;Missile,Stasis,Dead,Hidden,Invulnerable"/>
         <Range value="0.1"/>
-        <Period value="4"/>
+        <Period value="3.388"/>
         <DamagePoint value="0.361"/>
         <Backswing value="1.333"/>
         <Effect value="AP_DarkTemplarTaldarimWeaponSet"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -2420,7 +2420,7 @@ Button/Tooltip/AP_BirthZergling=Fast melee creature. Can morph into a Baneling.<
 Button/Tooltip/AP_Blink=Teleports the Stalker to a nearby target location. Ability can only be used once every <d ref="Abil,AP_Blink,Cost[0].Cooldown.TimeUse"/> seconds.
 Button/Tooltip/AP_BlinkShieldRestoreUpgrade=Allows the Stalker's Blink ability to restore <d ref="Effect,AP_VoidStalkerBlinkRestoreModifyUnit,VitalArray[Shields].Change*(Behavior,AP_VoidStalkerBlinkShieldRestore,Duration/Behavior,AP_VoidStalkerBlinkShieldRestore,Period)"/> shields over <d time="5"/> after use.
 Button/Tooltip/AP_BloodAmulet=Increases starting energy by 150 and maximum energy by 50.
-Button/Tooltip/AP_BloodHunterBrutalEfficiency=Increases the Blood Hunter's attack rate by <d ref="(100*Upgrade,AP_BloodHunterBrutalEfficiency,EffectArray[0].Value)/(Weapon,AP_DarkTemplarTaldarim,Period)" player="0"/>%.
+Button/Tooltip/AP_BloodHunterBrutalEfficiency=Doubles the Blood Hunter's attack rate.
 Button/Tooltip/AP_BroodLord=Flying heavy-assault unit. Shoots Broodlings at its target. A Broodling is a small creature that can attack ground units.<n/><n/><c val="#ColorAttackInfo">Can attack ground units.</c>
 Button/Tooltip/AP_BroodLordCocoon=This cocoon contains a Mutalisk that is morphing into a Brood Lord.
 Button/Tooltip/AP_BroodLordEvolvedCarapace=Increases Brood Lord life by 100 and armor by 1.

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -3620,7 +3620,7 @@ Button/Tooltip/AP_ValkyrieShapedHull=Increases Valkyrie life by 50.
 Button/Tooltip/AP_ValkyrieSpeedBoost=Increases the Valkyrie's movement speed by 70% for <d time="8"/>.
 Button/Tooltip/AP_VanguardFusionMortars=<c val="ffff8a">Vanguards</c> deal +<d ref="Upgrade,AP_VanguardFusionMortars,EffectArray[0].Value"/> damage to armored targets per attack.
 Button/Tooltip/AP_VanguardMatterDispersion=Increases the area of the <c val="ffff8a">Vanguard's</c> splash damage by <d ref="($UpgradeEffectArrayValue:AP_AlarakVanguardIncreaseSplashArea:Effect,AP_ImmortalTaldarimWeaponSearch,AreaArray[0].Radius$/Effect,AP_ImmortalTaldarimWeaponSearch,AreaArray[0].Radius-1)*100" player="0"/>%
-Button/Tooltip/AP_VanguardRapidfireCannon=<c val="ffff8a">Vanguards</c> fire <d ref="($UpgradeEffectArrayValue:AP_VanguardRapidfireCannon:Weapon,AP_ImmortalTaldarim,Period$) / Weapon,AP_ImmortalTaldarim,Period * 100" player="0"/>% faster.
+Button/Tooltip/AP_VanguardRapidfireCannon=<c val="ffff8a">Vanguards</c> fire <d ref="100 * (Weapon,AP_ImmortalTaldarim,Period / (Weapon,AP_ImmortalTaldarim,Period - $UpgradeEffectArrayValue:AP_VanguardRapidfireCannon:Weapon,AP_ImmortalTaldarim,Period$) - 1)" player="0"/>% faster.
 Button/Tooltip/AP_VanguardSolariteEnhancedScatterCannon=Increases Vanguard attack range by 2.
 Button/Tooltip/AP_VanguardStriderStabilization=Vanguards can attack while moving.
 Button/Tooltip/AP_ViciousGlaive=Attacks bounce three additional times, hitting up to six targets. Bounces also travel farther.


### PR DESCRIPTION
Crossing off two items on the list from feedback:
* Lessening Blood Hunter WC nerf to just 50% attack speed (see #210 for original values)
* Reducing Reaver Resource Efficiency to something more reasonable.
  * Base cost: 300/200/6, old RE: -100/-100/-2
  * -50/-25/-1 is about the most generally good / average amount I could think of, I could get behind focusing more on one resource, so maybe -25/-25/-2 or even -100/0/-2 to copy the ultralisk one. I don't think it's safe to both reduce gas and food cost by a lot, and I don't think we want any RE going past -50 gas except Predator.

Pairs with [client PR #408](https://github.com/Ziktofel/Archipelago/pull/408)

## Blood Hunter
![image](https://github.com/user-attachments/assets/8aa95e30-0b44-4653-938c-1942521f9aac)
![image](https://github.com/user-attachments/assets/9e1cd9fb-ee16-45a9-829c-86dc86973c93)
![image](https://github.com/user-attachments/assets/e84fe731-d997-44ad-a733-d4de9e784bfa)

## Reaver
![image](https://github.com/user-attachments/assets/0084f4d7-8b47-4437-85b9-fced1f195435)
![image](https://github.com/user-attachments/assets/01012b8e-1d93-4616-b1a0-066d8926637f)
