### PR TITLE
SC2: Small fixes and polish

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -1291,7 +1291,7 @@
         <GroupSoundArray index="Board" value="Thor_GroupBoard"/>
         <GroupSoundThreshold value="2"/>
         <HeroIcon value="Assets\Textures\btn-unit-terran-thormengsk.dds"/>
-        <HighlightTooltip value="Unit/Name/ThorMengsk"/>
+        <HighlightTooltip value="Unit/Name/AP_ThorMengsk"/>
         <LifeArmorIcon value="Assets\Textures\btn-upgrade-terran-vehicleplatinglevel0.dds"/>
         <MinimapIconScale value="1.000000"/>
         <MinimapIconBackgroundScale value="1.000000"/>
@@ -2719,7 +2719,7 @@
         <Aliases value="_UnitMedium"/>
         <Macros value="UnloadDropAnim"/>
         <On Terms="Abil.attack.ReadyStart" Send="AnimGroupApply Ready"/>
-        <On Terms="ActorCreation" Send="StatusSet WeaponNext 0"/>
+        <On Terms="ActorCreation" Send="StatusSet WeaponNext 1"/>
         <On Terms="Effect.AP_PunisherGrenadesLM.Start; At Caster" Send="StatusIncrement WeaponNext"/>
         <On Terms="Effect.AP_PunisherGrenadesLM.Start; At Caster; IsStatus WeaponNext 2" Send="StatusSet WeaponNext 0"/>
         <On Terms="Effect.AP_PunisherGrenadesLM.Start; At Caster; IsStatus WeaponNext 0" Send="AnimClear AttackRight"/>
@@ -17742,6 +17742,7 @@
             <BodySquibs Name="None"/>
         </DeathCustoms>
         <DeathActorModel value="AP_DisruptorDeath"/>
+        <PlacementActorModel value="AP_ProbeWarpinCursor"/>
         <PlacementModel value="Disruptor_Purifier_Collection"/>
         <PlacementSound value="Protoss_BuildingPlacementSmall"/>
         <PortraitModel value="Disruptor_Purifier_Portrait"/>
@@ -17765,7 +17766,7 @@
         <GroupSoundArray index="Movement" value="AP_Disruptor_Movement"/>
         <GroupSoundArray index="Board" value="Zealot_GroupBoard"/>
         <HeroIcon value="Assets\Textures\btn-unit-collection-purifier-disruptor.dds"/>
-        <HighlightTooltip value="Unit/Name/AP_PurifierDisruptor"/>
+        <HighlightTooltip value="Unit/Name/AP_Disruptor"/>
         <LifeArmorIcon value="Assets\Textures\btn-upgrade-protoss-groundarmorlevel0.dds"/>
         <SoundArray index="Ready" value="AP_Pusher_Ready"/>
         <SoundArray index="Help" value="AP_Pusher_Help"/>
@@ -32711,7 +32712,7 @@
         <HostSiteOps Ops="SOpAttachOriginStationary"/>
     </CActorSound>
     <CActorModel id="AP_ShuttleTransportUnloadModel" parent="ModelAnimationStyleOneShot">
-        <On Terms="Abil.AP_WarpPrismTransport.CargoUnload" Send="Create"/>
+        <On Terms="AbilTransport.AP_WarpPrismTransport.CargoUnload" Send="Create"/>
         <Host Subject="_Selectable"/>
         <HostSiteOps Ops="SOpAttachOrigin"/>
         <Model value="ShuttleTransportUnloadModel"/>
@@ -40022,7 +40023,7 @@
         <AcceptedTransfers index="Textures" value="1"/>
         <AcceptedTransfers index="Status" value="1"/>
         <AcceptedHostedPropTransfers index="BaseModelScale" value="0"/>
-        <On Terms="ActorCreation" Send="StatusSet WeaponNext 0"/>
+        <On Terms="ActorCreation" Send="StatusSet WeaponNext 1"/>
         <On Terms="Effect.AP_PunisherGrenadesMengskLM.Start; At Caster" Send="StatusIncrement WeaponNext"/>
         <On Terms="Effect.AP_PunisherGrenadesMengskLM.Start; At Caster; IsStatus WeaponNext 2" Send="StatusSet WeaponNext 0"/>
         <On Terms="Effect.AP_PunisherGrenadesMengskLM.Start; At Caster; IsStatus WeaponNext 0" Send="AnimClear AttackRight"/>
@@ -40149,7 +40150,7 @@
         <GroupSoundArray index="Board" value="Marauder_GroupBoard"/>
         <GroupSoundThreshold value="2"/>
         <HeroIcon value="Assets\Textures\btn-unit-terran-maraudermengsk.dds"/>
-        <HighlightTooltip value="Unit/Name/MarauderMengsk"/>
+        <HighlightTooltip value="Unit/Name/AP_MarauderMengsk"/>
         <LifeArmorIcon value="Assets\Textures\btn-upgrade-terran-infantryarmorlevel0.dds"/>
         <MinimapIconScale value="1.000000"/>
         <MinimapIconBackgroundScale value="1.000000"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -9375,10 +9375,12 @@
         <UnitIcon value="Assets\Textures\btn-unit-zerg-roach-vile.dds"/>
         <HeroIcon value="Assets\Textures\btn-unit-zerg-roach-vile.dds"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-roachex1b.dds"/>
+            <!-- override -->
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-roachex1b.dds"/>
         </GroupIcon>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-roachex1b.dds"/>
+            <!-- override -->
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-roachex1b.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorUnit id="AP_RoachCorpser" parent="AP_RoachBase" unitName="AP_RoachCorpser">
@@ -9394,10 +9396,12 @@
         <UnitIcon value="Assets\Textures\btn-unit-zerg-roach-corpser.dds"/>
         <HeroIcon value="Assets\Textures\btn-unit-zerg-roach-corpser.dds"/>
         <GroupIcon>
-            <Image value="Assets\Textures\btn-unit-zerg-roach-corpser.dds"/>
+            <!-- override -->
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-roachex1a.dds"/>
         </GroupIcon>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-roachex1a.dds"/>
+            <!-- override -->
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-roachex1a.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorAction id="AP_RoachAttack" parent="GenericAttack" effectImpact="AP_AcidSalivaU" effectLaunch="AP_AcidSalivaLM">

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -26961,6 +26961,7 @@
         <Wireframe>
             <Image value="Assets\Textures\wireframe-terran-liberator-agmodeblackops.dds"/>
         </Wireframe>
+        <HighlightTooltip value="Unit/Name/AP_MercLiberator"/>
     </CActorUnit>
     <CActorAction id="AP_LiberatorAGAttack" parent="GenericAttack" effectImpact="AP_LiberatorAGDamage" effectLaunch="AP_LiberatorAGMissileLM">
         <LaunchAssets Sound="Liberator_AG_Launch"/>
@@ -28616,6 +28617,7 @@
         <Wireframe>
             <Image value="AP\Assets\Textures\Wireframe-Terran-siegetank-mercenary-siegemode.dds"/>
         </Wireframe>
+        <HighlightTooltip value="Unit/Name/AP_SiegeBreaker"/>
     </CActorUnit>
     <CActorSound id="AP_SiegeBreakerSiegeModeSound" parent="SoundOneShot">
         <On Terms="AbilMorph.*.Start; MorphTo AP_SiegeBreakerSieged; !ValidatePlayer AP_HaveMultiTaskMAFServosSiegeTank" Send="Create"/>
@@ -29132,6 +29134,7 @@
         <Wireframe>
             <Image value="AP\Assets\Textures\Wireframe-Terran-Viking-mercenary-Assault.dds"/>
         </Wireframe>
+        <HighlightTooltip value="Unit/Name/AP_WreckingCrewFighter"/>
     </CActorUnit>
     <CActorUnit id="AP_WreckingCrewFighter" parent="GenericUnitMorph" unitName="AP_HelsAngelFighter">
         <Aliases value="_UnitLarge"/>
@@ -33206,6 +33209,7 @@
         <!--        <AbilSoundArray AbilCmd="FighterMode,Execute" Sound="Viking_FighterModeVO"/>-->
         <BarOffset value="70"/>
         <BarWidth value="70"/>
+        <HighlightTooltip value="Unit/Name/AP_BrynhildFighter"/>
         <GroupIcon>
             <Image value="Assets\Textures\Wireframe-Terran-Viking-Assault.dds"/>
         </GroupIcon>
@@ -33357,6 +33361,7 @@
         <!--        <On Terms="ModelEvent; ModelEventName VikingLandShock" Send="Create AP_VikingLandShock"/>-->
         <Aliases value="_UnitLarge"/>
         <Macros value="HHMattModelMacro"/>
+        <HighlightTooltip value="Unit/Name/AP_BrynhildFighter"/>
     </CActorUnit>
     <CActorModel id="AP_VikingLandShock" parent="ModelAnimationStyleOneShot">
         <Model value="AP_HHBomberBoosterShock"/>
@@ -33419,6 +33424,7 @@
         <!--        <On Terms="UnitPortrait.*.Configure" Target="::PortraitGameSelf" Send="AnimPlay Visor Morph,Start PlayForever,NonLooping"/>-->
         <!--        <On Terms="UnitPortrait.*.Configure" Target="::PortraitGameSelf" Send="PortraitAnimSetTimeFrom Visor MorphStart"/>-->
         <Aliases value="_UnitLarge"/>
+        <HighlightTooltip value="Unit/Name/AP_BrynhildFighter"/>
     </CActorUnit>
     <CActorModel id="AP_VikingFighterReentry" parent="ModelAdditionNoAnims">
         <On Terms="ActorCreation" Send="AnimBracketStart BSDb Birth Stand Death ContentPlayOnce"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ButtonData.xml
@@ -1063,10 +1063,18 @@
         <Icon value="AP\Assets\Textures\btn-building-terran-hivemindemulator.dds"/>
         <AlertIcon value="AP\Assets\Textures\btn-building-terran-hivemindemulator.dds"/>
         <EditorCategories value="Race:Terran"/>
+        <TooltipAppender Validator="AP_HaveHiveMindEmulatorZerg" Text="Button/Tooltip/AP_AppendZergBullet"/>
+        <TooltipAppender Validator="AP_HaveHiveMindEmulatorTerran" Text="Button/Tooltip/AP_AppendTerranBullet"/>
+        <TooltipAppender Validator="AP_HaveHiveMindEmulatorProtoss" Text="Button/Tooltip/AP_AppendProtossBullet"/>
+        <TooltipAppender Validator="AP_HiveMindEmulatorNotZerg" Text="Button/Tooltip/AP_AppendZergWarning"/>
     </CButton>
     <CButton id="AP_MindControl">
         <Icon value="Assets\Textures\btn-ability-terran-scannersweep-color.dds"/>
         <EditorCategories value="Race:Terran"/>
+        <TooltipAppender Validator="AP_HaveHiveMindEmulatorZerg" Text="Button/Tooltip/AP_AppendZergBullet"/>
+        <TooltipAppender Validator="AP_HaveHiveMindEmulatorTerran" Text="Button/Tooltip/AP_AppendTerranBullet"/>
+        <TooltipAppender Validator="AP_HaveHiveMindEmulatorProtoss" Text="Button/Tooltip/AP_AppendProtossBullet"/>
+        <TooltipAppender Validator="AP_HiveMindEmulatorNotZerg" Text="Button/Tooltip/AP_AppendZergWarning"/>
     </CButton>
     <CButton id="AP_Diamondback">
         <Icon value="Assets\Textures\btn-unit-terran-cobra.dds"/>
@@ -1255,7 +1263,10 @@
         <AlertIcon value="AP\Assets\Textures\btn-building-terran-sigmaprojector.dds"/>
         <Hotkey value="Button/Hotkey/AP_PsiDisrupter"/>
         <EditorCategories value="Race:Terran"/>
-        <HotkeyAlias value=""/>
+        <TooltipAppender Validator="AP_HavePsiDisrupterZerg" Text="Button/Tooltip/AP_AppendZergBullet"/>
+        <TooltipAppender Validator="AP_HavePsiDisrupterTerran" Text="Button/Tooltip/AP_AppendTerranBullet"/>
+        <TooltipAppender Validator="AP_HavePsiDisrupterProtoss" Text="Button/Tooltip/AP_AppendProtossBullet"/>
+        <TooltipAppender Validator="AP_PsiDisrupterNotZerg" Text="Button/Tooltip/AP_AppendZergWarning"/>
     </CButton>
     <CButton id="AP_Refinery">
         <Icon value="Assets\Textures\btn-building-terran-refinery.dds"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ModelData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ModelData.xml
@@ -11685,8 +11685,6 @@
         <LowQualityModel value="ProtossUnitBirth"/>
         <EditorCategories value="Race:Protoss"/>
         <Occlusion value="Show"/>
-        <ScaleMax value="0.850000,0.850000,0.850000"/>
-        <ScaleMin value="0.850000,0.850000,0.850000"/>
         <SelectionOffset value="0.000000,0.000000,-0.750000"/>
         <SelectionRadius value="0.750000"/>
         <ShadowRadius value="0.750000"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -7327,6 +7327,10 @@
         <CombineArray value="IsTerran"/>
         <Type value="And"/>
     </CValidatorCombine>
+    <CValidatorCombine id="AP_PsiDisrupterNotZerg">
+        <CombineArray value="AP_HavePsiDisrupterZerg"/>
+        <Negate value="1"/>
+    </CValidatorCombine>
     <CValidatorPlayerRequirement id="AP_HaveHiveMindEmulatorZerg">
         <Find value="1"/>
         <Value value="AP_HaveHiveMindEmulatorZerg"/>
@@ -7363,6 +7367,10 @@
         <CombineArray value="AP_UseHiveMindEmulatorZerg"/>
         <CombineArray value="AP_UseHiveMindEmulatorTerran"/>
         <CombineArray value="AP_UseHiveMindEmulatorProtoss"/>
+    </CValidatorCombine>
+    <CValidatorCombine id="AP_HiveMindEmulatorNotZerg">
+        <CombineArray value="AP_HaveHiveMindEmulatorZerg"/>
+        <Negate value="1"/>
     </CValidatorCombine>
     <CValidatorCombine id="AP_ProbeCanWarpin">
         <Type value="And"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -2301,6 +2301,10 @@ Button/Tooltip/AP_AnabolicSynthesis=Increases Ultralisk movement speed.
 Button/Tooltip/AP_AncillaryCarapaceHydralisk=Hydralisk gains +20 maximum life.
 Button/Tooltip/AP_AnionPulseCrystals=Improves Ion Cannon weapon attack range by 2.
 Button/Tooltip/AP_AnnihilatorAerialTracking=Allows Shadow Cannon to target air units.
+Button/Tooltip/AP_AppendProtossBullet=</n><c val="FFE303">• Protoss</c>
+Button/Tooltip/AP_AppendTerranBullet=</n><c val="FFE303">• Terran</c>
+Button/Tooltip/AP_AppendZergBullet=</n><c val="FFE303">• Zerg</c>
+Button/Tooltip/AP_AppendZergWarning=</n><c val="FFE303">Currently does not affect Zerg units!</c>
 Button/Tooltip/AP_Apocalypse=Deals <d ref="Effect,AP_ApocalypseDamage,Amount"/> damage to enemy units and <d ref="(Effect,AP_ApocalypseDamage,Amount) + (Effect,AP_ApocalypseDamage,AttributeBonus[Structure])"/> damage to enemy structures in a large area.
 Button/Tooltip/AP_ApolloCloakOnNova=Cloaks Nova for <d ref="Behavior,AP_NovaApolloCloak,Duration"/> seconds, preventing enemy units from seeing or attacking her. A cloaked unit will only be revealed by detectors or effects.
 Button/Tooltip/AP_Arbiter=Aiur Faction<n/>Army support craft. Has Stasis Field, Recall and Cloak Field abilities.<n/><n/><c val="ffff8a">Can attack ground and air units.</c>
@@ -2751,12 +2755,12 @@ Button/Tooltip/AP_HireSpartanCompany=Request 2 Spartan Company Mercenaries.<n/><
 Button/Tooltip/AP_HireSpartanCompanyPH=<c val="ff4040">Contract required. Visit the Cantina on the Hyperion to purchase.</c>
 Button/Tooltip/AP_Hive=Further evolved version of the Hatchery that allows additional upgrades and structures to be produced. Also spawns all Zerg units and receives gathered resources.
 Button/Tooltip/AP_HatchToHive=Evolve this Hatchery directly to a Hive, allowing additional upgrades and structures to be produced. Also spawns all Zerg units and receives gathered resources.
-Button/Tooltip/AP_HiveMindEmulator=Defensive structure. Can permanently Mind Control units of races you unlocked.
-Button/Tooltip/AP_HiveMindEmulatorAll=The Hive Mind Emulator can Mind Control units of any race.<n/><n/><c val="#ColorAttackInfo">Heroic units, workers and structures are immune.</c>
-Button/Tooltip/AP_HiveMindEmulatorProtoss=The Hive Mind Emulator can Mind Control Protoss  units.<n/><n/><c val="#ColorAttackInfo">Heroic units, workers and structures are immune.</c>
-Button/Tooltip/AP_HiveMindEmulatorTerran=The Hive Mind Emulator can Mind Control Terran units.<n/><n/><c val="#ColorAttackInfo">Heroic units, workers and structures are immune.</c>
-Button/Tooltip/AP_HiveMindEmulatorZerg=The Hive Mind Emulator can Mind Control Zerg units.<n/><n/><c val="#ColorAttackInfo">Heroic units, workers and structures are immune.</c>
-Button/Tooltip/AP_MindControl=Permanently converts targeted unit to player control. Can target units for the races you unlocked.<n/><n/><c val="#ColorAttackInfo">Heroic units, workers and structures are immune.</c>
+Button/Tooltip/AP_HiveMindEmulator=Defensive structure. Can permanently Mind Control units for each race you have unlocked for it.</n></n><c val="#ColorAttackInfo">Heroic units are immune.</c></n></n><c val="FFE303">Affected Races:</c>
+Button/Tooltip/AP_HiveMindEmulatorAll=The Hive Mind Emulator can Mind Control units of any race.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c>
+Button/Tooltip/AP_HiveMindEmulatorProtoss=The Hive Mind Emulator can Mind Control Protoss units.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c>
+Button/Tooltip/AP_HiveMindEmulatorTerran=The Hive Mind Emulator can Mind Control Terran units.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c>
+Button/Tooltip/AP_HiveMindEmulatorZerg=The Hive Mind Emulator can Mind Control Zerg units.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c>
+Button/Tooltip/AP_MindControl=Permanently converts targeted unit to player control. Can target units for each race you have unlocked for it.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c></n></n><c val="FFE303">Affected Races:
 Button/Tooltip/AP_HostileEnvironmentAdaptation=Increases SCV life by 15 and attack speed slightly.
 Button/Tooltip/AP_HotSBioPlasmidDischarge=Deals <d ref="Effect,AP_HotSBioPlasmidDischargeDamage,Amount"/> damage to a target unit or structure from long range.
 Button/Tooltip/AP_HotSBioStasis=Enemies in target area are stunned for <d ref="Behavior,AP_HotSBioStasis,Duration"/> seconds. Does not affect Heroic units or Structures.
@@ -2977,7 +2981,6 @@ Button/Tooltip/AP_MercZerglingSummon=Spawn four Devouring Ones, a powerful strai
 Button/Tooltip/AP_MercZerglingSummonUpg=Spawn six Devouring Ones, a powerful strain of zerglings from the Brood War.
 Button/Tooltip/AP_MicroFiltering=This refinery is producing Vespene gas 25% faster
 Button/Tooltip/AP_MindBolt=Kerrigan deals <d ref="Effect,AP_MindBoltDamage,Amount"/> damage to target unit or structure from long range.
-Button/Tooltip/AP_MindControl=Permanently converts targeted unit to player control. Can target units for the races you unlocked.<n/><n/><c val="#ColorAttackInfo">Heroic units, workers and structures are immune.</c>
 Button/Tooltip/AP_MissilePods=Missile Pods deal <d ref="Effect,AP_HurricaneMissileDamage,Amount * Effect,AP_HurricaneMissileDamagePersistent,PeriodCount"/> (+<d ref="Effect,AP_HurricaneMissileDamage,AttributeBonus[0] * Effect,AP_HurricaneMissileDamagePersistent,PeriodCount"/> vs. light) damage to air units in target area.
 Button/Tooltip/AP_MissilePodsUpgraded=Missile Pods deal <d ref="Effect,AP_HurricaneMissileDamage,Amount * Effect,AP_HurricaneMissileDamagePersistent,PeriodCount"/> damage to air units in target area.
 Button/Tooltip/AP_MissileTurret=Primary anti-air defensive structure. <n/><n/><c val="#ColorAttackInfo">Can attack air units.</c><n/><c val="FFE303">Detector</c>
@@ -3186,7 +3189,7 @@ Button/Tooltip/AP_PsiDisruption=Slows the attack and movement speeds of all near
 Button/Tooltip/AP_PsiDisruptionAll=Slows the attack and movement speeds of all nearby enemy units.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c>
 Button/Tooltip/AP_PsiDisruptionProtoss=Slows the attack and movement speeds of all nearby enemy Protoss units.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c>
 Button/Tooltip/AP_PsiDisruptionTerran=Slows the attack and movement speeds of all nearby enemy Terran units.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c>
-Button/Tooltip/AP_PsiDisruptor=Defensive structure. Slows the attack and movement speeds of all nearby units for all races you unlocked for it.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c>
+Button/Tooltip/AP_PsiDisruptor=Defensive structure. Slows the attack and movement speeds of all nearby units for each race you have unlocked for it.<n/><n/><c val="#ColorAttackInfo">Heroic units are immune.</c></n></n><c val="FFE303">Affected Races:</c>
 Button/Tooltip/AP_PsiStorm=Creates a storm of psionic energy that lasts <d ref="(Effect,AP_HighArchonPsiStormPersistent,PeriodCount*Effect,AP_HighArchonPsiStormPersistent,PeriodicPeriodArray[0]) + Behavior,AP_HighArchonPsiStorm,Duration"/> seconds, causing up to <d ref="Effect,AP_HighArchonPsiStormDamageInitial,Amount + (Effect,AP_HighArchonPsiStormPersistent,PeriodCount * Behavior,AP_HighArchonPsiStorm,Duration * Effect,AP_HighArchonPsiStormDamage,Amount / Behavior,AP_HighArchonPsiStorm,Period)"/> damage to all enemy units in the target area. Does not damage friendly units.
 Button/Tooltip/AP_PsiStrike=Kerrigan dashes through enemies, dealing <d ref="Effect,AP_PsiStrikeDamage,Amount"/> damage to all enemies in her path.<n/><n/><c val="ffff8a">Passive: Movement speed increased by 30%.</c>
 Button/Tooltip/AP_PsionicLift=Enemies in target area are stunned for <d ref="Behavior,AP_PsionicLift,Duration"/> seconds and take <d ref="Behavior,AP_PsionicLift,Duration * Effect,AP_PsionicLiftDamage,Amount"/> damage over time.<n/><n/><c val="ffff8a">Does not stun heroic units.</c>


### PR DESCRIPTION
- Updated tooltips for Psi Disrupter and Hive Mind Emulator to clarify, which races they affect
- Emphasized they don't work against Zerg baseline
![GIF_22 01 2025_09-34-52](https://github.com/user-attachments/assets/2b811b7d-07dc-47a8-bdd1-953cc8511e47)
(no race affected is a test state that cannot happen in an actual game)
- Fixed attack animation mismatch for Marauder and Aegis Guard (Hammer Securities were working properly)
- Fixed Scout warpin model scale
- Fixed Warp Prism unload model
- Updated Disruptor placement model
- Fixed Roach strains wireframe issue
- Fixed Highlight Tooltips for several units:
  - Aegis Guard
  - Blackhammer
  - Disruptor
  - Midnight Raiders
  - Siege Breakers
  - Hel's Angels
  - Brynhilds

Tested in local testmap