### PR TITLE
sc2: Fixing a bug where skylords wouldn't stack damage properly

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -8207,26 +8207,37 @@
         <Target Effect="AP_ReleaseInterceptorsSet" Value="TargetPoint"/>
     </CEffectIssueOrder>
     <CEffectDamage id="AP_CarrierTaldarimLaserDamage" parent="DU_WEAP">
-        <ValidatorArray value="noMarkers"/>
         <EditorCategories value="Race:Protoss"/>
         <Kind value="Ranged"/>
         <KindSplash value="Splash"/>
         <Amount value="50"/>
         <Death value="Fire"/>
     </CEffectDamage>
+    <CEffectSet id="AP_CarrierTaldarimLaserDamageWrapper">
+        <ValidatorArray value="AP_TargetInWeaponRange"/>
+        <EffectArray value="AP_CarrierTaldarimLaserDamage"/>
+    </CEffectSet>
+    <CEffectEnumArea id="AP_CarrierTaldarimLaserDamageSearch">
+        <EditorCategories value="Race:Protoss"/>
+        <IncludeArray Effect="AP_CarrierTaldarimLaserEffect" Value="Target"/>
+        <SearchFilters value="-;Player,Ally,Missile,Stasis,Dead,Hidden,Invulnerable"/>
+        <AreaArray RectangleWidth="1.5" RectangleHeight="15" Effect="AP_CarrierTaldarimLaserDamageWrapper"/>
+        <SearchFlags index="CallForHelp" value="1"/>
+    </CEffectEnumArea>
     <CEffectEnumArea id="AP_CarrierTaldarimLaserDamageArea">
         <EditorCategories value="Race:Protoss"/>
         <ExcludeArray Value="Target"/>
         <IncludeArray Effect="AP_CarrierTaldarimLaserCP" Value="Target"/>
         <IncludeArray Effect="AP_CarrierTaldarimLaserCP2BonusRange" Value="Target"/>
         <SearchFilters value="-;Player,Ally,Missile,Stasis,Dead,Hidden,Invulnerable"/>
-        <AreaArray Radius="0.8" Effect="AP_CarrierTaldarimLaserDamage"/>
+        <AreaArray Radius="0.8" Effect=""/>
         <SearchFlags index="CallForHelp" value="1"/>
-        <Marker Link="Effect/AP_CarrierTaldarimLaserDamage">
-            <MatchFlags index="Link" value="1"/>
-        </Marker>
     </CEffectEnumArea>
-    <CEffectSwitch id="AP_CarrierTaldarimLaserEffect">
+    <CEffectSet id="AP_CarrierTaldarimLaserEffect">
+        <EffectArray value="AP_CarrierTaldarimLaserEffectSwitch"/>
+        <EffectArray value="AP_CarrierTaldarimLaserDamageSearch"/>
+    </CEffectSet>
+    <CEffectSwitch id="AP_CarrierTaldarimLaserEffectSwitch">
         <CaseArray Validator="AP_Have1BonusRangeBehavior" Effect="AP_CarrierTaldarimLaserCP1BonusRange"/>
         <CaseArray Validator="AP_Have2BonusRangeBehavior" Effect="AP_CarrierTaldarimLaserCP2BonusRange"/>
         <CaseArray Validator="AP_Have3BonusRangeBehavior" Effect="AP_CarrierTaldarimLaserCP3BonusRange"/>


### PR DESCRIPTION
If multiple skylords attacked in the same tick, they wouldn't do additional damage.

This seems to be because the noMarkers validator wasn't working properly. Switched around some effects so the old effect tree is kept around for actor data reasons, and the top-level is replaced with a set that contains a new rectangular enumArea that does the actual damage.

Tested in-game that
* Skylords could still damage player units if attacking directly
* Skylords didn't do friendly fire otherwise
* Skylords still did the AoE properly
* Skylords' attacks would stack if attacking at the same time (tested by blinking a group of them into enemies)