### PR TITLE
Correct Two Overlayed Wireframes Displaying for Certain Zerg Strains 

### DIFF
--- a/Maps/ArchipelagoCampaign/NCO/ap_in_the_enemy_s_shadow.SC2Map/Objects
+++ b/Maps/ArchipelagoCampaign/NCO/ap_in_the_enemy_s_shadow.SC2Map/Objects
@@ -10492,9 +10492,9 @@
     <ObjectPoint Color="0,0,0,0" Id="1830833840" Name="No Fly Zone 054" PathingRadiusHard="2.5" PathingRadiusSoft="3" Position="105.42,141.4238,0" Scale="1,1,1" Type="NoFlyZone"/>
     <ObjectPoint Color="0,0,0,0" Id="1637971181" Name="No Fly Zone 034" PathingRadiusHard="2.5" PathingRadiusSoft="3" Position="49.741,174.5808,0" Scale="1,1,1" Type="NoFlyZone"/>
     <ObjectPoint Color="0,0,0,0" Id="1160309722" Name="S3 - Alarm Bot Patrol 1 - 1" Position="119,184.5,0" Scale="1,1,1" Type="Normal">
-    <ObjectPoint Id="2046855289" Position="97.051,224.5903,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 057" Color="0,0,0,0"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectPoint>
+    <ObjectPoint Id="2046855289" Position="97.051,224.5903,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 057" Color="0,0,0,0"/>
     <ObjectPoint Color="0,0,0,0" Id="1675461827" Name="S1 - Ghost Target" Position="85.1647,45.0485,0" Rotation="2.8657" Scale="1,1,1" Type="Normal"/>
     <ObjectPoint Color="0,0,0,0" Id="570270352" Name="Mid 2 Stone Walk From" Position="133.9443,182.4296,0" Rotation="5.098" Scale="1,1,1" Type="Normal"/>
     <ObjectPoint Color="0,0,0,0" Id="1399392562" Name="S3 - Alarm Bot Patrol 1 - 2" Position="125,190.5,0" Scale="1,1,1" Type="Normal">

--- a/Maps/ArchipelagoCampaign/NCO/ap_in_the_enemy_s_shadow.SC2Map/Objects
+++ b/Maps/ArchipelagoCampaign/NCO/ap_in_the_enemy_s_shadow.SC2Map/Objects
@@ -10492,6 +10492,7 @@
     <ObjectPoint Color="0,0,0,0" Id="1830833840" Name="No Fly Zone 054" PathingRadiusHard="2.5" PathingRadiusSoft="3" Position="105.42,141.4238,0" Scale="1,1,1" Type="NoFlyZone"/>
     <ObjectPoint Color="0,0,0,0" Id="1637971181" Name="No Fly Zone 034" PathingRadiusHard="2.5" PathingRadiusSoft="3" Position="49.741,174.5808,0" Scale="1,1,1" Type="NoFlyZone"/>
     <ObjectPoint Color="0,0,0,0" Id="1160309722" Name="S3 - Alarm Bot Patrol 1 - 1" Position="119,184.5,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2046855289" Position="97.051,224.5903,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 057" Color="0,0,0,0"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectPoint>
     <ObjectPoint Color="0,0,0,0" Id="1675461827" Name="S1 - Ghost Target" Position="85.1647,45.0485,0" Rotation="2.8657" Scale="1,1,1" Type="Normal"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -10366,12 +10366,12 @@
         <DeathArray index="Normal" ModelLink="AP_HydraliskImpalerDeath" SoundLink="Hydralisk_Explode"/>
         <PortraitModel value="AP_HydraliskImpalerPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-HydraliskEx1A.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-HydraliskEx1A.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-Zerg-Hydralisk-impaler.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-Zerg-Hydralisk-impaler.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-HydraliskEx1A.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-HydraliskEx1A.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorUnit id="AP_HydraliskLurker" parent="AP_HydraliskBase" unitName="AP_HydraliskLurker">
@@ -10381,12 +10381,12 @@
         <DeathArray index="Normal" ModelLink="AP_HydraliskLurkerDeath" SoundLink="Hydralisk_Explode"/>
         <PortraitModel value="AP_HydraliskLurkerPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-HydraliskEx1B.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-HydraliskEx1B.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-Zerg-Hydralisk-lurker.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-Zerg-Hydralisk-lurker.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-HydraliskEx1B.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-HydraliskEx1B.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorAction id="AP_HydraliskMeleeAttack" parent="GenericAttack" effectAttack="AP_HydraliskMelee">
@@ -11040,12 +11040,12 @@
         <DeathArray index="Normal" ModelLink="AP_SwarmHostEx1ADeath"/>
         <PortraitModel value="AP_SwarmHostSplitAPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-SwarmHostEx1A.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-SwarmHostEx1A.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-Zerg-SwarmHost-carrion.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-Zerg-SwarmHost-carrion.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-SwarmHostEx1A.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-SwarmHostEx1A.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorUnit id="AP_SwarmHostSplitB" parent="AP_SwarmHostBase" unitName="AP_SwarmHostSplitB">
@@ -11055,12 +11055,12 @@
         <PlacementModel value="AP_SwarmHostSplitB"/>
         <PortraitModel value="AP_SwarmHostSplitBPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-SwarmHostEx1B.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-SwarmHostEx1B.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-Zerg-SwarmHost-creeper.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-Zerg-SwarmHost-creeper.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-SwarmHostEx1B.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-SwarmHostEx1B.dds"/>
         </Wireframe>
         <On index="92" Terms="AbilMorph.*.Finish; MorphTo AP_SwarmHostBurrowed; MorphFrom AP_SwarmHostRooted" Send="AnimBracketStart Burrow Burrow IGNORE Unburrow ClosingFull,OpeningPlayForever,DontResetOnUnhide"/>
     </CActorUnit>
@@ -14019,10 +14019,10 @@
         <On Terms="Upgrade.AP_WarperPlayer.Remove; ValidateUnit AP_HaveHotSMutaliskBroodlord" Send="Create AP_MutaliskBroodlord"/>
         <On Terms="Upgrade.AP_WarperPlayer.Remove; ValidateUnit AP_HaveHotSMutaliskBroodlord" Send="Destroy"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-Mutalisk.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-Mutalisk.dds"/>
         </GroupIcon>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-Mutalisk.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-Mutalisk.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorUnit id="AP_MutaliskBroodlord" parent="AP_MutaliskBase" unitName="AP_MutaliskBroodlord">
@@ -14037,24 +14037,24 @@
         <DeathArray index="Normal" ModelLink="AP_MutaliskBroodlordDeath"/>
         <PortraitModel value="AP_MutaliskBroodlordPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-Mutaliskex1a.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-Mutaliskex1a.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-zerg-mutalisk-broodlord.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-zerg-mutalisk-broodlord.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-Mutaliskex1a.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-Mutaliskex1a.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorUnit id="AP_MutaliskViper" parent="AP_MutaliskBase" unitName="AP_MutaliskViper">
         <DeathArray index="Normal" ModelLink="AP_MutaliskViperDeath"/>
         <PortraitModel value="AP_MutaliskViperPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-Mutaliskex1b.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-Mutaliskex1b.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-zerg-mutalisk-viper.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-zerg-mutalisk-viper.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-Mutaliskex1b.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-Mutaliskex1b.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorAction id="AP_MutaliskAttackSegment1" parent="GenericAttack" effectImpact="AP_GlaiveWurmS1" effectLaunch="AP_GlaiveWurm">
@@ -27595,12 +27595,12 @@
         <DeathArray index="Normal" ModelLink="AP_UltraliskEx1BDeath"/>
         <PortraitModel value="AP_TorrasquePortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-ultraliskex1b.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-ultraliskex1b.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-zerg-ultralisk-torrasque.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-zerg-ultralisk-torrasque.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-ultraliskex1b.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-ultraliskex1b.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorUnit id="AP_UltraliskNoxious" parent="AP_UltraliskBase" unitName="AP_HotSNoxious">
@@ -27615,12 +27615,12 @@
         <PlacementModel value="AP_HotSNoxious"/>
         <PortraitModel value="AP_NoxiousPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-UltraliskEx1A.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-UltraliskEx1A.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-zerg-ultralisk-noxious.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-zerg-ultralisk-noxious.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-UltraliskEx1A.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-UltraliskEx1A.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorSplat id="AP_UltraliskBurrowedSplat" parent="BurrowedSplat" unitName="AP_Ultralisk">
@@ -32473,7 +32473,7 @@
         <PlacementModel value="Zergling"/>
         <PortraitModel value="ZerglingPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-Zergling.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-Zergling.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-zerg-zergling.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-zerg-zergling.dds"/>
@@ -32481,7 +32481,7 @@
             <ColorArray value="255,0,128,0"/>
         </VitalColors>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-Zergling.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-Zergling.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorUnit id="AP_HotSSwarmling" parent="AP_ZerglingBase" unitName="AP_HotSSwarmling">
@@ -32493,12 +32493,12 @@
         <DeathCustoms ModelLink="AP_HotSSwarmlingUpgradeDeath" SoundLink="Zergling_Explode" Name="Upgrade"/>
         <PortraitModel value="AP_SwarmlingPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-zerglingex1b.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-zerglingex1b.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-zerg-zergling-swarmling.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-zerg-zergling-swarmling.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-zerglingex1b.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-zerglingex1b.dds"/>
         </Wireframe>
     </CActorUnit>
     <CActorMissile id="AP_HotSRaptor" parent="AP_ZerglingBase" unitName="AP_HotSRaptor">
@@ -32506,12 +32506,12 @@
         <DeathCustoms ModelLink="AP_HotSRaptorUpgradeDeath" SoundLink="Zergling_Explode" Name="Upgrade"/>
         <PortraitModel value="AP_RaptorPortrait"/>
         <GroupIcon>
-            <Image value="Assets\Textures\Wireframe-Zerg-zerglingex1a.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-zerglingex1a.dds"/>
         </GroupIcon>
         <HeroIcon value="Assets\Textures\btn-unit-zerg-zergling-raptor.dds"/>
         <UnitIcon value="Assets\Textures\btn-unit-zerg-zergling-raptor.dds"/>
         <Wireframe>
-            <Image value="Assets\Textures\Wireframe-Zerg-zerglingex1a.dds"/>
+            <Image index="0" value="Assets\Textures\Wireframe-Zerg-zerglingex1a.dds"/>
         </Wireframe>
     </CActorMissile>
     <CActorAction id="AP_ZerglingAttack" parent="GenericAttack" effectAttack="AP_Claws">


### PR DESCRIPTION
Set strains that inherit wireframe from parents to instead override the inherited wireframe with the correct wireframe.