### PR TITLE
SC2: fix bug with raceswap unit replacements

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/Lib15EF4C78.galaxy
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/Lib15EF4C78.galaxy
@@ -3323,7 +3323,6 @@ void lib15EF4C78_gf_ReplaceGasStructure (unit lp_gasStructure, string lp_desired
         }
         else {
         }
-        Wait(0.1, c_timeGame);
         autoEA05D24C_g = UnitGroup(null, c_playerAny, RegionCircle(UnitGetPosition(lp_gasStructure), 1.0), UnitFilter(0, 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0);
         autoEA05D24C_u = UnitGroupCount(autoEA05D24C_g, c_unitCountAll);
         for (;; autoEA05D24C_u -= 1) {


### PR DESCRIPTION
fixed an issue that causes your main building to selfdestruct in all-in raceswaps