### PR TITLE
SC2: fix Thornshell double actor in Zero Hour

### DIFF
--- a/Maps/ArchipelagoCampaign/WoL/ap_zero_hour.SC2Map/Base.SC2Data/GameData/ActorData.xml
+++ b/Maps/ArchipelagoCampaign/WoL/ap_zero_hour.SC2Map/Base.SC2Data/GameData/ActorData.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Catalog>
-    <CActorUnit id="AP_MercRoach">
-        <On Terms="UnitBirth.AP_MercRoachBurrowed" Send="Create"/>
-        <On Terms="UnitBirth.AP_MercRoachBurrowed" Send="AnimBracketStart Burrow Burrow IGNORE Unburrow ClosingFull,OpeningPlayForever"/>
-    </CActorUnit>
     <!--                                                                                         -->
     <!-- Invisible Pylon ....................................................................... -->
     <!--                                                                                         -->


### PR DESCRIPTION
duplicate create event in the map only. 