### PR TITLE
SC2: fix SoA energy in some no-built sections

### DIFF
--- a/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
@@ -9770,6 +9770,7 @@ void libABFE498B_gf_AP_Triggers_startNoBuild (int lp_player) {
         lib15EF4C78_gf_ShowSpearofAdunUI(false, c_transitionDurationImmediate);
     }
     else {
+        lib15EF4C78_gf_AP_Player_ResetSoA(lp_player);
         lib15EF4C78_gf_PauseUnpauseSpearofAdunCooldowns(lp_player, false);
         lib15EF4C78_gf_PauseUnpauseSpearofAdunAutocasts(lp_player, false);
     }


### PR DESCRIPTION
pretty sure I fixed this before, but it didn't make it into the PR. So here we go again.