### PR TITLE
Change trade tokens to be based on supply of units sent

### DIFF
--- a/Mods/ArchipelagoCore.SC2Mod/Base.SC2Data/Lib5BD4895D.galaxy
+++ b/Mods/ArchipelagoCore.SC2Mod/Base.SC2Data/Lib5BD4895D.galaxy
@@ -1900,10 +1900,15 @@ void lib5BD4895D_gt_AP_Core_tradeFail_Init () {
 // Trigger: AP_Core_tradeSendSuccess
 //--------------------------------------------------------------------------------------------------
 bool lib5BD4895D_gt_AP_Core_tradeSendSuccess_Func (bool testConds, bool runActions) {
+    // Variable Declarations
+    fixed lv_totalsupply;
+
     // Automatic Variable Declarations
     unitgroup autoE5F28EA7_g;
     int autoE5F28EA7_u;
     unit autoE5F28EA7_var;
+
+    // Variable Initialization
 
     // Actions
     if (!runActions) {
@@ -1917,9 +1922,10 @@ bool lib5BD4895D_gt_AP_Core_tradeSendSuccess_Func (bool testConds, bool runActio
         for (;; autoE5F28EA7_u -= 1) {
             autoE5F28EA7_var = UnitGroupUnitFromEnd(autoE5F28EA7_g, autoE5F28EA7_u);
             if (autoE5F28EA7_var == null) { break; }
+            lv_totalsupply = (lv_totalsupply + UnitGetPropertyFixed(autoE5F28EA7_var, c_unitPropSuppliesUsed, c_unitPropCurrent));
             UnitRemove(autoE5F28EA7_var);
-            lib5BD4895D_gf_AP_Core_Trade_changeTradeCharges(1);
         }
+        lib5BD4895D_gf_AP_Core_Trade_changeTradeCharges(FloorI(lv_totalsupply));
         UnitIssueOrder(lib5BD4895D_gv_aP_Core_tradeUnit, Order(AbilityCommand("stop", 0)), c_orderQueueReplace);
     }
 

--- a/Mods/ArchipelagoCore.SC2Mod/Triggers
+++ b/Mods/ArchipelagoCore.SC2Mod/Triggers
@@ -4697,9 +4697,20 @@
             <Preset Type="PresetValue" Library="Ntve" Id="99AB77FB"/>
         </Element>
         <Element Type="Trigger" Id="C6CCBDE1">
+            <Variable Type="Variable" Library="5BD4895D" Id="EF1D3325"/>
             <Event Type="FunctionCall" Library="5BD4895D" Id="9953BA17"/>
             <Action Type="FunctionCall" Library="5BD4895D" Id="F0BCE823"/>
             <Action Type="FunctionCall" Library="5BD4895D" Id="F476A183"/>
+        </Element>
+        <Element Type="Variable" Id="EF1D3325">
+            <VariableType>
+                <Type Value="fixed"/>
+            </VariableType>
+            <Value Type="Param" Library="5BD4895D" Id="CB06633C"/>
+        </Element>
+        <Element Type="Param" Id="CB06633C">
+            <Value>0</Value>
+            <ValueType Type="fixed"/>
         </Element>
         <Element Type="FunctionCall" Id="9953BA17">
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000121"/>
@@ -4783,6 +4794,7 @@
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000137"/>
             <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="5A1B67B3"/>
             <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="E5F28EA7"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="028DFD3E"/>
             <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="EBE3CB2C"/>
             <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="1E4A9073"/>
             <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="518823BB"/>
@@ -4810,8 +4822,8 @@
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="C4DC760C"/>
             <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
             <Parameter Type="Param" Library="5BD4895D" Id="C4E83648"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="F5FAACDF"/>
             <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="4051A039"/>
-            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="028DFD3E"/>
         </Element>
         <Element Type="Param" Id="C4E83648">
             <ParameterDef Type="ParamDef" Library="Ntve" Id="F96B466D"/>
@@ -4824,6 +4836,52 @@
         <Element Type="Param" Id="DC4765E6">
             <ParameterDef Type="ParamDef" Library="Ntve" Id="00000403"/>
             <Variable Type="Variable" Library="5BD4895D" Id="2CA48070"/>
+        </Element>
+        <Element Type="FunctionCall" Id="F5FAACDF">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000136"/>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="9441B8B5"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="91D26374"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="A0E211AD"/>
+        </Element>
+        <Element Type="Param" Id="91D26374">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="00000219"/>
+            <Variable Type="Variable" Library="5BD4895D" Id="EF1D3325"/>
+        </Element>
+        <Element Type="Param" Id="A0E211AD">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="00000220"/>
+            <ExpressionType Type="fixed"/>
+            <ExpressionText>~A~ + ~B~</ExpressionText>
+            <ExpressionParam Type="Param" Library="5BD4895D" Id="1B3A2DC0"/>
+            <ExpressionParam Type="Param" Library="5BD4895D" Id="30BBB37F"/>
+        </Element>
+        <Element Type="Param" Id="1B3A2DC0">
+            <Variable Type="Variable" Library="5BD4895D" Id="EF1D3325"/>
+            <ExpressionCode Value="A"/>
+        </Element>
+        <Element Type="Param" Id="30BBB37F">
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="2900478E"/>
+            <ExpressionCode Value="B"/>
+        </Element>
+        <Element Type="FunctionCall" Id="2900478E">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="C65CC121"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="17BA1E3A"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="9FF1AAC2"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="DA2E20A4"/>
+        </Element>
+        <Element Type="Param" Id="17BA1E3A">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="9ADE2B3B"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="8DE8E045"/>
+        </Element>
+        <Element Type="FunctionCall" Id="8DE8E045">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="19CE733E"/>
+        </Element>
+        <Element Type="Param" Id="9FF1AAC2">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="D1035B0C"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000037"/>
+        </Element>
+        <Element Type="Param" Id="DA2E20A4">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="D006774F"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="E66C6645"/>
         </Element>
         <Element Type="FunctionCall" Id="4051A039">
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000078"/>
@@ -4839,13 +4897,20 @@
         </Element>
         <Element Type="FunctionCall" Id="028DFD3E">
             <FunctionDef Type="FunctionDef" Library="5BD4895D" Id="5D1083F2"/>
-            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="9441B8B5"/>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
             <Parameter Type="Param" Library="5BD4895D" Id="E289FA2B"/>
         </Element>
         <Element Type="Param" Id="E289FA2B">
             <ParameterDef Type="ParamDef" Library="5BD4895D" Id="47FB32D4"/>
-            <Value>1</Value>
-            <ValueType Type="int"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="0FBBDEDF"/>
+        </Element>
+        <Element Type="FunctionCall" Id="0FBBDEDF">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="C156C116"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="84CB3D02"/>
+        </Element>
+        <Element Type="Param" Id="84CB3D02">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="9608D93C"/>
+            <Variable Type="Variable" Library="5BD4895D" Id="EF1D3325"/>
         </Element>
         <Element Type="FunctionCall" Id="EBE3CB2C">
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000089"/>

--- a/Mods/ArchipelagoCore.SC2Mod/enUS.SC2Data/LocalizedData/TriggerStrings.txt
+++ b/Mods/ArchipelagoCore.SC2Mod/enUS.SC2Data/LocalizedData/TriggerStrings.txt
@@ -419,6 +419,7 @@ Variable/Name/lib_5BD4895D_ECA6224E=vespeneCost
 Variable/Name/lib_5BD4895D_ECEA655E=counter suffix
 Variable/Name/lib_5BD4895D_ED587702=counter suffix
 Variable/Name/lib_5BD4895D_EDE1A068=AP_Core_chatboxAnchor
+Variable/Name/lib_5BD4895D_EF1D3325=total supply
 Variable/Name/lib_5BD4895D_F0760C49=count label
 Variable/Name/lib_5BD4895D_F1352445=objective index
 Variable/Name/lib_5BD4895D_F1EC09D9=Timer Objectives

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -3664,7 +3664,7 @@ Button/Tooltip/AP_TissueAssimilation=Gains life equal to 40% of all damage dealt
 Button/Tooltip/AP_TornadoMissile=When attacking a mechanical unit, the Warhound launches electrically charged missiles at its target, dealing 30 damage per volley.<n/><c val="#ColorAttackInfo">Can attack ground units.</c>
 Button/Tooltip/AP_TorrasqueChrysalis=Allows the Ultralisk to revive upon death.<n/>Cooldown: <d ref="Behavior,AP_MercTorrasqueTimerBehavior,Duration"/> seconds.
 Button/Tooltip/AP_TorrasqueChrysalisFakeTimer=The Ultralisk cannot revive at this time.
-Button/Tooltip/AP_TradeCharge=You can receive this many units via Void Trade. You get 1 Token for every unit you send. Your Tokens are only valid for this mission.
+Button/Tooltip/AP_TradeCharge=You can receive this many units via Void Trade. You get 1 Token for every point of supply you send, rounded down. Your Tokens are only valid for this mission.
 Button/Tooltip/AP_TradeStructure=Can send friendly units to the void and receive random units from the void.
 Button/Tooltip/AP_TradeStructureDummyReceive=Asks the void for a random unit in exchange for a small tribute.<n/><n/>You can only receive units if other players have already deposited units into the void.
 Button/Tooltip/AP_TradeStructureDummyReceive5=Asks the void for 5 random units in exchange for a medium tribute.<n/><n/>You can only receive units if other players have already deposited units into the void.


### PR DESCRIPTION
This changes Void Trade to award 1 Token per 1 supply of units sent (rounded down) instead of 1 Token per 1 unit sent. The description on the Token button on the trade structure is updated to match this behavior.

The aim of this change is addressing feedback that it is too optimal to send cheap units to gain Tokens.

There are a number of opinions on where the balance for Trade should land, but currently there is a legacy problem that is apparently encouraging unfun gameplay. The original (and in a way intended) cost to receive units was just the resource cost (50 minerals, 10 gas per unit), but the introduction of Tokens has significantly increased the cost by also requiring the resources of a unit.

In the abuse case of sending away your starting army & workers, the Token cost becomes zero, so there is still a purpose to having *some* extra resource cost. However, for legitimate use cases the minimum cost per received unit is currently 100/10 instead of 50/10, by building & sending your cheapest available unit, which will generally be workers. It is strictly a bad use of your own resources to send better units, so it becomes a social challenge to convince others to make trading fun.

Some amount of social friction is expected (and has been expressed as desired by some), but I believe this change eases the friction in a healthy direction by lessening the drawback of sending stronger, more expensive units. Higher-tier units usually cost more than 50 minerals per supply as well as some amount of gas, so it is still the optimal play to send workers, but the reduced loss per Token should make it feel less bad to casually send actual units.

For example:
- A Marauder costs 100/25/2. Currently this is a 50/25 loss per Token compared to 50/0/1 workers, with this change it becomes a 0/25 loss.
- A Battlecruiser costs 400/300/6. Currently this is a 350/300 loss per Token, becoming a 100/300 loss.

---

I tested this PR by generating a game with 2 Void Trade players, using a debug print to see the counted supply of units in the trade building, and then actually sending and receiving units between slots to check the math is implemented correctly.

Specifically, the units I used were Zerglings, Zerglings with Swarmling strain, Roaches, Scouts, and Scouts with 2x Resource Efficiency.
- A single Zergling counts for 0 Tokens (0.5 supply rounded down), but 2 Zerglings count for 1 Token.
- Swarmlings still counted as 0.5 supply each. I thought they would become 0.33 supply each but apparently this isn't the case, I assume this isn't a bug but am mentioning it just in case.
- Roaches count as 2 supply & Tokens as expected. 
- Scouts count as 3 supply & Tokens, as expected.
- After getting 2x Resource Efficiency, Scouts counted for 2 supply & Tokens, including already built ones. Technically this makes the supply-reducing REs a situational one-time nerf to the units' value in trading, but I think this edge case isn't worth working around.
