### PR TITLE
Allow transports to load colossi under Void Trade transport patch

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -5570,9 +5570,28 @@
         <Find value="0"/>
     </CValidatorUnitType>
     <!-- For use in patching transports -->
-    <CValidatorUnitFilters id="AP_IsNotAirUnit">
+    <CValidatorCombine id="AP_IsNotAirUnit">
+        <ResultFailed value="CantLoadThatUnit"/>
+        <Type value="Or"/>
+        <CombineArray value="AP_IsNotAirPlaneUnit"/>
+        <!-- This covers vanilla colossi as well as AP regular + purifier colossi via select alias -->
+        <CombineArray value="IsColossus"/>
+        <CombineArray value="AP_IsAPColossusTaldarim"/>
+        <CombineArray value="AP_IsVanillaColossusTaldarim"/>
+        <CombineArray value="AP_IsVanillaColossusPurifier"/>
+    </CValidatorCombine>
+    <CValidatorUnitFilters id="AP_IsNotAirPlaneUnit">
         <Filters value="-;Air,AirUnit"/>
     </CValidatorUnitFilters>
+    <CValidatorUnitType id="AP_IsAPColossusTaldarim">
+        <Value value="AP_ColossusTaldarim"/>
+    </CValidatorUnitType>
+    <CValidatorUnitType id="AP_IsVanillaColossusTaldarim">
+        <Value value="ColossusTaldarim"/>
+    </CValidatorUnitType>
+    <CValidatorUnitType id="AP_IsVanillaColossusPurifier">
+        <Value value="ColossusPurifier"/>
+    </CValidatorUnitType>
     <CValidatorUnitType id="AP_IsAPPredatorNest">
         <Value value="AP_ZergMercenaryCompound"/>
     </CValidatorUnitType>


### PR DESCRIPTION
This fixes regular transports not being able to load Colossi due to them being Air plane units.

Tested on a LotV and WoL map with `AP_WarpPrism` and `AP_Medivac` loading the following:
- `AP_Colossus`
- `AP_ColossusTaldarim`
- `AP_ColossusPurifier`
- `Colossus`
- `ColossusTaldarim`
- `ColossusPurifier`
  - The above two don't exist in the WoL map and thus didn't spawn there, as expected
- `AP_VoidRayAiur`, standing in for a generic air unit
- `AP_Drone`, standing in for a generic ground unit

The 6 Colossus variants and the Drone loaded into both transports on both maps, the Void Ray loaded into neither transport on both maps.