### PR TITLE
Move trade cost to unit to fix trade not costing resources

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -236,14 +236,10 @@
             <Unit value="AP_TradeStructureSendDummy"/>
         </InfoArray>
         <InfoArray index="Train2" Time="600">
-            <Resource index="Minerals" value="50"/>
-            <Resource index="Vespene" value="10"/>
             <Button DefaultButtonFace="AP_TradeStructureDummyReceive" State="Restricted" Requirements="AP_NotTradeStructureBusyAndCanReceive1"/>
             <Unit value="AP_TradeStructureReceiveDummy"/>
         </InfoArray>
         <InfoArray index="Train3" Time="600">
-            <Resource index="Minerals" value="250"/>
-            <Resource index="Vespene" value="50"/>
             <Button DefaultButtonFace="AP_TradeStructureDummyReceive5" State="Restricted" Requirements="AP_NotTradeStructureBusyAndCanReceive5"/>
             <Unit value="AP_TradeStructureReceive5Dummy"/>
         </InfoArray>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -10045,6 +10045,8 @@
         <Collide index="Locust" value="1"/>
         <Collide index="Small" value="1"/>
         <Food value="-2"/>
+        <CostResource index="Minerals" value="50"/>
+        <CostResource index="Vespene" value="10"/>
         <Radius value="1"/>
         <InnerRadius value="0.75"/>
         <EditorCategories value="ObjectType:Other,ObjectFamily:Melee"/>
@@ -10061,6 +10063,8 @@
         <Collide index="Locust" value="1"/>
         <Collide index="Small" value="1"/>
         <Food value="-10"/>
+        <CostResource index="Minerals" value="250"/>
+        <CostResource index="Vespene" value="50"/>
         <Radius value="1"/>
         <InnerRadius value="0.75"/>
         <EditorCategories value="ObjectType:Other,ObjectFamily:Melee"/>


### PR DESCRIPTION
This fixes trade "refunding" the resource cost of the trade by moving the cost from the training ability to the dummy units.

Trade triggers calculate the actual cost of the trade as `(number of units received) * (cost of the dummy unit)`, so this was always supposed to be the case.

I tested this by stopping all resource gathering and pressing the two receive buttons to see the exact resource changes.