### PR TITLE
Misc fixes

### DIFF
--- a/Maps/ArchipelagoCampaign/LotV/ap_amon_s_fall.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/LotV/ap_amon_s_fall.SC2Map/MapScript.galaxy
@@ -2260,8 +2260,10 @@ bool gt_StartGameQ_Func (bool testConds, bool runActions) {
     TriggerExecute(gt_QuantumRayCheck, true, false);
     UIAlertPoint("Trigger", gv_pLAYER_01_USER, StringExternal("Param/Value/ADA11C5C"), null, PointFromId(1));
     libLbty_gf_OrderWorkerstoGatherNearbyResources(RegionPlayableMap(), gv_pLAYER_01_USER);
+    lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_pLAYER_01_USER);
     VisRevealArea(gv_pLAYER_01_USER, RegionFromId(2), 0.0, false);
     Wait(3.0, c_timeReal);
+    lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_pLAYER_01_USER);
     TriggerQueueEnter();
     TriggerExecute(gt_ObjectiveDestroyCrystalsCreate, true, true);
     gv_pingsAllowed = true;

--- a/Maps/ArchipelagoCampaign/LotV/ap_amon_s_fall.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/LotV/ap_amon_s_fall.SC2Map/Triggers
@@ -5270,8 +5270,11 @@
         <Action Type="FunctionCall" Id="372EE94B"/>
         <Action Type="FunctionCall" Id="0BADCE85"/>
         <Action Type="FunctionCall" Id="CD5A71E4"/>
+        <Action Type="FunctionCall" Id="9A480251"/>
         <Action Type="FunctionCall" Id="0AEB9825"/>
         <Action Type="FunctionCall" Id="E95BD983"/>
+        <Action Type="Comment" Id="2773DA81"/>
+        <Action Type="FunctionCall" Id="C07FF407"/>
         <Action Type="FunctionCall" Id="BE26BFA5"/>
         <Action Type="FunctionCall" Id="7B8A39A0"/>
         <Action Type="FunctionCall" Id="D4F0C27F"/>
@@ -5505,6 +5508,14 @@
         <ParameterDef Type="ParamDef" Library="Lbty" Id="3F42FBCD"/>
         <Variable Type="Variable" Id="34A58E06"/>
     </Element>
+    <Element Type="FunctionCall" Id="9A480251">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="84565F53"/>
+        <Parameter Type="Param" Id="3E91B606"/>
+    </Element>
+    <Element Type="Param" Id="3E91B606">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="CF70F2A6"/>
+        <Variable Type="Variable" Id="34A58E06"/>
+    </Element>
     <Element Type="FunctionCall" Id="0AEB9825">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="685AF92D"/>
         <Parameter Type="Param" Id="1DA6A9D3"/>
@@ -5543,6 +5554,19 @@
     <Element Type="Param" Id="9FDB7639">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="00000420"/>
         <Preset Type="PresetValue" Library="Ntve" Id="00000012"/>
+    </Element>
+    <Element Type="Comment" Id="2773DA81">
+        <Comment>
+            2nd pass after ally transfer control finished
+        </Comment>
+    </Element>
+    <Element Type="FunctionCall" Id="C07FF407">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="84565F53"/>
+        <Parameter Type="Param" Id="32A78A1D"/>
+    </Element>
+    <Element Type="Param" Id="32A78A1D">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="CF70F2A6"/>
+        <Variable Type="Variable" Id="34A58E06"/>
     </Element>
     <Element Type="FunctionCall" Id="BE26BFA5">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="74DFFAD8"/>

--- a/Maps/ArchipelagoCampaign/LotV/ap_into_the_void.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/LotV/ap_into_the_void.SC2Map/MapScript.galaxy
@@ -1913,6 +1913,7 @@ bool gt_TransferZergControlToPlayer_Func (bool testConds, bool runActions) {
         libNtve_gf_RescueUnit(lv_unit, gv_pLAYER_01_USER, true);
         lib15EF4C78_gf_AP_Player_ReapplyDefaultBehaviorsToUnit(lv_unit);
     }
+    lib15EF4C78_gf_StartingWorkersAutoHarvest(gv_pLAYER_01_USER, RegionEntireMap(), null);
     PlayerModifyPropertyInt(gv_pLAYER_01_USER, c_playerPropSuppliesLimit, c_playerPropOperAdd, 200);
     UnitGroupAddUnitGroup(lv_unitGroup, UnitGroup("AP_Hive", gv_pLAYER_01_USER, RegionEntireMap(), UnitFilter(0, 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0));
     UnitGroupAddUnitGroup(lv_unitGroup, UnitGroup("AP_Lair", gv_pLAYER_01_USER, RegionEntireMap(), UnitFilter(0, 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0));
@@ -3413,6 +3414,7 @@ bool gt_StartGameStage2Q_Func (bool testConds, bool runActions) {
     }
 
     UIAlertPoint("Trigger", gv_pLAYER_01_USER, StringExternal("Param/Value/ADA11C5C"), null, PointFromId(443));
+    lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_pLAYER_01_USER);
     libVCMI_gf_StartingWorkersAutoHarvest(RegionFromId(7), RegionFromId(8));
     TriggerExecute(gt_UpdateKerriganDefendRegion, true, false);
     TriggerExecute(gt_KerriganSpellAI, true, false);

--- a/Maps/ArchipelagoCampaign/LotV/ap_into_the_void.SC2Map/Objects
+++ b/Maps/ArchipelagoCampaign/LotV/ap_into_the_void.SC2Map/Objects
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8" standalone="no"?><PlacedObjects Version="27">
-    <ObjectDoodad Id="2000" Position="158.06,151.1267,7.9973" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+<?xml version="1.0" encoding="utf-8"?>
+<PlacedObjects Version="27">
+    <ObjectDoodad Id="2000" Variation="4" Position="158.06,151.1267,7.9973" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -10,15 +11,15 @@
     <ObjectDoodad Id="1979" Position="164.1413,136.623,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1114" Position="74.3286,68.3908,10.0095" Rotation="4.3234" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1114" Variation="4" Position="74.3286,68.3908,10.0095" Rotation="4.3234" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1055" Position="15.581,15.1127,8.444" Rotation="2.692" Scale="1.0566,1.0566,1.0566" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1055" Variation="4" Position="15.581,15.1127,8.444" Rotation="2.692" Scale="1.0566,1.0566,1.0566" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2046" Position="105.2602,249.2875,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="2046" Variation="2" Position="105.2602,249.2875,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1941" Position="97.4643,235.9997,11.9853" Rotation="4.838" Scale="1,1,1" Type="Void_Temple">
@@ -26,12 +27,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="964" Position="97.9448,111.2326,11.9873" Rotation="0.9453" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2178" Variation="3" Position="169.09,47.7294,11.6677" Rotation="6.2194" Scale="1.1572,1.1572,1.1572" Type="IceWorldAmbientCrystals">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2178" Position="169.09,47.7294,11.6677" Rotation="6.2194" Scale="1.1572,1.1572,1.1572" Type="IceWorldAmbientCrystals" Variation="3">
+    <ObjectDoodad Id="964" Variation="1" Position="97.9448,111.2326,11.9873" Rotation="0.9453" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -40,7 +41,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1954" Position="131.7863,186.4362,11.9853" Rotation="4.814" Scale="1.064,1.064,1.064" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1954" Variation="2" Position="131.7863,186.4362,11.9853" Rotation="4.814" Scale="1.064,1.064,1.064" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -59,19 +60,19 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1030" Position="79.0212,10.8635,9.9873" Rotation="0.8464" Scale="0.45,0.45,0.45" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="1030" Variation="1" Position="79.0212,10.8635,9.9873" Rotation="0.8464" Scale="0.45,0.45,0.45" Type="TheVoid_GroundScar">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1094" Position="14.446,15.57,8.3273" Rotation="1.8535" Scale="0.5,0.5,0.5" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1094" Variation="4" Position="14.446,15.57,8.3273" Rotation="1.8535" Scale="0.5,0.5,0.5" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1959" Position="130.5026,199.618,11.9853" Scale="0.9375,0.9375,0.9375" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1959" Variation="2" Position="130.5026,199.618,11.9853" Scale="0.9375,0.9375,0.9375" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2183" Position="180.3002,52.078,11.8403" Scale="1,1,1" Type="Void_Crystals" Variation="1">
+    <ObjectDoodad Id="2183" Variation="1" Position="180.3002,52.078,11.8403" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -79,11 +80,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1929" Position="43.5876,163.149,11.9865" Rotation="3.456" Scale="1,1,1" Type="Blast_Craters" Variation="3">
+    <ObjectDoodad Id="1929" Variation="3" Position="43.5876,163.149,11.9865" Rotation="3.456" Scale="1,1,1" Type="Blast_Craters">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2018" Position="140.4187,196.302,9.9831" Scale="0.9375,0.9375,0.9375" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="2018" Variation="2" Position="140.4187,196.302,9.9831" Scale="0.9375,0.9375,0.9375" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -92,16 +93,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1027" Position="146,137.5,7.873" Rotation="5.2077" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1027" Variation="1" Position="146,137.5,7.873" Rotation="5.2077" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1982" Position="163.2441,123.0437,9.9897" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1982" Variation="4" Position="163.2441,123.0437,9.9897" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2005" Position="151.3271,167.6613,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="2005" Variation="2" Position="151.3271,167.6613,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -110,7 +111,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1050" Position="76,136.5,9.9868" Rotation="0.0244" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1050" Variation="1" Position="76,136.5,9.9868" Rotation="0.0244" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -120,63 +121,63 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2224" Position="94.3598,183.3098,9.081" Rotation="0.8488" Scale="1,1,1" Type="TheVoid_FloatingRocks" Variation="2">
+    <ObjectDoodad Id="2224" Variation="2" Position="94.3598,183.3098,9.081" Rotation="0.8488" Scale="1,1,1" Type="TheVoid_FloatingRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2043" Position="102.1606,239.16,11.9863" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="2043" Variation="2" Position="102.1606,239.16,11.9863" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1965" Position="128.876,187.0795,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="1965" Variation="1" Position="128.876,187.0795,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2189" Pitch="0.7265" Position="172.3056,45.3315,12.5952" Roll="5.5454" Scale="1,1,1" Type="GasCrystalDoodad">
+    <ObjectDoodad Id="2189" Position="172.3056,45.3315,12.5952" Scale="1,1,1" Type="GasCrystalDoodad" Pitch="0.7265" Roll="5.5454">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1990" Position="111.48,225.5798,9.9897" Rotation="2.1533" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1990" Variation="4" Position="111.48,225.5798,9.9897" Rotation="2.1533" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1923" Position="94.955,221.0964,11.9853" Scale="0.75,0.75,0.75" Type="XelNaga_GroundPlates_TheVoid" Variation="9">
+    <ObjectDoodad Id="1923" Variation="9" Position="94.955,221.0964,11.9853" Scale="0.75,0.75,0.75" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2024" Position="38.3395,175.2658,11.985" Scale="1.0644,1.0644,1.0644" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2024" Variation="3" Position="38.3395,175.2658,11.985" Scale="1.0644,1.0644,1.0644" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="997" Position="106.9562,148.9023,11.9855" Rotation="0.951" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
-        <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2211" Position="90.8063,198.349,-21.8232" Rotation="5.9033" Scale="4,4,4" Type="Void_Nebula_Storm">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="997" Variation="4" Position="106.9562,148.9023,11.9855" Rotation="0.951" Scale="1,1,1" Type="Void_XelNaga_Structure">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="1109" Position="30.6777,60.0251,8.3142" Rotation="0.865" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1972" Position="68.7502,226.8666,-0.015" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="1972" Variation="1" Position="68.7502,226.8666,-0.015" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2015" Position="171.9177,137.6418,7.985" Scale="1.0502,1.0502,1.0502" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2196" Position="171.3193,42.522,10.2297" Rotation="1.8337" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="978" Position="69.6062,74.1047,11.987" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="978" Variation="1" Position="69.6062,74.1047,11.987" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1946" Pitch="6.1086" Position="118.8698,228.7697,9.8896" Rotation="0.4338" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="2196" Variation="1" Position="171.3193,42.522,10.2297" Rotation="1.8337" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1946" Position="118.8698,228.7697,9.8896" Rotation="0.4338" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="6.1086">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -185,10 +186,10 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1040" Position="70.7114,186.1003,9.986" Rotation="3.9912" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="17">
+    <ObjectDoodad Id="1040" Variation="17" Position="70.7114,186.1003,9.986" Rotation="3.9912" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1104" Position="21.3515,54.3747,9.9257" Rotation="0.2832" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1104" Variation="1" Position="21.3515,54.3747,9.9257" Rotation="0.2832" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -197,22 +198,22 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="983" Position="70.7216,122.0561,7.9902" Rotation="4.964" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="4">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2193" Position="164.658,47.6733,9.898" Rotation="1.108" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1969" Position="43.065,212.0231,10.3474" Rotation="3.9472" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="983" Variation="4" Position="70.7216,122.0561,7.9902" Rotation="4.964" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2036" Position="94.64,198.65,11.9907" Rotation="3.7255" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1969" Variation="4" Position="43.065,212.0231,10.3474" Rotation="3.9472" Scale="1,1,1" Type="Void_XelNaga_Structure">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2036" Variation="4" Position="94.64,198.65,11.9907" Rotation="3.7255" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -221,15 +222,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1045" Position="73.2768,48.0908,9.9826" Rotation="1.8308" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1045" Variation="4" Position="73.2768,48.0908,9.9826" Rotation="1.8308" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2184" Position="175.5456,62.0871,11.9824" Scale="1,1,1" Type="Void_Crystals" Variation="4">
+    <ObjectDoodad Id="2184" Variation="4" Position="175.5456,62.0871,11.9824" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1987" Position="110.67,216.0698,9.981" Rotation="1.999" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1987" Variation="4" Position="110.67,216.0698,9.981" Rotation="1.999" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1960" Position="133.0241,161.1787,11.9855" Rotation="1.5622" Scale="1.0256,1.0256,1.0256" Type="Void_SmallRocks">
@@ -237,17 +238,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1036" Position="136.9497,102.1962,8.0095" Rotation="2.1533" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1036" Variation="3" Position="136.9497,102.1962,8.0095" Rotation="2.1533" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2029" Position="43.5886,183.959,11.9978" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="992" Position="93.1052,155.95,9.984" Rotation="3.629" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2029" Variation="2" Position="43.5886,183.959,11.9978" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -256,16 +252,21 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1926" Position="80.1916,228.164,11.9853" Rotation="2.0375" Scale="1,1,1" Type="Blast_Craters" Variation="3">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1053" Position="18.5144,44.01,2.188" Rotation="1.5197" Scale="1,1,1" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="992" Variation="1" Position="93.1052,155.95,9.984" Rotation="3.629" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1943" Position="120.234,182.9653,11.9853" Rotation="1.7392" Scale="1.064,1.064,1.064" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1926" Variation="3" Position="80.1916,228.164,11.9853" Rotation="2.0375" Scale="1,1,1" Type="Blast_Craters">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1053" Variation="1" Position="18.5144,44.01,2.188" Rotation="1.5197" Scale="1,1,1" Type="Void_Cliff_Rocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1943" Variation="2" Position="120.234,182.9653,11.9853" Rotation="1.7392" Scale="1.064,1.064,1.064" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -277,19 +278,19 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="991" Position="57,155.5,10.036" Rotation="0.1684" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2201" Variation="2" Position="178.5185,51,11.9677" Rotation="0.2875" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2201" Position="178.5185,51,11.9677" Rotation="0.2875" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="2">
+    <ObjectDoodad Id="991" Variation="1" Position="57,155.5,10.036" Rotation="0.1684" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2002" Position="155.0932,160.6806,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="2002" Variation="2" Position="155.0932,160.6806,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1112" Position="26.1413,54.8742,8.0007" Rotation="4.3237" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1112" Variation="4" Position="26.1413,54.8742,8.0007" Rotation="4.3237" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -298,33 +299,33 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1000" Position="98.696,152.541,12.009" Rotation="4.3825" Scale="0.9,0.9,0.9" Type="Void_XelNaga_Structure">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2222" Position="89.3398,194.9125,10.8837" Rotation="3.9904" Scale="1.5,1.5,1.5" Type="TheVoid_FloatingRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2021" Position="138.7636,219.8176,9.9953" Rotation="4.9672" Scale="0.9382,0.9382,0.9382" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1000" Position="98.696,152.541,12.009" Rotation="4.3825" Scale="0.9,0.9,0.9" Type="Void_XelNaga_Structure">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2021" Variation="2" Position="138.7636,219.8176,9.9953" Rotation="4.9672" Scale="0.9382,0.9382,0.9382" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1028" Position="156.22,115.2597,9.9897" Rotation="2.1533" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1028" Variation="3" Position="156.22,115.2597,9.9897" Rotation="2.1533" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1952" Position="114.2934,204.0073,9.6853" Rotation="3.4216" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="1952" Variation="2" Position="114.2934,204.0073,9.6853" Rotation="3.4216" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1995" Position="134.5634,165.3051,11.985" Scale="0.9714,0.9714,0.9714" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1995" Variation="3" Position="134.5634,165.3051,11.985" Scale="0.9714,0.9714,0.9714" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2176" Position="174.7641,56.1994,12.1965" Rotation="1.7365" Scale="0.8303,0.8303,0.8303" Type="IceWorldAmbientCrystals" Variation="3">
+    <ObjectDoodad Id="2176" Variation="3" Position="174.7641,56.1994,12.1965" Rotation="1.7365" Scale="0.8303,0.8303,0.8303" Type="IceWorldAmbientCrystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -333,18 +334,18 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2016" Position="173.0134,133.9663,11.985" Scale="1.0485,1.0485,1.0485" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2016" Variation="1" Position="173.0134,133.9663,11.985" Scale="1.0485,1.0485,1.0485" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1931" Position="124.7707,183.4731,11.7854" Rotation="1.9758" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="1931" Variation="1" Position="124.7707,183.4731,11.7854" Rotation="1.9758" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1092" Position="32.9614,18.3891,8.2294" Rotation="0.564" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="3">
+    <ObjectDoodad Id="1092" Variation="3" Position="32.9614,18.3891,8.2294" Rotation="0.564" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1998" Pitch="5.934" Position="152.66,166.7,9.8745" Rotation="5.458" Scale="1,1,1" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1998" Variation="2" Position="152.66,166.7,9.8745" Rotation="5.458" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="5.934">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -353,18 +354,18 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1957" Position="121.1318,181.2805,11.9863" Scale="1.0395,1.0395,1.0395" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1957" Variation="3" Position="121.1318,181.2805,11.9863" Scale="1.0395,1.0395,1.0395" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1048" Position="83.4511,43.3334,9.9941" Rotation="3.5524" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1048" Variation="2" Position="83.4511,43.3334,9.9941" Rotation="3.5524" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2041" Position="69.4863,243.5942,11.985" Rotation="1.4416" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="2041" Variation="1" Position="69.4863,243.5942,11.985" Rotation="1.4416" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1938" Position="101.8566,220.4357,11.872" Rotation="5.784" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1938" Variation="2" Position="101.8566,220.4357,11.872" Rotation="5.784" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -374,10 +375,13 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2007" Position="159.381,190.1984,9.9855" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="2007" Variation="2" Position="159.381,190.1984,9.9855" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1980" Position="164.7324,127.4702,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="1980" Variation="1" Position="164.7324,127.4702,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="999" Position="128.6687,179.37,9.9853" Rotation="0.7578" Scale="1.0388,1.0388,1.0388" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2209" Position="72.893,135.7448,-19.5205" Rotation="5.9033" Scale="3,3,3" Type="Void_Nebula_Storm">
@@ -385,24 +389,21 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="999" Position="128.6687,179.37,9.9853" Rotation="0.7578" Scale="1.0388,1.0388,1.0388" Type="TheVoid_RubblePile">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2026" Position="41.6926,168.2954,11.9855" Scale="1.0971,1.0971,1.0971" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="2026" Variation="2" Position="41.6926,168.2954,11.9855" Scale="1.0971,1.0971,1.0971" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1921" Position="76.011,224.5178,11.8916" Rotation="0.8427" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1921" Variation="2" Position="76.011,224.5178,11.8916" Rotation="0.8427" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1988" Position="110.63,222.67,9.9897" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1988" Variation="4" Position="110.63,222.67,9.9897" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2191" Pitch="5.4975" Position="168.0698,47.0798,11.9677" Rotation="2.0761" Scale="1,1,1" Type="GasCrystalDoodad">
+    <ObjectDoodad Id="2191" Position="168.0698,47.0798,11.9677" Rotation="2.0761" Scale="1,1,1" Type="GasCrystalDoodad" Pitch="5.4975">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -411,15 +412,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2035" Position="83.6193,198.0776,11.986" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="2035" Variation="2" Position="83.6193,198.0776,11.986" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1944" Position="121.6618,180.3481,11.9863" Rotation="1.7392" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1944" Variation="1" Position="121.6618,180.3481,11.9863" Rotation="1.7392" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1042" Position="104.1076,150.1723,11.9721" Rotation="5.4868" Scale="0.9,0.9,0.9" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="1042" Variation="2" Position="104.1076,150.1723,11.9721" Rotation="5.4868" Scale="0.9,0.9,0.9" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -427,50 +428,46 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="976" Position="80.1513,63.139,7.987" Rotation="4.1635" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2198" Variation="3" Position="179.3654,49.8105,11.993" Rotation="1.514" Scale="1.1904,1.1904,1.1904" Type="Void_GoldPiles">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="976" Variation="1" Position="80.1513,63.139,7.987" Rotation="4.1635" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2198" Position="179.3654,49.8105,11.993" Rotation="1.514" Scale="1.1904,1.1904,1.1904" Type="Void_GoldPiles" Variation="3">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2013" Position="147.5698,198.18,9.991" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2013" Variation="4" Position="147.5698,198.18,9.991" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1974" Position="46.0498,223.15,9.98" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1974" Variation="4" Position="46.0498,223.15,9.98" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1949" Position="83.5661,194.868,11.9863" Rotation="3.5085" Scale="1.046,1.046,1.046" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1949" Variation="2" Position="83.5661,194.868,11.9863" Rotation="3.5085" Scale="1.046,1.046,1.046" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2038" Position="71.5041,239.6071,11.9716" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="2038" Variation="2" Position="71.5041,239.6071,11.9716" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2237" Position="155.038,61.9943,7.9892" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="4">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1047" Position="79.5397,43.7053,7.9875" Rotation="5.5788" Scale="1,1,1" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="2237" Variation="4" Position="155.038,61.9943,7.9892" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1106" Pitch="5.8466" Position="21.95,60.72,12.1791" Rotation="0.358" Scale="1.1496,1.1496,1.1496" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1047" Variation="2" Position="79.5397,43.7053,7.9875" Rotation="5.5788" Scale="1,1,1" Type="TheVoid_RubblePile">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1106" Position="21.95,60.72,12.1791" Rotation="0.358" Scale="1.1496,1.1496,1.1496" Type="Void_Cliff_Rocks" Pitch="5.8466">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1971" Position="178.7546,52.6416,11.9677" Rotation="6.0075" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2195" Position="174.057,44.054,10.1176" Rotation="2.6787" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="1">
+    <ObjectDoodad Id="1971" Variation="1" Position="178.7546,52.6416,11.9677" Rotation="6.0075" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -479,14 +476,18 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2008" Position="159.238,184.998,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1038" Position="143.5,95.5,11.9865" Rotation="0.9616" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="2195" Variation="1" Position="174.057,44.054,10.1176" Rotation="2.6787" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1924" Position="95.0817,217.2341,11.9853" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="9">
+    <ObjectDoodad Id="2008" Position="159.238,184.998,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1038" Variation="4" Position="143.5,95.5,11.9865" Rotation="0.9616" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1924" Variation="9" Position="95.0817,217.2341,11.9853" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -495,29 +496,29 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2031" Position="98.6198,187.396,9.9863" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2031" Variation="4" Position="98.6198,187.396,9.9863" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1962" Position="125.8796,184.5895,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="1962" Variation="2" Position="125.8796,184.5895,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1985" Position="148.4765,106.1003,9.9897" Rotation="5.273" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1985" Variation="4" Position="148.4765,106.1003,9.9897" Rotation="5.273" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2186" Position="177.7233,42.5766,9.9748" Scale="1,1,1" Type="Void_Crystals" Variation="4">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1056" Position="16.5446,21.7946,8.186" Rotation="5.4477" Scale="0.976,0.976,0.976" Type="Void_CrackSplat" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1904" Position="93.5817,222.298,11.9853" Rotation="5.8381" Scale="1.0632,1.0632,1.0632" Type="Void_CrackSplat" Variation="1">
+    <ObjectDoodad Id="2186" Variation="4" Position="177.7233,42.5766,9.9748" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1819" Position="76,115,11.997" Rotation="3.1784" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1056" Variation="2" Position="16.5446,21.7946,8.186" Rotation="5.4477" Scale="0.976,0.976,0.976" Type="Void_CrackSplat">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1904" Variation="1" Position="93.5817,222.298,11.9853" Rotation="5.8381" Scale="1.0632,1.0632,1.0632" Type="Void_CrackSplat">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1819" Variation="1" Position="76,115,11.997" Rotation="3.1784" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -529,75 +530,75 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1845" Position="82.5,153.5,11.9765" Rotation="3.6291" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1845" Variation="1" Position="82.5,153.5,11.9765" Rotation="3.6291" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2174" Position="172.6638,47.0344,10.3674" Rotation="1.4704" Scale="1.0412,1.0412,1.0412" Type="IceWorldAmbientCrystals" Variation="1">
+    <ObjectDoodad Id="2174" Variation="1" Position="172.6638,47.0344,10.3674" Rotation="1.4704" Scale="1.0412,1.0412,1.0412" Type="IceWorldAmbientCrystals">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1236" Position="166.7155,120.9355,9.9875" Rotation="2.9548" Scale="1.0722,1.0722,1.0722" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1236" Variation="2" Position="166.7155,120.9355,9.9875" Rotation="2.9548" Scale="1.0722,1.0722,1.0722" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1897" Pitch="0.039" Position="71.0798,197.18,11.0493" Roll="0.3315" Rotation="4.029" Scale="1.5,1.5,2" Type="XelNaga_GroundPlates_TheVoid" Variation="5">
+    <ObjectDoodad Id="1897" Variation="5" Position="71.0798,197.18,11.0493" Rotation="4.029" Scale="1.5,1.5,2" Type="XelNaga_GroundPlates_TheVoid" Pitch="0.039" Roll="0.3315">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2082" Position="73.6926,191.8056,9.986" Rotation="5.4091" Scale="1.1516,1.1516,1.1516" Type="LightOmniRed">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1794" Position="109,73,11.987" Rotation="1.375" Scale="0.9328,0.9328,0.9328" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1794" Variation="3" Position="109,73,11.987" Rotation="1.375" Scale="0.9328,0.9328,0.9328" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2060" Position="55.4516,194.4692,9.9873" Rotation="3.9455" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2060" Variation="3" Position="55.4516,194.4692,9.9873" Rotation="3.9455" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1863" Position="88,176.5,11.9843" Rotation="2.9294" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1863" Variation="1" Position="88,176.5,11.9843" Rotation="2.9294" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1836" Position="75.4572,116.9443,11.9863" Scale="0.9296,0.9296,0.9296" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1836" Variation="1" Position="75.4572,116.9443,11.9863" Scale="0.9296,0.9296,0.9296" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1799" Position="106.6071,72.817,11.9975" Rotation="3.1445" Scale="1.0075,1.0075,1.0075" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1799" Variation="3" Position="106.6071,72.817,11.9975" Rotation="3.1445" Scale="1.0075,1.0075,1.0075" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1900" Position="98.8183,230.0141,11.9853" Scale="1,1,1" Type="Void_Temple_Small" Variation="6">
+    <ObjectDoodad Id="1900" Variation="6" Position="98.8183,230.0141,11.9853" Scale="1,1,1" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2087" Position="79.7846,224.9296,11.9865" Rotation="5.1738" Scale="1.0881,1.0881,1.0881" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2087" Variation="5" Position="79.7846,224.9296,11.9865" Rotation="5.1738" Scale="1.0881,1.0881,1.0881" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="128" Position="59.3874,242.304,0.0004" Rotation="1.5678" Scale="1,1,1" TintColor="0,0,128" Type="CreepCloud">
+    <ObjectDoodad Id="128" Position="59.3874,242.304,0.0004" Rotation="1.5678" Scale="1,1,1" Type="CreepCloud" TintColor="0,0,128">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1833" Position="70.0095,135.2233,10.0017" Scale="0.9616,0.9616,0.9616" Type="TheVoid_RubblePile" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2057" Position="67.9458,214.4382,9.9943" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1833" Variation="2" Position="70.0095,135.2233,10.0017" Scale="0.9616,0.9616,0.9616" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1858" Position="60.0837,195.1276,9.986" Rotation="0.95" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="9">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1172" Position="141,93,7.9916" Rotation="6.1936" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="2057" Variation="3" Position="67.9458,214.4382,9.9943" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1822" Position="53,151,8.0244" Rotation="3.3098" Scale="1.0288,1.0288,1.0288" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1858" Variation="9" Position="60.0837,195.1276,9.986" Rotation="0.95" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1172" Variation="2" Position="141,93,7.9916" Rotation="6.1936" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1822" Variation="1" Position="53,151,8.0244" Rotation="3.3098" Scale="1.0288,1.0288,1.0288" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -606,36 +607,36 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1909" Pitch="1.0424" Position="107.6223,238.4492,-3.1123" Rotation="0.7331" Scale="1,1,1" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1909" Variation="1" Position="107.6223,238.4492,-3.1123" Rotation="0.7331" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1840" Position="90.101,148.3156,9.9841" Scale="0.9262,0.9262,0.9262" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1840" Variation="2" Position="90.101,148.3156,9.9841" Scale="0.9262,0.9262,0.9262" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2171" Position="171.2307,46.8708,11.6677" Rotation="1.108" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="4">
+    <ObjectDoodad Id="2171" Variation="4" Position="171.2307,46.8708,11.6677" Rotation="1.108" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1883" Position="80.6132,220.8437,11.9853" Scale="0.75,0.75,0.75" Type="XelNaga_GroundPlates_TheVoid" Variation="17">
+    <ObjectDoodad Id="1883" Variation="17" Position="80.6132,220.8437,11.9853" Scale="0.75,0.75,0.75" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2064" Position="87.2204,199.4606,11.9907" Rotation="0.4104" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="2064" Variation="2" Position="87.2204,199.4606,11.9907" Rotation="0.4104" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1805" Position="110.5,77.5,9.987" Rotation="1.057" Scale="0.9328,0.9328,0.9328" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1805" Variation="1" Position="110.5,77.5,9.987" Rotation="1.057" Scale="0.9328,0.9328,0.9328" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2118" Position="120.5,134,7.9814" Rotation="2.3063" Scale="1.0998,1,1" TintColor="158,169,160 2.000000" Type="TheVoid_Ramp" Variation="1">
+    <ObjectDoodad Id="2118" Variation="1" Position="120.5,134,7.9814" Rotation="2.3063" Scale="1.0998,1,1" Type="TheVoid_Ramp" TintColor="158,169,160 2.000000">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1894" Position="92.5,224,11.9853" Scale="1,1,1" Type="Void_Temple_Small" Variation="1">
+    <ObjectDoodad Id="1894" Variation="1" Position="92.5,224,11.9853" Scale="1,1,1" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -644,23 +645,23 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="814" Position="94.5017,236.653,11.9853" Scale="1,1,1" Type="Slayn_CliffTemples_Lit" Variation="2">
+    <ObjectDoodad Id="814" Variation="2" Position="94.5017,236.653,11.9853" Scale="1,1,1" Type="Slayn_CliffTemples_Lit">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1827" Position="59.126,143.9855,8.026" Scale="0.9465,0.9465,0.9465" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1827" Variation="3" Position="59.126,143.9855,8.026" Scale="0.9465,0.9465,0.9465" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2051" Position="47.2897,205.13,9.9924" Rotation="2.2067" Scale="1.09,1.09,1.09" TintColor="176,176,176" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2051" Variation="3" Position="47.2897,205.13,9.9924" Rotation="2.2067" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" TintColor="176,176,176">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1864" Position="78.5,180.5,11.9855" Rotation="0.2692" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1864" Variation="1" Position="78.5,180.5,11.9855" Rotation="0.2692" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1812" Position="122.1555,19.398,7.9863" Scale="1,1,1" Type="Void_Crystals" Variation="1">
+    <ObjectDoodad Id="1812" Variation="1" Position="122.1555,19.398,7.9863" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -673,7 +674,7 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1850" Position="81.028,147.535,9.986" Scale="1.0461,1.0461,1.0461" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1850" Variation="3" Position="81.028,147.535,9.986" Scale="1.0461,1.0461,1.0461" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -699,12 +700,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1205" Position="103.1335,104.8522,9.9873" Rotation="3.662" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1205" Variation="4" Position="103.1335,104.8522,9.9873" Rotation="3.662" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1876" Position="77.5,187.5,9.9982" Rotation="0.8535" Scale="0.9406,0.9406,0.9406" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1876" Variation="2" Position="77.5,187.5,9.9982" Rotation="0.8535" Scale="0.9406,0.9406,0.9406" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -715,11 +716,11 @@
     <ObjectDoodad Id="1855" Position="71.4187,166.0815,12.0051" Rotation="1.874" Scale="0.8498,0.8498,0.8498" Type="TheVoid_RockPointy2">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1891" Position="65.0607,200.374,9.9855" Rotation="5.595" Scale="2,2,2" Type="Void_Temple_Small" Variation="4">
+    <ObjectDoodad Id="1891" Variation="4" Position="65.0607,200.374,9.9855" Rotation="5.595" Scale="2,2,2" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2088" Position="97.1728,224.7453,11.9853" Rotation="5.1738" Scale="1.0881,1.0881,1.0881" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2088" Variation="5" Position="97.1728,224.7453,11.9853" Rotation="5.1738" Scale="1.0881,1.0881,1.0881" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -728,16 +729,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2115" Position="50.3562,59.8964,7.9975" Rotation="1.6313" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2115" Variation="5" Position="50.3562,59.8964,7.9975" Rotation="1.6313" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2054" Position="52.755,226.7502,9.991" Rotation="0.2946" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="2054" Variation="2" Position="52.755,226.7502,9.991" Rotation="0.2946" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1869" Position="109.138,146.81,11.9863" Scale="0.9091,0.9091,0.9091" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1869" Variation="2" Position="109.138,146.81,11.9863" Scale="0.9091,0.9091,0.9091" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -749,7 +750,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1847" Pitch="1.0424" Position="86.5,151,0.2236" Rotation="0.3247" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1847" Position="86.5,151,0.2236" Rotation="0.3247" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -757,7 +758,7 @@
     <ObjectDoodad Id="2071" Position="85.0922,220.2978,12.033" Rotation="5.3041" Scale="0.9384,0.9384,0.9384" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1884" Position="95.6052,205.4902,11.9863" Rotation="3.718" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="4">
+    <ObjectDoodad Id="1884" Variation="4" Position="95.6052,205.4902,11.9863" Rotation="3.718" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -767,11 +768,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1817" Position="42.9057,18.8576,11.9868" Scale="1,1,1" Type="Void_Crystals" Variation="3">
+    <ObjectDoodad Id="1817" Variation="3" Position="42.9057,18.8576,11.9868" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1906" Position="65.2031,200.3894,9.9855" Rotation="5.5925" Scale="0.7597,0.7597,0.7597" Type="XelNaga_GroundPlates_Amon" Variation="1">
+    <ObjectDoodad Id="1906" Variation="1" Position="65.2031,200.3894,9.9855" Rotation="5.5925" Scale="0.7597,0.7597,0.7597" Type="XelNaga_GroundPlates_Amon">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -780,14 +781,14 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1838" Position="56.4853,110.0253,12.0083" Scale="0.94,0.94,0.94" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1838" Variation="3" Position="56.4853,110.0253,12.0083" Scale="0.94,0.94,0.94" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1861" Position="77,182.5,11.9816" Scale="0.9438,0.9438,0.9438" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1861" Variation="3" Position="77,182.5,11.9816" Scale="0.9438,0.9438,0.9438" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2062" Position="80.407,196.0815,11.9841" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2062" Variation="3" Position="80.407,196.0815,11.9841" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -799,54 +800,54 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1185" Position="43.4033,29.8413,7.9362" Rotation="2.198" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1185" Variation="2" Position="43.4033,29.8413,7.9362" Rotation="2.198" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1856" Position="66.6047,166.7053,11.9865" Scale="0.965,0.965,0.965" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1856" Variation="1" Position="66.6047,166.7053,11.9865" Scale="0.965,0.965,0.965" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2059" Position="64.9348,202.8044,9.985" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2059" Variation="3" Position="64.9348,202.8044,9.985" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1835" Position="77.4345,118.806,10.038" Rotation="5.483" Scale="1.0095,1.0095,1.0095" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1835" Variation="2" Position="77.4345,118.806,10.038" Rotation="5.483" Scale="1.0095,1.0095,1.0095" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2085" Position="79.5646,231.3442,11.985" Rotation="4.2536" Scale="1.127,1.127,1.127" Type="LightOmniBlueLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1902" Position="98.7331,229.0053,11.9853" Scale="1,1,1" Type="Void_Temple_Small" Variation="3">
+    <ObjectDoodad Id="1902" Variation="3" Position="98.7331,229.0053,11.9853" Scale="1,1,1" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1797" Position="113.854,66.9577,11.987" Scale="0.9616,0.9616,0.9616" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1797" Variation="1" Position="113.854,66.9577,11.987" Scale="0.9616,0.9616,0.9616" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2066" Position="90.7416,174.8752,9.9653" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2066" Variation="3" Position="90.7416,174.8752,9.9653" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1881" Position="92.77,208.0844,11.9785" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="7">
+    <ObjectDoodad Id="1881" Variation="7" Position="92.77,208.0844,11.9785" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2169" Position="175.9155,46.9687,11.9738" Rotation="1.108" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1842" Position="87.5,153.5,11.9882" Rotation="3.6845" Scale="1.0903,1.0903,1.0903" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="2169" Variation="2" Position="175.9155,46.9687,11.9738" Rotation="1.108" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1235" Position="169.3962,119.027,9.9946" Scale="1.0485,1.0485,1.0485" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1842" Variation="2" Position="87.5,153.5,11.9882" Rotation="3.6845" Scale="1.0903,1.0903,1.0903" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1235" Variation="1" Position="169.3962,119.027,9.9946" Scale="1.0485,1.0485,1.0485" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1911" Position="102.6164,188.4636,9.9863" Rotation="0.772" Scale="2,2,2" Type="Void_Temple_Small" Variation="4">
+    <ObjectDoodad Id="1911" Variation="4" Position="102.6164,188.4636,9.9863" Rotation="0.772" Scale="2,2,2" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -854,15 +855,15 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1820" Position="55,154,7.982" Rotation="1.7424" Scale="1.0288,1.0288,1.0288" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1820" Variation="2" Position="55,154,7.982" Rotation="1.7424" Scale="1.0288,1.0288,1.0288" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1866" Position="87.1213,179.7497,11.9855" Scale="0.9406,0.9406,0.9406" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1866" Variation="1" Position="87.1213,179.7497,11.9855" Scale="0.9406,0.9406,0.9406" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2049" Position="55.6245,197.225,9.989" Rotation="2.897" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2049" Variation="3" Position="55.6245,197.225,9.989" Rotation="2.897" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -870,7 +871,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="812" Position="85.9841,236.6491,11.9853" Scale="1,1,1" Type="Slayn_CliffTemples_Lit" Variation="2">
+    <ObjectDoodad Id="812" Variation="2" Position="85.9841,236.6491,11.9853" Scale="1,1,1" Type="Slayn_CliffTemples_Lit">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -879,34 +880,34 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1892" Position="94.5512,226.8303,11.9853" Scale="1,1,1" Type="Void_Temple_Small" Variation="7">
+    <ObjectDoodad Id="1892" Variation="7" Position="94.5512,226.8303,11.9853" Scale="1,1,1" Type="Void_Temple_Small">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2116" Position="56.7116,68.5544,8.0207" Rotation="4.5134" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2116" Variation="5" Position="56.7116,68.5544,8.0207" Rotation="4.5134" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1807" Position="111.5,75,9.996" Rotation="5.8376" Scale="1.0546,1.0546,1.0546" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1807" Variation="2" Position="111.5,75,9.996" Rotation="5.8376" Scale="1.0546,1.0546,1.0546" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1241" Position="177.2731,54.2546,11.9953" Rotation="2.2363" Scale="1.1904,1.1904,1.1904" Type="Void_GoldPiles" Variation="3">
+    <ObjectDoodad Id="1241" Variation="3" Position="177.2731,54.2546,11.9953" Rotation="2.2363" Scale="1.1904,1.1904,1.1904" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2072" Position="90.7634,219.4101,11.9848" Rotation="1.5708" Scale="0.9384,0.9384,0.9384" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1875" Pitch="5.934" Position="88.38,180.5698,11.9956" Rotation="6.2065" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1875" Position="88.38,180.5698,11.9956" Rotation="6.2065" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="5.934">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1848" Position="83.3425,153.2514,11.9997" Scale="1.0297,1.0297,1.0297" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1848" Variation="3" Position="83.3425,153.2514,11.9997" Scale="1.0297,1.0297,1.0297" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1917" Position="113.688,199.797,9.9853" Rotation="0.88" Scale="0.7597,0.7597,0.7597" Type="XelNaga_GroundPlates_Amon" Variation="1">
+    <ObjectDoodad Id="1917" Variation="1" Position="113.688,199.797,9.9853" Rotation="0.88" Scale="0.7597,0.7597,0.7597" Type="XelNaga_GroundPlates_Amon">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -915,15 +916,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1814" Position="107.3073,69.8872,9.9821" Scale="1,1,1" Type="Void_Crystals" Variation="3">
+    <ObjectDoodad Id="1814" Variation="3" Position="107.3073,69.8872,9.9821" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="816" Position="53.5,145,7.8813" Rotation="5.532" Scale="1.0998,1,1" TintColor="157,170,169 2.250000" Type="TheVoid_Ramp" Variation="1">
+    <ObjectDoodad Id="816" Variation="1" Position="53.5,145,7.8813" Rotation="5.532" Scale="1.0998,1,1" Type="TheVoid_Ramp" TintColor="157,170,169 2.250000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1853" Position="112.5,136.5,7.9782" Rotation="1.2976" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1853" Variation="1" Position="112.5,136.5,7.9782" Rotation="1.2976" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -931,12 +932,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1878" Position="78,188,9.9902" Rotation="6.1853" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1878" Variation="4" Position="78,188,9.9902" Rotation="6.1853" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1811" Position="119.8107,22.173,11.9638" Scale="1,1,1" Type="Void_Crystals" Variation="4">
+    <ObjectDoodad Id="1811" Variation="4" Position="119.8107,22.173,11.9638" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -949,11 +950,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1828" Position="52.4533,150.6972,8.0253" Scale="1.0092,1.0092,1.0092" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1828" Variation="1" Position="52.4533,150.6972,8.0253" Scale="1.0092,1.0092,1.0092" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1871" Pitch="1.0424" Position="87.5,195.5,-0.9113" Rotation="0.7495" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1871" Position="87.5,195.5,-0.9113" Rotation="0.7495" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -975,31 +976,31 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1889" Position="83.5383,224.1997,11.9853" Scale="1,1,1" Type="Void_Temple_Small" Variation="1">
+    <ObjectDoodad Id="1889" Variation="1" Position="83.5383,224.1997,11.9853" Scale="1,1,1" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1332" Pitch="5.8466" Position="32.2998,116.7797,11.8903" Rotation="0.9118" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1332" Position="32.2998,116.7797,11.8903" Rotation="0.9118" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="5.8466">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1375" Position="30.7512,131.9133,-0.012" Rotation="2.8178" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1375" Variation="2" Position="30.7512,131.9133,-0.012" Rotation="2.8178" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1749" Position="107.8083,117.8791,9.987" Rotation="0.945" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1749" Variation="1" Position="107.8083,117.8791,9.987" Rotation="0.945" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1726" Position="148,144.5,11.9738" Rotation="4.3371" Scale="0.5,0.5,0.5" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1726" Variation="1" Position="148,144.5,11.9738" Rotation="4.3371" Scale="0.5,0.5,0.5" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1787" Position="112,64,11.987" Rotation="3.1445" Scale="1.0075,1.0075,1.0075" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1787" Variation="2" Position="112,64,11.987" Rotation="3.1445" Scale="1.0075,1.0075,1.0075" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1680" Position="150.3093,33.67,9.9875" Rotation="1.7692" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1680" Variation="1" Position="150.3093,33.67,9.9875" Rotation="1.7692" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1022,92 +1023,92 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="682" Position="79.7824,205.125,11.9865" Rotation="2.5632" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="18">
+    <ObjectDoodad Id="682" Variation="18" Position="79.7824,205.125,11.9865" Rotation="2.5632" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1325" Position="14.3242,97.9106,5.9028" Rotation="1.7165" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1325" Variation="2" Position="14.3242,97.9106,5.9028" Rotation="1.7165" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1350" Position="37.9423,25.3493,11.998" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1350" Variation="1" Position="37.9423,25.3493,11.998" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1384" Position="29.4438,164.7514,7.7961" Rotation="6.1086" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1384" Variation="1" Position="29.4438,164.7514,7.7961" Rotation="6.1086" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1762" Position="114.6142,108.981,8.022" Scale="1.0927,1.0927,1.0927" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1762" Variation="3" Position="114.6142,108.981,8.022" Scale="1.0927,1.0927,1.0927" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1673" Position="138.5,54,7.9941" Rotation="1.7692" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1673" Variation="3" Position="138.5,54,7.9941" Rotation="1.7692" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1698" Position="142.8288,104.9553,7.8994" Rotation="2.9023" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1698" Variation="2" Position="142.8288,104.9553,7.8994" Rotation="2.9023" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1737" Position="95.7595,104.7282,11.9904" Scale="1.0563,1.0563,1.0563" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1737" Variation="3" Position="95.7595,104.7282,11.9904" Scale="1.0563,1.0563,1.0563" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1347" Position="82.07,48.6884,10" Rotation="0.845" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1347" Variation="3" Position="82.07,48.6884,10" Rotation="0.845" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1320" Position="34.3996,65.5407,8.2155" Rotation="3.8803" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1320" Variation="3" Position="34.3996,65.5407,8.2155" Rotation="3.8803" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1389" Position="34.987,159.5874,7.8874" Rotation="0.1975" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1389" Variation="4" Position="34.987,159.5874,7.8874" Rotation="0.1975" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1676" Position="140,41.5,8.0097" Rotation="5.1613" Scale="0.9807,0.9807,0.9807" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1676" Variation="2" Position="140,41.5,8.0097" Rotation="5.1613" Scale="0.9807,0.9807,0.9807" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1767" Position="107.5,110.5,11.987" Rotation="4.4162" Scale="0.9602,0.9602,0.9602" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1767" Variation="2" Position="107.5,110.5,11.987" Rotation="4.4162" Scale="0.9602,0.9602,0.9602" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1370" Position="27.8437,134.1157,6.2878" Rotation="2.416" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1370" Variation="2" Position="27.8437,134.1157,6.2878" Rotation="2.416" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1329" Position="61.727,77.4304,11.9858" Rotation="1.4736" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1329" Variation="2" Position="61.727,77.4304,11.9858" Rotation="1.4736" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1723" Position="152,146,11.9873" Rotation="5.553" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1723" Variation="1" Position="152,146,11.9873" Rotation="5.553" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1744" Position="101.561,102.5292,9.9802" Rotation="0.9453" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1685" Position="113,61,9.9997" Rotation="4.8991" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1396" Position="35.4721,172.2236,8.8908" Rotation="1.5632" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1744" Variation="1" Position="101.561,102.5292,9.9802" Rotation="0.9453" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1311" Position="63.1271,25.0107,0.6911" Rotation="3.7817" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1685" Variation="2" Position="113,61,9.9997" Rotation="4.8991" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1396" Variation="1" Position="35.4721,172.2236,8.8908" Rotation="1.5632" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1311" Variation="2" Position="63.1271,25.0107,0.6911" Rotation="3.7817" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1116,19 +1117,19 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1314" Position="44.0332,67.2145,9.9946" Rotation="5.8774" Scale="0.7597,0.7597,0.7597" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1314" Variation="1" Position="44.0332,67.2145,9.9946" Rotation="5.8774" Scale="0.7597,0.7597,0.7597" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1704" Position="142.5314,91.0468,7.9926" Rotation="2.1354" Scale="1.001,1.001,1.001" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1704" Variation="2" Position="142.5314,91.0468,7.9926" Rotation="2.1354" Scale="1.001,1.001,1.001" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1731" Position="102.5,98.5,7.9338" Rotation="0.424" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1731" Variation="2" Position="102.5,98.5,7.9338" Rotation="0.424" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="651" Pitch="6.1086" Position="61.7697,227.67,10.2897" Rotation="5.8764" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="651" Position="61.7697,227.67,10.2897" Rotation="5.8764" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="6.1086">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1138,7 +1139,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1773" Position="103.2578,97.633,7.9775" Rotation="2.5065" Scale="0.934,0.934,0.934" Type="Void_CrackSplat" Variation="1">
+    <ObjectDoodad Id="1773" Variation="1" Position="103.2578,97.633,7.9775" Rotation="2.5065" Scale="0.934,0.934,0.934" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1151,19 +1152,19 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1713" Position="148.5,132.5,7.3762" Rotation="0.7294" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1713" Variation="4" Position="148.5,132.5,7.3762" Rotation="0.7294" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1754" Position="121,119,11.987" Rotation="1.1015" Scale="0.8498,0.8498,0.8498" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1754" Variation="1" Position="121,119,11.987" Rotation="1.1015" Scale="0.8498,0.8498,0.8498" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1360" Position="16.522,11.3085,8.4875" Rotation="5.8488" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1360" Variation="1" Position="16.522,11.3085,8.4875" Rotation="5.8488" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1339" Position="36.9255,75.0781,9.988" Rotation="3.435" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1339" Variation="5" Position="36.9255,75.0781,9.988" Rotation="3.435" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1173,33 +1174,33 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1301" Position="36.339,72.7875,3.2827" Rotation="1.1176" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1301" Variation="1" Position="36.339,72.7875,3.2827" Rotation="1.1176" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1695" Position="19.5,53.5,9.9785" Rotation="2.4018" Scale="1,1,1" Type="Void_Sand_Drifts" Variation="2">
+    <ObjectDoodad Id="1695" Variation="2" Position="19.5,53.5,9.9785" Rotation="2.4018" Scale="1,1,1" Type="Void_Sand_Drifts">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="658" Pitch="6.1086" Position="78.3298,223.42,11.7895" Rotation="0.4545" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="658" Position="78.3298,223.42,11.7895" Rotation="0.4545" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Pitch="6.1086">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1780" Position="133.24,53.6337,7.987" Rotation="5.2102" Scale="0.905,0.905,0.905" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="1780" Variation="2" Position="133.24,53.6337,7.987" Rotation="5.2102" Scale="0.905,0.905,0.905" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1759" Pitch="1.0424" Position="118,121.5,1.9228" Rotation="6.196" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1716" Position="150.978,131.4594,7.9875" Scale="1.0722,1.0722,1.0722" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1759" Position="118,121.5,1.9228" Rotation="6.196" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1342" Position="30.4965,58.666,8.2746" Rotation="1.3413" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="1">
+    <ObjectDoodad Id="1716" Variation="2" Position="150.978,131.4594,7.9875" Scale="1.0722,1.0722,1.0722" Type="TheVoid_RubblePile">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1342" Variation="1" Position="30.4965,58.666,8.2746" Rotation="1.3413" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -1208,15 +1209,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1296" Position="33.1428,33.007,7.988" Rotation="0.394" Scale="0.976,0.976,0.976" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="1296" Variation="2" Position="33.1428,33.007,7.988" Rotation="0.394" Scale="0.976,0.976,0.976" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1403" Position="35.4218,174.2841,11.9694" Rotation="5.2644" Scale="1.0058,1.0058,1.0058" Type="TheVoid_RockPointy" Variation="2">
+    <ObjectDoodad Id="1403" Variation="2" Position="35.4218,174.2841,11.9694" Rotation="5.2644" Scale="1.0058,1.0058,1.0058" Type="TheVoid_RockPointy">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1777" Position="98.3562,95.7607,7.987" Rotation="0.8183" Scale="1.0578,1.0578,1.0578" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1777" Variation="4" Position="98.3562,95.7607,7.987" Rotation="0.8183" Scale="1.0578,1.0578,1.0578" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1224,12 +1225,12 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1319" Position="18.2897,86.98,3.7294" Rotation="2.0996" Scale="1,1,1" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1319" Variation="2" Position="18.2897,86.98,3.7294" Rotation="2.0996" Scale="1,1,1" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1356" Position="26.4892,54.75,8.0332" Rotation="3.8515" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1356" Variation="2" Position="26.4892,54.75,8.0332" Rotation="3.8515" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1238,11 +1239,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1709" Position="143.0715,103.549,7.9726" Scale="0.9267,0.9267,0.9267" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1709" Variation="2" Position="143.0715,103.549,7.9726" Scale="0.9267,0.9267,0.9267" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1768" Position="101.7734,97.153,7.9802" Rotation="3.4272" Scale="0.9614,0.9614,0.9614" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1768" Variation="2" Position="101.7734,97.153,7.9802" Rotation="3.4272" Scale="0.9614,0.9614,0.9614" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1254,7 +1255,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1289" Position="43.006,44.2636,2.1875" Rotation="1.5195" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1289" Variation="1" Position="43.006,44.2636,2.1875" Rotation="1.5195" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1264,20 +1265,20 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1682" Position="148.517,44.2194,11.996" Rotation="1.2863" Scale="1.0786,1.0786,1.0786" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1682" Variation="1" Position="148.517,44.2194,11.996" Rotation="1.2863" Scale="1.0786,1.0786,1.0786" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1395" Position="32.305,173.136,-0.1074" Rotation="1.0781" Scale="1.25,1.25,1.25" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1395" Variation="4" Position="32.305,173.136,-0.1074" Rotation="1.0781" Scale="1.25,1.25,1.25" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1304" Position="35.1025,77.372,9.9912" Rotation="5.3305" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy" Variation="2">
+    <ObjectDoodad Id="1304" Variation="2" Position="35.1025,77.372,9.9912" Rotation="5.3305" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1373" Position="71.8437,70.6921,11.9902" Rotation="0.558" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1373" Variation="1" Position="71.8437,70.6921,11.9902" Rotation="0.558" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1286,16 +1287,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1724" Position="150.0852,142.483,11.9875" Scale="1.0722,1.0722,1.0722" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1724" Variation="1" Position="150.0852,142.483,11.9875" Scale="1.0722,1.0722,1.0722" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="689" Position="70.1464,206.873,11.985" Rotation="5.8737" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="689" Variation="4" Position="70.1464,206.873,11.985" Rotation="5.8737" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1751" Position="112.5,122,9.9975" Rotation="5.6765" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1751" Variation="3" Position="112.5,122,9.9975" Rotation="5.6765" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1305,11 +1306,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1675" Position="144.5,37,7.967" Scale="1.017,1.017,1.017" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1675" Variation="2" Position="144.5,37,7.967" Scale="1.017,1.017,1.017" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1760" Position="120.0883,127.0134,7.9873" Rotation="5.6765" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1760" Variation="2" Position="120.0883,127.0134,7.9873" Rotation="5.6765" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1318,7 +1319,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1742" Position="94.3947,101.538,9.9853" Rotation="6.0117" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1742" Variation="3" Position="94.3947,101.538,9.9853" Rotation="6.0117" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1326,17 +1327,17 @@
     <ObjectDoodad Id="1348" Position="75.0603,48.3825,9.993" Rotation="6.1213" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy2">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1327" Position="17.1787,89.8957,10.4704" Rotation="6.234" Scale="1,1,1" Type="TheVoid_RockPointy" Variation="1">
+    <ObjectDoodad Id="1327" Variation="1" Position="17.1787,89.8957,10.4704" Rotation="6.234" Scale="1,1,1" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1391" Position="21.4807,164.306,7.8764" Rotation="0.1975" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1391" Variation="4" Position="21.4807,164.306,7.8764" Rotation="0.1975" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1765" Position="123.703,121.1418,11.987" Scale="1.0634,1.0634,1.0634" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1765" Variation="3" Position="123.703,121.1418,11.987" Scale="1.0634,1.0634,1.0634" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1344,11 +1345,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1739" Position="104.5883,109.027,11.9873" Scale="1.0563,1.0563,1.0563" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1739" Variation="3" Position="104.5883,109.027,11.9873" Scale="1.0563,1.0563,1.0563" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1696" Position="16.5,47,7.9873" Rotation="2.8635" Scale="1,1,1" Type="Void_Sand_Drifts" Variation="2">
+    <ObjectDoodad Id="1696" Variation="2" Position="16.5,47,7.9873" Rotation="2.8635" Scale="1,1,1" Type="Void_Sand_Drifts">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1356,12 +1357,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1345" Position="26.2563,12.0378,0.2248" Rotation="0.5634" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1345" Variation="5" Position="26.2563,12.0378,0.2248" Rotation="0.5634" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1788" Position="118.6447,70.1203,11.987" Scale="1.0104,1.0104,1.0104" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1788" Variation="3" Position="118.6447,70.1203,11.987" Scale="1.0104,1.0104,1.0104" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1369,11 +1370,11 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1309" Position="58.2326,74.7226,7.9736" Rotation="6.177" Scale="0.8498,0.8498,0.8498" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1309" Variation="4" Position="58.2326,74.7226,7.9736" Rotation="6.177" Scale="0.8498,0.8498,0.8498" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1398" Position="34.78,171.6442,0.3754" Rotation="1.5632" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1398" Variation="1" Position="34.78,171.6442,0.3754" Rotation="1.5632" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1383,11 +1384,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1368" Position="31.9428,117.3273,11.9755" Rotation="4.6726" Scale="0.9,0.9,0.9" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1368" Variation="2" Position="31.9428,117.3273,11.9755" Rotation="4.6726" Scale="0.9,0.9,0.9" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1746" Pitch="1.0424" Position="111,115,0.9228" Rotation="0.3247" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1746" Position="111,115,0.9228" Rotation="0.3247" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1396,16 +1397,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1775" Position="117.9731,113.2646,8.2087" Rotation="4.0375" Scale="0.9123,0.9123,0.9123" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1775" Variation="4" Position="117.9731,113.2646,8.2087" Rotation="4.0375" Scale="0.9123,0.9123,0.9123" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1668" Pitch="1.3256" Position="141.5,48,-0.9125" Rotation="5.867" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1668" Position="141.5,48,-0.9125" Rotation="5.867" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.3256">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1294" Position="20.7993,61.6865,11.985" Rotation="4.6791" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy" Variation="2">
+    <ObjectDoodad Id="1294" Variation="2" Position="20.7993,61.6865,11.985" Rotation="4.6791" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -1419,29 +1420,29 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1355" Position="41.395,65.429,7.9875" Rotation="5.705" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1355" Variation="2" Position="41.395,65.429,7.9875" Rotation="5.705" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1729" Position="158,144.5,7.9833" Rotation="4.3195" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1729" Variation="4" Position="158,144.5,7.9833" Rotation="4.3195" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1706" Position="135.504,96.0173,7.9692" Rotation="2.801" Scale="1.095,1.095,1.095" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1706" Variation="3" Position="135.504,96.0173,7.9692" Rotation="2.801" Scale="1.095,1.095,1.095" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1303" Position="35.8037,79.6406,10.0246" Rotation="5.1665" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy" Variation="3">
+    <ObjectDoodad Id="1303" Variation="3" Position="35.8037,79.6406,10.0246" Rotation="5.1665" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1404" Position="41.24,167.9921,11.8872" Rotation="3.9453" Scale="1,1,1" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1404" Variation="4" Position="41.24,167.9921,11.8872" Rotation="3.9453" Scale="1,1,1" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1782" Position="119.774,72.6538,11.987" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="1782" Variation="1" Position="119.774,72.6538,11.987" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1463,20 +1464,20 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1337" Position="22.6772,62.4255,12.1767" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1337" Variation="1" Position="22.6772,62.4255,12.1767" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1362" Position="23.3466,111.9357,10.1982" Rotation="6.2482" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1362" Variation="1" Position="23.3466,111.9357,10.1982" Rotation="6.2482" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1401" Position="39.4455,176.8193,11.8955" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1401" Variation="4" Position="39.4455,176.8193,11.8955" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1298" Position="33.775,20.9882,7.99" Rotation="2.3293" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1298" Variation="4" Position="33.775,20.9882,7.99" Rotation="2.3293" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -1484,38 +1485,38 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1779" Position="107.5341,27.959,11.987" Rotation="4.5498" Scale="0.9731,0.9731,0.9731" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1779" Variation="5" Position="107.5341,27.959,11.987" Rotation="4.5498" Scale="0.9731,0.9731,0.9731" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1718" Position="157.1838,126.522,7.978" Scale="0.9665,0.9665,0.9665" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1718" Variation="3" Position="157.1838,126.522,7.978" Scale="0.9665,0.9665,0.9665" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1757" Position="113.5,110,7.9814" Rotation="1.9726" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1757" Variation="3" Position="113.5,110,7.9814" Rotation="1.9726" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1367" Position="75.9758,71.116,11.986" Rotation="4.1638" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1367" Variation="1" Position="75.9758,71.116,11.986" Rotation="4.1638" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1340" Position="36.6616,61.4338,7.9875" Rotation="0.5637" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1340" Variation="5" Position="36.6616,61.4338,7.9875" Rotation="0.5637" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1665" Position="149.1191,25.9987,7.9873" Rotation="1.5144" Scale="0.9301,0.9301,0.9301" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1665" Variation="1" Position="149.1191,25.9987,7.9873" Rotation="1.5144" Scale="0.9301,0.9301,0.9301" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="652" Position="64.8637,226.5244,9.899" Rotation="4.4626" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="652" Variation="4" Position="64.8637,226.5244,9.899" Rotation="4.4626" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1770" Position="85.4438,87.185,9.987" Scale="1.0917,1.0917,1.0917" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1770" Variation="3" Position="85.4438,87.185,9.987" Scale="1.0917,1.0917,1.0917" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1524,11 +1525,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1291" Position="15.914,53.0756,11.9184" Rotation="0.3286" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy" Variation="2">
+    <ObjectDoodad Id="1291" Variation="2" Position="15.914,53.0756,11.9184" Rotation="0.3286" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1358" Position="29.4187,59.8044,8.2453" Rotation="3.8515" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1358" Variation="2" Position="29.4187,59.8044,8.2453" Rotation="3.8515" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1537,51 +1538,51 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1711" Position="146.463,101.5803,11.9873" Scale="1.0915,1.0915,1.0915" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1711" Variation="3" Position="146.463,101.5803,11.9873" Scale="1.0915,1.0915,1.0915" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1732" Pitch="1.0424" Position="96.5,111.5,3.298" Rotation="6.2434" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1732" Position="96.5,111.5,3.298" Rotation="6.2434" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1653" Position="131,3,11.9875" Rotation="4.5895" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1653" Variation="2" Position="131,3,11.9875" Rotation="4.5895" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1566" Position="97.3925,233.8078,11.985" Rotation="1.622" Scale="1,1,1" Type="Void_Temple" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2389" Position="170.1511,40.8786,9.9904" Rotation="1.769" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="1566" Variation="1" Position="97.3925,233.8078,11.985" Rotation="1.622" Scale="1,1,1" Type="Void_Temple">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="531" Position="20.0747,26.7917,8" Rotation="1.3251" Scale="1.25,1.25,1.25" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="2389" Variation="1" Position="170.1511,40.8786,9.9904" Rotation="1.769" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="1428" Position="43.2795,116.1782,11.9873" Rotation="5.8723" Scale="1.0998,1.0998,1.0998" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1535" Position="85.2976,9.245,9.9877" Rotation="0.7292" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1535" Variation="1" Position="85.2976,9.245,9.9877" Rotation="0.7292" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1466" Position="34.527,128.6838,9.9812" Rotation="1.2292" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1466" Variation="4" Position="34.527,128.6838,9.9812" Rotation="1.2292" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1489" Position="76.9553,46.7631,9.9863" Rotation="4.7998" Scale="1.0095,1.0095,1.0095" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1489" Variation="5" Position="76.9553,46.7631,9.9863" Rotation="4.7998" Scale="1.0095,1.0095,1.0095" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1627" Position="112.5,22.5,11.988" Rotation="0.7917" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1627" Variation="4" Position="112.5,22.5,11.988" Rotation="0.7917" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1589,12 +1590,12 @@
     <ObjectDoodad Id="1584" Position="29.3881,80.0864,-0.013" Rotation="5.5195" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1421" Position="50.222,186.0146,9.5937" Rotation="2.134" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1421" Variation="3" Position="50.222,186.0146,9.5937" Rotation="2.134" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1510" Position="63.0236,82.357,-0.001" Rotation="3.4113" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1510" Variation="4" Position="63.0236,82.357,-0.001" Rotation="3.4113" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1604,32 +1605,32 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2380" Position="128.8422,182.749,11.9868" Rotation="2.5722" Scale="0.9382,0.9382,0.9382" Type="Void_CrackSplat" Variation="4">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="522" Position="44.175,209.4206,6.684" Rotation="1.9304" Scale="0.65,0.65,0.65" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="522" Variation="1" Position="44.175,209.4206,6.684" Rotation="1.9304" Scale="0.65,0.65,0.65" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1543" Position="95.8896,98.0776,8.0031" Rotation="4.6096" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="2380" Variation="4" Position="128.8422,182.749,11.9868" Rotation="2.5722" Scale="0.9382,0.9382,0.9382" Type="Void_CrackSplat">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1543" Variation="2" Position="95.8896,98.0776,8.0031" Rotation="4.6096" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1602" Position="82.2631,192.2524,-0.013" Rotation="0.161" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1577" Position="39.6635,153.6801,7.987" Scale="0.9946,0.9946,0.9946" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1577" Variation="1" Position="39.6635,153.6801,7.987" Scale="0.9946,0.9946,0.9946" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2402" Position="149.7517,56.5998,9.99" Rotation="5.9501" Scale="0.9328,0.9328,0.9328" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="2402" Variation="3" Position="149.7517,56.5998,9.99" Rotation="5.9501" Scale="0.9328,0.9328,0.9328" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1443" Position="43.4567,67.1057,10" Scale="0.9143,0.9143,0.9143" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1443" Variation="3" Position="43.4567,67.1057,10" Scale="0.9143,0.9143,0.9143" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1637,41 +1638,41 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1507" Position="55.5397,111.8198,11.999" Rotation="0.6174" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1507" Variation="3" Position="55.5397,111.8198,11.999" Rotation="0.6174" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1416" Position="45.6474,221.2021,9.3737" Rotation="1.0375" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1416" Variation="2" Position="45.6474,221.2021,9.3737" Rotation="1.0375" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2377" Position="134.9333,184.1381,9.9814" Rotation="2.4763" Scale="1.0952,1.0952,1.0952" Type="Void_CrackSplat" Variation="4">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="527" Position="30.5,14.5,4.4558" Rotation="4.0253" Scale="0.65,0.65,0.65" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="527" Variation="2" Position="30.5,14.5,4.4558" Rotation="4.0253" Scale="0.65,0.65,0.65" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1538" Position="82.145,90.9235,11.9873" Rotation="1.187" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="2377" Variation="4" Position="134.9333,184.1381,9.9814" Rotation="2.4763" Scale="1.0952,1.0952,1.0952" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1641" Position="138,16,7.798" Rotation="3.1723" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1538" Variation="3" Position="82.145,90.9235,11.9873" Rotation="1.187" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1641" Variation="1" Position="138,16,7.798" Rotation="3.1723" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1580" Position="33.5124,135.5617,7.9736" Rotation="1.0087" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1580" Variation="1" Position="33.5124,135.5617,7.9736" Rotation="1.0087" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1607" Position="66.142,130.9343,8.004" Scale="0.9116,0.9116,0.9116" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1607" Variation="1" Position="66.142,130.9343,8.004" Scale="0.9116,0.9116,0.9116" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1485" Position="82.4406,48.272,9.9865" Scale="1.0356,1.0356,1.0356" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1485" Variation="1" Position="82.4406,48.272,9.9865" Scale="1.0356,1.0356,1.0356" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1679,7 +1680,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1563" Position="60.7985,22.91,7.9941" Rotation="5.379" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1563" Variation="1" Position="60.7985,22.91,7.9941" Rotation="5.379" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1689,25 +1690,25 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1648" Position="132.3107,18.7182,7.9821" Scale="1.0344,1.0344,1.0344" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1648" Variation="2" Position="132.3107,18.7182,7.9821" Scale="1.0344,1.0344,1.0344" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2363" Position="77.9516,48.8796,9.9606" Rotation="1.3591" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="2363" Variation="4" Position="77.9516,48.8796,9.9606" Rotation="1.3591" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1530" Position="38.4438,35.044,11.983" Rotation="1.7497" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1530" Variation="3" Position="38.4438,35.044,11.983" Rotation="1.7497" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1425" Pitch="1.0424" Position="72.8488,231.738,-0.9123" Rotation="5.0346" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1425" Position="72.8488,231.738,-0.9123" Rotation="5.0346" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="412" Position="84.4997,15.4997,7.991" Rotation="2.356" Scale="1.5,1.5,1.5" TeamColor="0" Type="Korhal_TarmacSplat" Variation="1">
+    <ObjectDoodad Id="412" Variation="1" Position="84.4997,15.4997,7.991" Rotation="2.356" Scale="1.5,1.5,1.5" Type="Korhal_TarmacSplat" TeamColor="0">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -1716,7 +1717,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1471" Position="49.781,105.9826,10.3188" Rotation="4.9643" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1471" Variation="4" Position="49.781,105.9826,10.3188" Rotation="4.9643" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1724,15 +1725,15 @@
     <ObjectDoodad Id="1589" Position="98.8498,102.66,-0.013" Rotation="0.161" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1630" Position="103.7626,37.3884,10" Scale="0.9594,0.9594,0.9594" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1630" Variation="1" Position="103.7626,37.3884,10" Scale="0.9594,0.9594,0.9594" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2371" Position="134.8894,165.8537,11.9814" Rotation="4.6577" Scale="0.9975,0.9975,0.9975" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="2371" Variation="2" Position="134.8894,165.8537,11.9814" Rotation="4.6577" Scale="0.9975,0.9975,0.9975" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1544" Position="87.9841,91.0158,8.01" Rotation="3.5754" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1544" Variation="2" Position="87.9841,91.0158,8.01" Rotation="3.5754" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1740,24 +1741,24 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1513" Position="78.1674,71.8945,7.9875" Rotation="2.8261" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1513" Variation="3" Position="78.1674,71.8945,7.9875" Rotation="2.8261" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1410" Position="43.5898,185.7646,11.8996" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1410" Variation="4" Position="43.5898,185.7646,11.8996" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1479" Position="54.2185,98.5676,10.005" Scale="1.0485,1.0485,1.0485" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1479" Variation="1" Position="54.2185,98.5676,10.005" Scale="1.0485,1.0485,1.0485" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1452" Position="19.1711,109.2431,10.1264" Rotation="0.8105" Scale="1.0175,1.0175,1.0175" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1452" Variation="2" Position="19.1711,109.2431,10.1264" Rotation="0.8105" Scale="1.0175,1.0175,1.0175" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1574" Position="20.7878,163.9353,8.0085" Rotation="3.6748" Scale="0.9526,0.9526,0.9526" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1574" Variation="3" Position="20.7878,163.9353,8.0085" Rotation="3.6748" Scale="0.9526,0.9526,0.9526" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1765,7 +1766,7 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1520" Position="42.406,26.525,9.9926" Rotation="0.1232" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1520" Variation="1" Position="42.406,26.525,9.9926" Rotation="0.1232" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1774,7 +1775,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1553" Position="96.4875,10.6477,9.9873" Rotation="3.4343" Scale="1.0375,1.0375,1.0375" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1553" Variation="2" Position="96.4875,10.6477,9.9873" Rotation="3.4343" Scale="1.0375,1.0375,1.0375" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2394" Position="154.1821,61.3564,7.787" Rotation="4.4543" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
@@ -1786,7 +1787,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2420" Position="166.43,47.19,11.9462" Rotation="1.8916" Scale="0.9,0.9,0.9" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2420" Variation="4" Position="166.43,47.19,11.9462" Rotation="1.8916" Scale="0.9,0.9,0.9" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1803,18 +1804,18 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="440" Position="19.2106,60.865,11.8298" Rotation="4.6791" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy" Variation="1">
+    <ObjectDoodad Id="440" Variation="1" Position="19.2106,60.865,11.8298" Rotation="4.6791" Scale="0.75,0.75,0.75" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1461" Position="30.3496,112.2385,9.9873" Rotation="0.4536" Scale="1.0217,1.0217,1.0217" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="1461" Variation="2" Position="30.3496,112.2385,9.9873" Rotation="0.4536" Scale="1.0217,1.0217,1.0217" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1438" Position="23.7907,86.9453,10.6875" Rotation="4.0937" Scale="0.901,0.901,0.901" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1438" Variation="4" Position="23.7907,86.9453,10.6875" Rotation="4.0937" Scale="0.901,0.901,0.901" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1525" Position="38.183,22.1276,11.9672" Rotation="1.8925" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1525" Variation="2" Position="38.183,22.1276,11.9672" Rotation="1.8925" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1824,11 +1825,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1663" Position="149.6923,21.8044,7.9873" Rotation="0.2724" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1663" Variation="1" Position="149.6923,21.8044,7.9873" Rotation="0.2724" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1556" Position="106.1496,106.402,10.0004" Rotation="3.791" Scale="0.9602,0.9602,0.9602" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1556" Variation="2" Position="106.1496,106.402,10.0004" Rotation="3.791" Scale="0.9602,0.9602,0.9602" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1837,7 +1838,7 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1617" Pitch="1.0424" Position="110.5,40,1.9272" Rotation="0.325" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1617" Variation="1" Position="110.5,40,1.9272" Rotation="0.325" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1845,11 +1846,11 @@
     <ObjectDoodad Id="1594" Position="29.9101,128.817,-0.013" Rotation="0.161" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1456" Position="46.519,109.5266,9.9943" Rotation="4.4304" Scale="1.05,1.05,1.05" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1456" Variation="1" Position="46.519,109.5266,9.9943" Rotation="4.4304" Scale="1.05,1.05,1.05" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1499" Position="62.32,85.1811,10.013" Rotation="4.137" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1499" Variation="4" Position="62.32,85.1811,10.013" Rotation="4.137" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1859,7 +1860,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2374" Position="152.6682,145.8007,11.9794" Rotation="3.784" Scale="1.027,1.027,1.027" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="2374" Variation="2" Position="152.6682,145.8007,11.9794" Rotation="3.784" Scale="1.027,1.027,1.027" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1867,7 +1868,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1415" Pitch="5.934" Position="48.91,223.71,10.09" Rotation="0.645" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1415" Position="48.91,223.71,10.09" Rotation="0.645" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="5.934">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -1875,7 +1876,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1449" Position="17.7043,91.243,10.475" Rotation="5.4143" Scale="1.075,1.075,1.075" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1449" Variation="2" Position="17.7043,91.243,10.475" Rotation="5.4143" Scale="1.075,1.075,1.075" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1884,16 +1885,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1608" Position="107.4912,29.8503,11.9875" Rotation="5.5578" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1608" Variation="4" Position="107.4912,29.8503,11.9875" Rotation="5.5578" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1571" Position="17.2727,161.667,7.981" Scale="1.0112,1.0112,1.0112" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1571" Variation="1" Position="17.2727,161.667,7.981" Scale="1.0112,1.0112,1.0112" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1491" Position="72.1242,48.0556,7.987" Rotation="1.8305" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1491" Variation="1" Position="72.1242,48.0556,7.987" Rotation="1.8305" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1901,7 +1902,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="437" Pitch="6.1086" Position="51.65,201.16,9.79" Rotation="2.5561" Scale="1.074,1.074,1.074" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="437" Position="51.65,201.16,9.79" Rotation="2.5561" Scale="1.074,1.074,1.074" Type="Void_Cliff_Rocks" Pitch="6.1086">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1915,56 +1916,56 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1625" Position="105,40,7.9841" Rotation="1.5314" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1625" Variation="1" Position="105,40,7.9841" Rotation="1.5314" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2391" Position="172.1027,60.9038,9.9904" Rotation="0.1098" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="529" Position="15.5,12,2.4978" Rotation="2.374" Scale="0.955,0.955,0.955" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="529" Variation="2" Position="15.5,12,2.4978" Rotation="2.374" Scale="0.955,0.955,0.955" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1564" Position="39.3281,38.4958,9.999" Rotation="0.642" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2391" Variation="3" Position="172.1027,60.9038,9.9904" Rotation="0.1098" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2364" Position="79.0883,49.6413,9.9675" Rotation="5.716" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1564" Variation="1" Position="39.3281,38.4958,9.999" Rotation="0.642" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1655" Position="127.495,10.6762,11.9873" Scale="1.0131,1.0131,1.0131" Type="TheVoid_RubblePile" Variation="3">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1533" Position="76.3532,13.0725,9.9892" Rotation="4.9665" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2364" Variation="1" Position="79.0883,49.6413,9.9675" Rotation="5.716" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="411" Position="75.6994,24.6994,7.991" Rotation="2.356" Scale="1.5,1.5,1.5" TeamColor="0" Type="Korhal_TarmacSplat" Variation="1">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="1655" Variation="3" Position="127.495,10.6762,11.9873" Scale="1.0131,1.0131,1.0131" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1430" Position="23.0104,10.848,8.4401" Rotation="3.395" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1533" Variation="1" Position="76.3532,13.0725,9.9892" Rotation="4.9665" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2400" Position="151.2583,54.412,7.662" Rotation="4.6696" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="411" Variation="1" Position="75.6994,24.6994,7.991" Rotation="2.356" Scale="1.5,1.5,1.5" Type="Korhal_TarmacSplat" TeamColor="0">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="550" Position="17.8925,35.4255,6.9035" Rotation="1.2333" Scale="1,1,1" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1430" Variation="2" Position="23.0104,10.848,8.4401" Rotation="3.395" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="550" Variation="2" Position="17.8925,35.4255,6.9035" Rotation="1.2333" Scale="1,1,1" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1579" Position="36.969,131.9172,8.0017" Scale="0.9428,0.9428,0.9428" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2400" Variation="1" Position="151.2583,54.412,7.662" Rotation="4.6696" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1579" Variation="3" Position="36.969,131.9172,8.0017" Scale="0.9428,0.9428,0.9428" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1976,29 +1977,29 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1441" Position="18.328,89.1093,10.61" Rotation="5.473" Scale="1.0163,1.0163,1.0163" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1441" Variation="5" Position="18.328,89.1093,10.61" Rotation="5.473" Scale="1.0163,1.0163,1.0163" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1508" Pitch="1.0424" Position="60.0612,81.3952,-0.8122" Rotation="0.8493" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1508" Variation="1" Position="60.0612,81.3952,-0.8122" Rotation="0.8493" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1423" Position="52.005,188.722,9.891" Rotation="0.9816" Scale="0.5998,0.5998,0.5998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1423" Variation="1" Position="52.005,188.722,9.891" Rotation="0.9816" Scale="0.5998,0.5998,0.5998" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1541" Position="86.9357,93.1247,9.7131" Rotation="3.268" Scale="0.4,0.4,0.4" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1541" Variation="1" Position="86.9357,93.1247,9.7131" Rotation="3.268" Scale="0.4,0.4,0.4" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2382" Position="130.202,194.684,11.9814" Rotation="4.0861" Scale="0.9543,0.9543,0.9543" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="2382" Variation="4" Position="130.202,194.684,11.9814" Rotation="4.0861" Scale="0.9543,0.9543,0.9543" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1646" Position="143.2805,15.2431,7.9792" Scale="0.978,0.978,0.978" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1646" Variation="3" Position="143.2805,15.2431,7.9792" Scale="0.978,0.978,0.978" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2008,7 +2009,7 @@
     <ObjectDoodad Id="1582" Position="58.667,77.6513,-0.0126" Rotation="1.973" Scale="1.5,1.5,1.5" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="425" Position="81.4997,30.4997,7.991" Rotation="2.356" Scale="1.5,1.5,1.5" TeamColor="0" Type="Korhal_TarmacSplat" Variation="1">
+    <ObjectDoodad Id="425" Variation="1" Position="81.4997,30.4997,7.991" Rotation="2.356" Scale="1.5,1.5,1.5" Type="Korhal_TarmacSplat" TeamColor="0">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -2016,47 +2017,47 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1487" Position="82.2382,44.3161,9.9873" Rotation="2.6657" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1487" Variation="2" Position="82.2382,44.3161,9.9873" Rotation="2.6657" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1418" Position="54.4714,228.1074,9.8737" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1418" Variation="4" Position="54.4714,228.1074,9.8737" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1505" Pitch="1.0424" Position="67.466,82.518,-0.9162" Rotation="0.3251" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1505" Position="67.466,82.518,-0.9162" Rotation="0.3251" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1643" Position="139,16,7.9875" Rotation="1.0957" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1643" Variation="3" Position="139,16,7.9875" Rotation="1.0957" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1536" Position="77.997,14.9187,7.9814" Rotation="0.729" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1536" Variation="1" Position="77.997,14.9187,7.9814" Rotation="0.729" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2379" Position="126.1496,188.848,11.9797" Rotation="4.352" Scale="0.9536,0.9536,0.9536" Type="Void_CrackSplat" Variation="3">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="525" Position="14.1652,17.9606,2.0075" Rotation="1.2812" Scale="0.955,0.955,0.955" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="525" Variation="1" Position="14.1652,17.9606,2.0075" Rotation="1.2812" Scale="0.955,0.955,0.955" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1469" Position="18.1396,161.6547,7.9875" Rotation="1.009" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2379" Variation="3" Position="126.1496,188.848,11.9797" Rotation="4.352" Scale="0.9536,0.9536,0.9536" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1494" Position="88.358,54.6118,2.61" Rotation="3.8271" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1469" Variation="1" Position="18.1396,161.6547,7.9875" Rotation="1.009" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1494" Variation="1" Position="88.358,54.6118,2.61" Rotation="3.8271" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1628" Position="121,21,11.983" Rotation="5.3273" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1628" Variation="2" Position="121,21,11.983" Rotation="5.3273" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2069,22 +2070,22 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2386" Position="158.5351,37.65,11.7902" Rotation="5.1604" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="532" Position="16.036,22.9687,5.0874" Rotation="1.2812" Scale="0.65,0.65,0.65" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1561" Position="69.6625,28.1562,7.9873" Rotation="5.3791" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="2386" Variation="1" Position="158.5351,37.65,11.7902" Rotation="5.1604" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1427" Position="45.5578,112.8103,11.9877" Rotation="4.6726" Scale="0.9,0.9,0.9" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1561" Variation="4" Position="69.6625,28.1562,7.9873" Rotation="5.3791" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1427" Variation="3" Position="45.5578,112.8103,11.9877" Rotation="4.6726" Scale="0.9,0.9,0.9" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2092,14 +2093,14 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1454" Position="36.0871,114.7492,10.0092" Rotation="0.5646" Scale="0.5998,0.5998,0.5998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1454" Variation="1" Position="36.0871,114.7492,10.0092" Rotation="0.5646" Scale="0.5998,0.5998,0.5998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1477" Position="49.0737,103.9953,10.0817" Scale="1.038,1.038,1.038" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1477" Variation="3" Position="49.0737,103.9953,10.0817" Scale="1.038,1.038,1.038" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1615" Position="103.7211,35.7863,9.1872" Rotation="4.963" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1615" Variation="1" Position="103.7211,35.7863,9.1872" Rotation="4.963" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2108,29 +2109,29 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1633" Position="117.013,39.3581,7.9931" Rotation="0.582" Scale="0.9611,0.9611,0.9611" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1633" Variation="1" Position="117.013,39.3581,7.9931" Rotation="0.582" Scale="0.9611,0.9611,0.9611" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1546" Position="92.4135,99.5705,10.0202" Rotation="0.9455" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1546" Variation="1" Position="92.4135,99.5705,10.0202" Rotation="0.9455" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2369" Position="133.961,161.7197,11.9814" Rotation="1.2822" Scale="0.944,0.944,0.944" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="2369" Variation="2" Position="133.961,161.7197,11.9814" Rotation="1.2822" Scale="0.944,0.944,0.944" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1408" Pitch="1.0424" Position="34.9226,165.5205,3.7873" Rotation="5.8674" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1408" Position="34.9226,165.5205,3.7873" Rotation="5.8674" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1515" Position="71,135.5,9.9692" Rotation="4.8041" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1515" Variation="3" Position="71,135.5,9.9692" Rotation="4.8041" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1622" Position="109.957,41.382,7.996" Rotation="2.5292" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1622" Variation="4" Position="109.957,41.382,7.996" Rotation="2.5292" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2138,12 +2139,12 @@
     <ObjectDoodad Id="1597" Position="37.0266,14.9152,-0.013" Rotation="0.161" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2422" Position="174.5798,58.1198,12.0986" Rotation="1.8916" Scale="0.9,0.9,0.9" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2422" Variation="4" Position="174.5798,58.1198,12.0986" Rotation="1.8916" Scale="0.9,0.9,0.9" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1463" Position="33.319,118.4543,11.9873" Rotation="1.1791" Scale="1.0551,1.0551,1.0551" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="1463" Variation="2" Position="33.319,118.4543,11.9873" Rotation="1.1791" Scale="1.0551,1.0551,1.0551" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2152,21 +2153,21 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1433" Position="34.3801,25.702,7.955" Rotation="1.312" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1433" Variation="2" Position="34.3801,25.702,7.955" Rotation="1.312" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1522" Position="58.3117,20.4211,9.993" Rotation="4.3398" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1522" Variation="1" Position="58.3117,20.4211,9.993" Rotation="4.3398" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1656" Position="128.7238,4.4533,11.9926" Scale="0.94,0.94,0.94" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1656" Variation="1" Position="128.7238,4.4533,11.9926" Scale="0.94,0.94,0.94" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2392" Position="178.1958,61.307,11.9782" Rotation="0.7397" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="2392" Variation="3" Position="178.1958,61.307,11.9782" Rotation="0.7397" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2184,12 +2185,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1619" Pitch="1.0424" Position="116,35,2.1271" Rotation="1.6206" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1619" Variation="1" Position="116,35,2.1271" Rotation="1.6206" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1497" Position="76.6066,67.8054,9.9865" Rotation="4.3232" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1497" Variation="2" Position="76.6066,67.8054,9.9865" Rotation="4.3232" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2211,48 +2212,48 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1558" Position="102.956,110.1147,11.9873" Rotation="1.5173" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1558" Variation="3" Position="102.956,110.1147,11.9873" Rotation="1.5173" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1661" Position="148.3901,43.4682,11.9907" Rotation="1.0397" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1661" Variation="4" Position="148.3901,43.4682,11.9907" Rotation="1.0397" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1472" Position="50.1855,102.543,10.1921" Rotation="4.964" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1472" Variation="1" Position="50.1855,102.543,10.1921" Rotation="4.964" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1451" Position="14.3376,97.9384,10.2121" Rotation="0.6923" Scale="1.075,1.075,1.075" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1451" Variation="3" Position="14.3376,97.9384,10.2121" Rotation="0.6923" Scale="1.075,1.075,1.075" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1569" Position="18.0478,138.3422,7.9873" Rotation="1.9802" Scale="0.9475,0.9475,0.9475" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1569" Variation="2" Position="18.0478,138.3422,7.9873" Rotation="1.9802" Scale="0.9475,0.9475,0.9475" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1610" Position="72.4587,129.8867,-0.013" Rotation="0.1606" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1551" Position="90.017,6.7246,9.9877" Rotation="1.591" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1551" Variation="3" Position="90.017,6.7246,9.9877" Rotation="1.591" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2372" Position="137.484,150.7683,9.9948" Rotation="5.9294" Scale="1.0192,1.0192,1.0192" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="2372" Variation="4" Position="137.484,150.7683,9.9948" Rotation="5.9294" Scale="1.0192,1.0192,1.0192" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1518" Position="40.3535,28.4135,10.0097" Rotation="5.4902" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1518" Variation="2" Position="40.3535,28.4135,10.0097" Rotation="5.4902" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1413" Position="38.0507,181.128,9.9958" Rotation="5.2641" Scale="1.0058,1.0058,1.0058" Type="TheVoid_RockPointy" Variation="4">
+    <ObjectDoodad Id="1413" Variation="4" Position="38.0507,181.128,9.9958" Rotation="5.2641" Scale="1.0058,1.0058,1.0058" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2262,20 +2263,20 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2398" Position="165.0983,47.7145,5.7795" Rotation="1.472" Scale="0.9,0.9,0.9" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="2398" Variation="2" Position="165.0983,47.7145,5.7795" Rotation="1.472" Scale="0.9,0.9,0.9" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1557" Position="57.5354,115.964,7.9916" Scale="0.94,0.94,0.94" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1557" Variation="3" Position="57.5354,115.964,7.9916" Scale="0.94,0.94,0.94" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1439" Position="34.7145,86.1774,10.076" Rotation="4.615" Scale="0.9362,0.9362,0.9362" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1439" Variation="5" Position="34.7145,86.1774,10.076" Rotation="4.615" Scale="0.9362,0.9362,0.9362" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1524" Position="47.146,17.0466,11.9636" Rotation="3.7817" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1524" Variation="2" Position="47.146,17.0466,11.9636" Rotation="3.7817" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2284,11 +2285,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1498" Position="91.8754,53.9157,7.993" Rotation="4.1638" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1498" Variation="1" Position="91.8754,53.9157,7.993" Rotation="4.1638" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1616" Position="116.5,40.5,7.178" Rotation="1.8771" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1616" Variation="2" Position="116.5,40.5,7.178" Rotation="1.8771" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2296,7 +2297,7 @@
     <ObjectDoodad Id="1595" Position="19.9047,128.5466,-0.013" Rotation="0.161" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1414" Position="51.0454,185.2644,7.481" Rotation="0.7204" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1414" Variation="1" Position="51.0454,185.2644,7.481" Rotation="0.7204" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2306,16 +2307,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1639" Position="135,18.5,7.9682" Rotation="3.9401" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1639" Variation="2" Position="135,18.5,7.9682" Rotation="3.9401" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1548" Position="73.3803,12.1875,9.9873" Rotation="2.3916" Scale="1.026,1.026,1.026" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1548" Variation="2" Position="73.3803,12.1875,9.9873" Rotation="2.3916" Scale="1.026,1.026,1.026" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2375" Position="154.893,156.0937,9.9814" Rotation="0.4277" Scale="1.0683,1.0683,1.0683" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2375" Variation="5" Position="154.893,156.0937,9.9814" Rotation="0.4277" Scale="1.0683,1.0683,1.0683" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2323,16 +2324,16 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1570" Position="15.446,148.2072,8.0097" Scale="1.0634,1.0634,1.0634" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1570" Variation="1" Position="15.446,148.2072,8.0097" Scale="1.0634,1.0634,1.0634" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1448" Position="21.5373,87.0256,10.5402" Rotation="6.1003" Scale="0.9914,0.9914,0.9914" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1448" Variation="2" Position="21.5373,87.0256,10.5402" Rotation="6.1003" Scale="0.9914,0.9914,0.9914" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1475" Position="58.298,106.4064,10.104" Rotation="0.7685" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1475" Variation="4" Position="58.298,106.4064,10.104" Rotation="0.7685" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2341,24 +2342,24 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1411" Position="38.823,181.9794,11.8388" Rotation="1.5705" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1411" Variation="4" Position="38.823,181.9794,11.8388" Rotation="1.5705" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1545" Position="86.2885,94.1274,10.0537" Rotation="4.1638" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1545" Variation="1" Position="86.2885,94.1274,10.0537" Rotation="4.1638" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2370" Position="135.4172,153.8735,11.996" Rotation="5.4731" Scale="1.0344,1.0344,1.0344" Type="Void_CrackSplat" Variation="1">
+    <ObjectDoodad Id="2370" Variation="1" Position="135.4172,153.8735,11.996" Rotation="5.4731" Scale="1.0344,1.0344,1.0344" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1634" Position="114.4755,22.0053,11.9758" Scale="1.0927,1.0927,1.0927" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1634" Variation="3" Position="114.4755,22.0053,11.9758" Scale="1.0927,1.0927,1.0927" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1575" Position="29.4245,164.6767,7.9973" Scale="0.936,0.936,0.936" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1575" Variation="1" Position="29.4245,164.6767,7.9973" Scale="0.936,0.936,0.936" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2369,7 +2370,7 @@
     <ObjectDoodad Id="1478" Position="50.23,99.9924,10.0932" Rotation="5.2038" Scale="0.9521,0.9521,0.9521" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1453" Position="33.95,114.46,10.0024" Rotation="3.6237" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1453" Variation="2" Position="33.95,114.46,10.0024" Rotation="3.6237" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2378,22 +2379,22 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1552" Position="96.2531,11.7158,9.9877" Rotation="0.2592" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1552" Variation="4" Position="96.2531,11.7158,9.9877" Rotation="0.2592" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1659" Position="150,17,11.994" Rotation="5.5166" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1659" Variation="3" Position="150,17,11.994" Rotation="5.5166" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1521" Position="56.3586,21.2463,9.9877" Rotation="6.0402" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1521" Variation="4" Position="56.3586,21.2463,9.9877" Rotation="6.0402" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1434" Position="17.3093,34.7961,8.3593" Rotation="1.312" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1434" Variation="2" Position="17.3093,34.7961,8.3593" Rotation="1.312" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2401,7 +2402,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1460" Position="34.69,86.6237,10.014" Rotation="5.9567" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1460" Variation="1" Position="34.69,86.6237,10.014" Rotation="5.9567" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2413,7 +2414,7 @@
     <ObjectDoodad Id="1598" Position="10.2167,10.625,-0.013" Rotation="0.161" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2421" Position="170.0971,53.2766,12.1943" Rotation="0.5292" Scale="1.0786,1.0786,1.0786" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="2421" Variation="2" Position="170.0971,53.2766,12.1943" Rotation="0.5292" Scale="1.0786,1.0786,1.0786" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2423,39 +2424,39 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1539" Position="66.5,126,8.0031" Rotation="0.0246" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1539" Variation="1" Position="66.5,126,8.0031" Rotation="0.0246" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="526" Position="15.8513,22.5317,8.1723" Rotation="1.4667" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="2376" Variation="3" Position="150.4025,170.259,9.9814" Rotation="4.1958" Scale="1.004,1.004,1.004" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2376" Position="150.4025,170.259,9.9814" Rotation="4.1958" Scale="1.004,1.004,1.004" Type="Void_CrackSplat" Variation="3">
+    <ObjectDoodad Id="526" Variation="2" Position="15.8513,22.5317,8.1723" Rotation="1.4667" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1640" Position="129,17.5,7.979" Rotation="2.9177" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1640" Variation="4" Position="129,17.5,7.979" Rotation="2.9177" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1506" Position="63.8972,87.3952,9.962" Rotation="0.647" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1506" Variation="1" Position="63.8972,87.3952,9.962" Rotation="0.647" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1417" Position="52.2377,226.8947,10.0051" Rotation="0.3486" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1417" Variation="1" Position="52.2377,226.8947,10.0051" Rotation="0.3486" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1484" Position="53.9284,109.076,9.9814" Rotation="4.9643" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1484" Variation="1" Position="53.9284,109.076,9.9814" Rotation="4.9643" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="426" Position="83.4997,22.4997,7.991" Rotation="3.9267" Scale="1.5,1.5,1.5" TeamColor="0" Type="Korhal_TarmacSplat">
+    <ObjectDoodad Id="426" Position="83.4997,22.4997,7.991" Rotation="3.9267" Scale="1.5,1.5,1.5" Type="Korhal_TarmacSplat" TeamColor="0">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -2463,7 +2464,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1581" Position="33.988,134.8586,7.9931" Scale="1.0412,1.0412,1.0412" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1581" Variation="2" Position="33.988,134.8586,7.9931" Scale="1.0412,1.0412,1.0412" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2475,26 +2476,26 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="413" Position="90.4997,21.4997,7.991" Rotation="2.356" Scale="1.5,1.5,1.5" TeamColor="0" Type="Korhal_TarmacSplat" Variation="1">
+    <ObjectDoodad Id="413" Variation="1" Position="90.4997,21.4997,7.991" Rotation="2.356" Scale="1.5,1.5,1.5" Type="Korhal_TarmacSplat" TeamColor="0">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1424" Pitch="1.0424" Position="67.1435,236.3618,-0.9123" Rotation="5.8671" Scale="1,1,1" Type="Void_Cliff_Rocks">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2385" Position="153.8664,43.1037,11.9904" Rotation="1.2861" Scale="1.0786,1.0786,1.0786" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1424" Position="67.1435,236.3618,-0.9123" Rotation="5.8671" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1562" Position="70.4602,27.1665,7.9814" Rotation="5.379" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2385" Variation="1" Position="153.8664,43.1037,11.9904" Rotation="1.2861" Scale="1.0786,1.0786,1.0786" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1649" Position="126.7,17.7,8.004" Scale="0.9323,0.9323,0.9323" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1562" Variation="1" Position="70.4602,27.1665,7.9814" Rotation="5.379" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1649" Variation="3" Position="126.7,17.7,8.004" Scale="0.9323,0.9323,0.9323" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2506,40 +2507,40 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1493" Position="86.8977,45.562,7.9291" Rotation="0.9216" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1493" Variation="2" Position="86.8977,45.562,7.9291" Rotation="0.9216" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1470" Position="15.252,158.4294,7.992" Rotation="1.4665" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1470" Variation="4" Position="15.252,158.4294,7.992" Rotation="1.4665" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1429" Position="24.7355,52.311,7.9875" Rotation="1.0764" Scale="0.9177,0.9177,0.9177" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="1429" Variation="2" Position="24.7355,52.311,7.9875" Rotation="1.0764" Scale="0.9177,0.9177,0.9177" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1534" Position="73.9526,17.5734,9.9873" Rotation="0.1665" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1534" Variation="2" Position="73.9526,17.5734,9.9873" Rotation="0.1665" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1652" Position="128,13,11.993" Rotation="0.0773" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1652" Variation="2" Position="128,13,11.993" Rotation="0.0773" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2388" Position="150.871,38.7956,11.9873" Rotation="1.769" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="530" Variation="1" Position="23,10.5,8.3457" Rotation="3.4663" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2388" Variation="1" Position="150.871,38.7956,11.9873" Rotation="1.769" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="530" Position="23,10.5,8.3457" Rotation="3.4663" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1567" Variation="1" Position="25.622,133.9792,8.0097" Scale="1.016,1.016,1.016" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1567" Position="25.622,133.9792,8.0097" Scale="1.016,1.016,1.016" Type="TheVoid_RubblePile" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1626" Position="119.447,21.996,11.9873" Rotation="6.096" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1626" Variation="1" Position="119.447,21.996,11.9873" Rotation="6.096" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2548,34 +2549,30 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2426" Position="174.9753,43.004,9.7893" Rotation="1.8916" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2426" Variation="4" Position="174.9753,43.004,9.7893" Rotation="1.8916" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1467" Position="23.984,134.6376,7.9875" Rotation="1.009" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1467" Variation="1" Position="23.984,134.6376,7.9875" Rotation="1.009" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="438" Position="55.4492,197.5803,9.9875" Rotation="2.5764" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="438" Variation="1" Position="55.4492,197.5803,9.9875" Rotation="2.5764" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1488" Position="83.4052,45.4924,9.9877" Rotation="5.4287" Scale="1.0644,1.0644,1.0644" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1488" Variation="4" Position="83.4052,45.4924,9.9877" Rotation="5.4287" Scale="1.0644,1.0644,1.0644" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1645" Position="137,17,7.9965" Scale="1.0927,1.0927,1.0927" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1645" Variation="3" Position="137,17,7.9965" Scale="1.0927,1.0927,1.0927" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1542" Position="92.8322,98.2258,9.715" Rotation="4.7697" Scale="0.4,0.4,0.4" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1542" Variation="1" Position="92.8322,98.2258,9.715" Rotation="4.7697" Scale="0.4,0.4,0.4" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2381" Position="132.3173,191.9833,11.9912" Rotation="2.3203" Scale="0.9487,0.9487,0.9487" Type="Void_CrackSplat" Variation="3">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2584,16 +2581,20 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="2381" Variation="3" Position="132.3173,191.9833,11.9912" Rotation="2.3203" Scale="0.9487,0.9487,0.9487" Type="Void_CrackSplat">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="1420" Position="51.3037,226.0734,5.778" Rotation="0.4411" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1511" Position="57.6237,78.243,0.0051" Rotation="4.2705" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1511" Variation="2" Position="57.6237,78.243,0.0051" Rotation="4.2705" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1442" Position="29.8994,87.4916,10.175" Rotation="0.2634" Scale="0.901,0.901,0.901" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1442" Variation="5" Position="29.8994,87.4916,10.175" Rotation="0.2634" Scale="0.901,0.901,0.901" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2608,7 +2609,7 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1576" Position="36.7211,157.8991,8" Scale="0.9458,0.9458,0.9458" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1576" Variation="1" Position="36.7211,157.8991,8" Scale="0.9458,0.9458,0.9458" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2625,17 +2626,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1618" Pitch="1.0424" Position="107.5,42,1.9272" Rotation="0.3247" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1618" Variation="2" Position="107.5,42,1.9272" Rotation="0.3247" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1559" Position="66.6416,124.6992,7.984" Scale="0.9328,0.9328,0.9328" Type="TheVoid_RubblePile" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2396" Position="176.8837,60.9555,12.03" Rotation="1.2861" Scale="1.0786,1.0786,1.0786" Type="TheVoid_RubblePile" Variation="1">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="1559" Variation="1" Position="66.6416,124.6992,7.984" Scale="0.9328,0.9328,0.9328" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2644,7 +2640,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1660" Position="154.5,29.5,11.9875" Rotation="0.273" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="2396" Variation="1" Position="176.8837,60.9555,12.03" Rotation="1.2861" Scale="1.0786,1.0786,1.0786" Type="TheVoid_RubblePile">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1660" Variation="3" Position="154.5,29.5,11.9875" Rotation="0.273" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2654,11 +2655,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1437" Position="37.4445,82.1257,9.977" Rotation="2.3381" Scale="0.984,0.984,0.984" Type="Void_CrackSplat" Variation="1">
+    <ObjectDoodad Id="1437" Variation="1" Position="37.4445,82.1257,9.977" Rotation="2.3381" Scale="0.984,0.984,0.984" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1568" Position="35.7724,127.3994,9.987" Scale="0.9323,0.9323,0.9323" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1568" Variation="1" Position="35.7724,127.3994,9.987" Scale="0.9323,0.9323,0.9323" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2666,7 +2667,7 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1473" Position="47.811,108.3532,9.997" Rotation="0.0212" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1473" Variation="1" Position="47.811,108.3532,9.997" Rotation="0.0212" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2674,17 +2675,17 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1519" Position="38.05,26.3962,11.9782" Rotation="0.1232" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1519" Variation="1" Position="38.05,26.3962,11.9782" Rotation="0.1232" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1412" Position="39.7287,183.0825,11.9821" Rotation="5.2641" Scale="1.0058,1.0058,1.0058" Type="TheVoid_RockPointy" Variation="1">
+    <ObjectDoodad Id="1412" Variation="1" Position="39.7287,183.0825,11.9821" Rotation="5.2641" Scale="1.0058,1.0058,1.0058" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2373" Position="145.8974,142.9985,9.9772" Rotation="6.1582" Scale="0.9372,0.9372,0.9372" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2373" Variation="5" Position="145.8974,142.9985,9.9772" Rotation="6.1582" Scale="0.9372,0.9372,0.9372" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2693,7 +2694,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1614" Position="107.3464,31.912,5.646" Rotation="5.2814" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1614" Variation="2" Position="107.3464,31.912,5.646" Rotation="5.2814" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2701,49 +2702,49 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1455" Position="31.3894,113.5498,9.9873" Rotation="2.016" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1455" Variation="2" Position="31.3894,113.5498,9.9873" Rotation="2.016" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1476" Position="57.8674,104.067,10.0034" Rotation="0.727" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1476" Variation="1" Position="57.8674,104.067,10.0034" Rotation="0.727" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1409" Pitch="5.934" Position="42.0097,183.14,11.499" Rotation="0.7202" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1409" Position="42.0097,183.14,11.499" Rotation="0.7202" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="5.934">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1514" Position="78.5087,68.1794,7.987" Rotation="0.3085" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1514" Variation="1" Position="78.5087,68.1794,7.987" Rotation="0.3085" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1632" Position="111.2832,41.1018,7.9931" Rotation="5.472" Scale="0.9802,0.9802,0.9802" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1632" Variation="3" Position="111.2832,41.1018,7.9931" Rotation="5.472" Scale="0.9802,0.9802,0.9802" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2368" Position="134.2011,157.0302,11.9826" Rotation="3.9553" Scale="1.0117,1.0117,1.0117" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2368" Variation="5" Position="134.2011,157.0302,11.9826" Rotation="3.9553" Scale="1.0117,1.0117,1.0117" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1547" Position="80.0576,8.4826,9.9873" Scale="1.0346,1.0346,1.0346" Type="TheVoid_RubblePile" Variation="3">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1462" Position="40.0004,117.7043,11.9873" Rotation="1.0292" Scale="0.93,0.93,0.93" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1547" Variation="3" Position="80.0576,8.4826,9.9873" Scale="1.0346,1.0346,1.0346" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1501" Position="75.5,126,9.9873" Rotation="0.8215" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1462" Variation="5" Position="40.0004,117.7043,11.9873" Rotation="1.0292" Scale="0.93,0.93,0.93" Type="Void_CrackSplat">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1501" Variation="2" Position="75.5,126,9.9873" Rotation="0.8215" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1623" Position="108.6323,42.8085,7.9987" Rotation="3.6408" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1623" Variation="1" Position="108.6323,42.8085,7.9987" Rotation="3.6408" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2423" Position="165.7861,72.0356,11.8884" Rotation="1.8918" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="2423" Variation="1" Position="165.7861,72.0356,11.8884" Rotation="1.8918" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2751,12 +2752,12 @@
     <ObjectDoodad Id="1596" Position="23.5688,6.0512,-0.013" Rotation="0.161" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1657" Position="123.5,20,7.9875" Rotation="5.618" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1657" Variation="2" Position="123.5,20,7.9875" Rotation="5.618" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1554" Position="54.7724,20.8508,9.9873" Rotation="2.1977" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1554" Variation="2" Position="54.7724,20.8508,9.9873" Rotation="2.1977" Scale="0.9655,0.9655,0.9655" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2771,15 +2772,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1523" Position="54.3984,22.0502,9.9873" Rotation="0.733" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1523" Variation="2" Position="54.3984,22.0502,9.9873" Rotation="0.733" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1445" Position="35.845,75.76,9.9973" Rotation="1.699" Scale="0.9914,0.9914,0.9914" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1445" Variation="1" Position="35.845,75.76,9.9973" Rotation="1.699" Scale="0.9914,0.9914,0.9914" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1486" Position="76.863,47.5964,9.9873" Scale="0.9013,0.9013,0.9013" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1486" Variation="3" Position="76.863,47.5964,9.9873" Scale="0.9013,0.9013,0.9013" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2789,43 +2790,43 @@
     <ObjectDoodad Id="1583" Position="65.9543,80.425,-0.0126" Rotation="1.9726" Scale="1.5,1.5,1.5" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1642" Position="143,14.5,7.754" Rotation="3.365" Scale="0.45,0.45,0.45" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1642" Variation="2" Position="143,14.5,7.754" Rotation="3.365" Scale="0.45,0.45,0.45" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2378" Position="123.9277,181.7951,11.9826" Rotation="4.133" Scale="0.9267,0.9267,0.9267" Type="Void_CrackSplat" Variation="5">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="524" Position="14.6496,14.4565,8.4265" Rotation="2.0554" Scale="0.955,0.955,0.955" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1537" Position="85.256,86.2565,9.9873" Rotation="4.1638" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="2378" Variation="5" Position="123.9277,181.7951,11.9826" Rotation="4.133" Scale="0.9267,0.9267,0.9267" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1419" Position="43.8071,217.9711,9.893" Rotation="1.5705" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1537" Variation="2" Position="85.256,86.2565,9.9873" Rotation="4.1638" Scale="1.0998,1.0998,1.0998" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1419" Variation="4" Position="43.8071,217.9711,9.893" Rotation="1.5705" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="493" Position="171.1081,122.9743,11.9841" Scale="0.7,0.7,0.7" Type="Void_Temple_Destroyed" Variation="3">
+    <ObjectDoodad Id="493" Variation="3" Position="171.1081,122.9743,11.9841" Scale="0.7,0.7,0.7" Type="Void_Temple_Destroyed">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1504" Position="70.5275,77.1538,11.9736" Scale="0.9,0.9,0.9" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1504" Variation="1" Position="70.5275,77.1538,11.9736" Scale="0.9,0.9,0.9" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1629" Position="107.5205,27.9792,11.9873" Scale="1.0361,1.0361,1.0361" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1629" Variation="3" Position="107.5205,27.9792,11.9873" Scale="1.0361,1.0361,1.0361" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1590" Position="94.277,111.408,-0.013" Rotation="0.161" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1468" Position="15.6984,147.6728,7.994" Rotation="1.009" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1468" Variation="1" Position="15.6984,147.6728,7.994" Rotation="1.009" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2835,11 +2836,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1495" Position="91.5075,48.705,7.9948" Rotation="0.0905" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1495" Variation="2" Position="91.5075,48.705,7.9948" Rotation="0.0905" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1426" Pitch="1.0424" Position="72.4863,235.3906,-0.9123" Rotation="5.9758" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1426" Variation="1" Position="72.4863,235.3906,-0.9123" Rotation="5.9758" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2847,7 +2848,7 @@
     <ObjectDoodad Id="415" Position="39.9362,27.8112,9.97" Rotation="5.6682" Scale="1.0947,1.0947,1.0947" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1529" Position="41.7988,44.9091,7.9907" Rotation="5.1855" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1529" Variation="1" Position="41.7988,44.9091,7.9907" Rotation="5.1855" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2857,16 +2858,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1651" Position="128.593,11.3674,11.99" Rotation="4.874" Scale="0.5,0.5,0.5" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1651" Variation="1" Position="128.593,11.3674,11.99" Rotation="4.874" Scale="0.5,0.5,0.5" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1560" Position="64.2736,27.1318,7.9921" Rotation="0.1662" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2387" Position="158.4011,40.4743,11.979" Rotation="5.0341" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1560" Variation="2" Position="64.2736,27.1318,7.9921" Rotation="0.1662" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2876,7 +2872,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2424" Position="155.4072,64.5842,9.7863" Rotation="1.8918" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2387" Variation="4" Position="158.4011,40.4743,11.979" Rotation="5.0341" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2424" Variation="4" Position="155.4072,64.5842,9.7863" Rotation="1.8918" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2885,42 +2886,42 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1624" Position="116.5,40.5,7.978" Rotation="0.4416" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1624" Variation="1" Position="116.5,40.5,7.978" Rotation="0.4416" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1490" Position="80.0671,47.7392,9.9877" Rotation="2.2446" Scale="0.5498,0.5498,0.5498" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="1490" Variation="1" Position="80.0671,47.7392,9.9877" Rotation="2.2446" Scale="0.5498,0.5498,0.5498" Type="TheVoid_GroundScar">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="436" Pitch="5.934" Position="47.38,203.8398,8.1958" Rotation="1.9411" Scale="1.25,1.25,1.25" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="436" Variation="2" Position="47.38,203.8398,8.1958" Rotation="1.9411" Scale="1.25,1.25,1.25" Type="Void_Cliff_Rocks" Pitch="5.934">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1465" Position="19.8183,136.3393,7.988" Rotation="1.009" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="3">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1532" Position="74.3098,15.02,10.0002" Rotation="5.558" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1465" Variation="3" Position="19.8183,136.3393,7.988" Rotation="1.009" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1431" Position="15.324,19.212,8.2521" Rotation="1.312" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1565" Position="78.7861,234.0544,11.9853" Rotation="4.5998" Scale="1,1,1" Type="Void_Temple" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2390" Position="168.38,57.0031,9.9904" Rotation="0.8776" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1532" Variation="4" Position="74.3098,15.02,10.0002" Rotation="5.558" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="528" Position="59.955,84.4028,9.9868" Rotation="3.8801" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1431" Variation="2" Position="15.324,19.212,8.2521" Rotation="1.312" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1565" Variation="1" Position="78.7861,234.0544,11.9853" Rotation="4.5998" Scale="1,1,1" Type="Void_Temple">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="528" Variation="3" Position="59.955,84.4028,9.9868" Rotation="3.8801" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2390" Variation="2" Position="168.38,57.0031,9.9904" Rotation="0.8776" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2935,15 +2936,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1483" Position="56.1633,101.709,10.5192" Rotation="4.964" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1483" Variation="1" Position="56.1633,101.709,10.5192" Rotation="4.964" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1440" Position="16.3283,99.6323,10.2607" Rotation="3.4182" Scale="1.043,1.043,1.043" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="1440" Variation="2" Position="16.3283,99.6323,10.2607" Rotation="3.4182" Scale="1.043,1.043,1.043" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1578" Position="34.208,159.408,7.9873" Scale="0.9941,0.9941,0.9941" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1578" Variation="3" Position="34.208,159.408,7.9873" Scale="0.9941,0.9941,0.9941" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2955,20 +2956,20 @@
     <ObjectDoodad Id="1601" Position="86.3974,150.55,-0.013" Rotation="0.161" Scale="2,2,2" Type="LightOmniRedLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2383" Position="127.6911,197.1196,11.99" Rotation="6.1972" Scale="0.9194,0.9194,0.9194" Type="Void_CrackSplat" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="521" Position="43.696,212.6027,10.0654" Rotation="1.435" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="521" Variation="1" Position="43.696,212.6027,10.0654" Rotation="1.435" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1540" Position="80.93,88.345,11.9873" Rotation="4.1638" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2383" Variation="2" Position="127.6911,197.1196,11.99" Rotation="6.1972" Scale="0.9194,0.9194,0.9194" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1647" Position="146.143,17.2016,8.0097" Scale="1.0031,1.0031,1.0031" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1540" Variation="1" Position="80.93,88.345,11.9873" Rotation="4.1638" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1647" Variation="2" Position="146.143,17.2016,8.0097" Scale="1.0031,1.0031,1.0031" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -2977,17 +2978,17 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1509" Pitch="0.588" Position="59.1567,86.2263,4.3872" Rotation="3.1774" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1509" Variation="1" Position="59.1567,86.2263,4.3872" Rotation="3.1774" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="0.588">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1422" Position="47.0166,184.2614,9.897" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1422" Variation="1" Position="47.0166,184.2614,9.897" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1343" Position="20.01,44.5798,7.988" Rotation="0.5634" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1343" Variation="5" Position="20.01,44.5798,7.988" Rotation="0.5634" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -2997,15 +2998,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1758" Position="108,114,11.9887" Rotation="4.7814" Scale="0.65,0.65,0.65" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1758" Variation="1" Position="108,114,11.9887" Rotation="4.7814" Scale="0.65,0.65,0.65" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1717" Position="157,127.5,7.9965" Rotation="5.553" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1717" Variation="1" Position="157,127.5,7.9965" Rotation="5.553" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1776" Position="82.5722,89.311,12.0021" Rotation="4.7783" Scale="1.0297,1.0297,1.0297" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1776" Variation="4" Position="82.5722,89.311,12.0021" Rotation="4.7783" Scale="1.0297,1.0297,1.0297" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3013,32 +3014,32 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1297" Position="31.874,36.592,7.9743" Rotation="3.9064" Scale="0.976,0.976,0.976" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="1297" Variation="2" Position="31.874,36.592,7.9743" Rotation="3.9064" Scale="0.976,0.976,0.976" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1402" Position="39.25,170.7897,11.9873" Rotation="0.3432" Scale="0.7998,0.7998,0.7998" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="1402" Variation="1" Position="39.25,170.7897,11.9873" Rotation="0.3432" Scale="0.7998,0.7998,0.7998" Type="TheVoid_GroundScar">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1735" Position="93.3781,115.298,9.984" Rotation="0.9453" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1708" Position="139.8232,104.257,7.9873" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1318" Position="23.1777,86.0998,3.982" Rotation="2.389" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1735" Variation="1" Position="93.3781,115.298,9.984" Rotation="0.9453" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1357" Position="18.747,45.0004,7.9875" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1708" Variation="1" Position="139.8232,104.257,7.9873" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1379" Position="15.6496,149.3581,6.284" Rotation="1.7072" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1318" Variation="1" Position="23.1777,86.0998,3.982" Rotation="2.389" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1357" Variation="1" Position="18.747,45.0004,7.9875" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1379" Variation="2" Position="15.6496,149.3581,6.284" Rotation="1.7072" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3047,19 +3048,19 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1666" Position="154.5205,27.3444,11.9873" Rotation="4.9562" Scale="1.046,1.046,1.046" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1666" Variation="1" Position="154.5205,27.3444,11.9873" Rotation="4.9562" Scale="1.046,1.046,1.046" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="655" Pitch="6.0212" Position="70.0698,216.24,9.5607" Rotation="0.2453" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="655" Position="70.0698,216.24,9.5607" Rotation="0.2453" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="6.0212">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1705" Position="138.334,92.4975,7.997" Scale="1.0563,1.0563,1.0563" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1705" Variation="3" Position="138.334,92.4975,7.997" Scale="1.0563,1.0563,1.0563" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1730" Position="44.288,214.2023,10.6286" Rotation="4.0974" Scale="0.9465,0.9465,0.9465" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1730" Variation="5" Position="44.288,214.2023,10.6286" Rotation="4.0974" Scale="0.9465,0.9465,0.9465" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3067,16 +3068,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1315" Position="34.8598,66.5297,8.0761" Rotation="4.7617" Scale="1,1,1" TintColor="NULL 1.250000" Type="TheVoid_RockPointy" Variation="1">
+    <ObjectDoodad Id="1315" Variation="1" Position="34.8598,66.5297,8.0761" Rotation="4.7617" Scale="1,1,1" Type="TheVoid_RockPointy" TintColor="NULL 1.250000">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1382" Position="18.9094,163.1623,7.7014" Rotation="0.4643" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1382" Variation="1" Position="18.9094,163.1623,7.7014" Rotation="0.4643" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1293" Position="38.9584,24.4045,11.9663" Rotation="3.782" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1293" Variation="1" Position="38.9584,24.4045,11.9663" Rotation="3.782" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3085,22 +3086,22 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1772" Position="99.5,111,11.987" Rotation="1.1855" Scale="0.939,0.939,0.939" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1772" Variation="5" Position="99.5,111,11.987" Rotation="1.1855" Scale="0.939,0.939,0.939" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1361" Position="30.7045,87.8386,10.1381" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1361" Variation="1" Position="30.7045,87.8386,10.1381" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1338" Position="42.3012,68.1914,9.9885" Rotation="0.5637" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1338" Variation="4" Position="42.3012,68.1914,9.9885" Rotation="0.5637" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1712" Position="154,131.5,7.961" Rotation="5.5532" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1712" Variation="2" Position="154,131.5,7.961" Rotation="5.5532" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1755" Position="123.5,122,11.971" Rotation="1.1015" Scale="0.8498,0.8498,0.8498" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1755" Variation="3" Position="123.5,122,11.971" Rotation="1.1015" Scale="0.8498,0.8498,0.8498" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3108,7 +3109,7 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1781" Position="139.7373,54.5017,7.987" Rotation="0.2031" Scale="0.9624,0.9624,0.9624" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1781" Variation="5" Position="139.7373,54.5017,7.987" Rotation="0.2031" Scale="0.9624,0.9624,0.9624" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3117,7 +3118,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1300" Pitch="6.1086" Position="35.96,76.5197,9.9892" Rotation="1.1176" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1300" Position="35.96,76.5197,9.9892" Rotation="1.1176" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Pitch="6.1086">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3136,12 +3137,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1736" Position="98.3127,116.5178,12.0026" Rotation="0.9453" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1736" Variation="1" Position="98.3127,116.5178,12.0026" Rotation="0.9453" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1677" Position="132.145,51.8732,7.98" Scale="0.9946,0.9946,0.9946" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1677" Variation="1" Position="132.145,51.8732,7.98" Scale="0.9946,0.9946,0.9946" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3149,25 +3150,25 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1388" Position="40.5158,154.8737,7.905" Rotation="0.1977" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1388" Variation="3" Position="40.5158,154.8737,7.905" Rotation="0.1977" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1722" Position="151.5,141.5,12.0012" Rotation="4.3198" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1722" Variation="2" Position="151.5,141.5,12.0012" Rotation="4.3198" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="695" Position="34.5,18,3.2583" Rotation="4.0253" Scale="0.65,0.65,0.65" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="695" Variation="1" Position="34.5,18,3.2583" Rotation="4.0253" Scale="0.65,0.65,0.65" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1745" Position="99,105.5,11.9873" Rotation="3.2253" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1745" Variation="2" Position="99,105.5,11.9873" Rotation="3.2253" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1371" Position="66.2011,69.0634,9.8137" Rotation="5.6171" Scale="0.9091,0.9091,0.9091" Type="TheVoid_RockPointy" Variation="2">
+    <ObjectDoodad Id="1371" Variation="2" Position="66.2011,69.0634,9.8137" Rotation="5.6171" Scale="0.9091,0.9091,0.9091" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3181,7 +3182,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1310" Pitch="6.1086" Position="20.75,88.67,10.0051" Rotation="2.7692" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1310" Position="20.75,88.67,10.0051" Rotation="2.7692" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="6.1086">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3190,34 +3191,34 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1791" Position="131.3552,74.5646,9.987" Scale="1.0368,1.0368,1.0368" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1791" Variation="1" Position="131.3552,74.5646,9.987" Scale="1.0368,1.0368,1.0368" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1748" Position="115,122.5,9.9985" Rotation="5.6765" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1748" Variation="2" Position="115,122.5,9.9985" Rotation="5.6765" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1727" Position="145.5,142.5,9.9858" Rotation="6.2348" Scale="0.5,0.5,0.5" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1727" Variation="1" Position="145.5,142.5,9.9858" Rotation="6.2348" Scale="0.5,0.5,0.5" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1333" Pitch="5.934" Position="34.71,125.0698,9.99" Rotation="1.4401" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1333" Variation="2" Position="34.71,125.0698,9.99" Rotation="1.4401" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="5.934">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1374" Position="33.4055,134.5114,7.0832" Rotation="2.7546" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1374" Variation="1" Position="33.4055,134.5114,7.0832" Rotation="2.7546" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1307" Position="32.2966,61.121,8.0314" Rotation="0.844" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1307" Variation="1" Position="32.2966,61.121,8.0314" Rotation="0.844" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1392" Position="144.7243,137.737,7.9875" Scale="1.0722,1.0722,1.0722" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1392" Variation="1" Position="144.7243,137.737,7.9875" Scale="1.0722,1.0722,1.0722" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3230,11 +3231,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1324" Position="170.4934,44.995,11.968" Rotation="2.6787" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="1">
+    <ObjectDoodad Id="1324" Variation="1" Position="170.4934,44.995,11.968" Rotation="2.6787" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1351" Position="33.6853,42.0463,7.9875" Rotation="1.75" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1351" Variation="1" Position="33.6853,42.0463,7.9875" Rotation="1.75" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3242,7 +3243,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1702" Position="133.6735,99.2133,8.0117" Rotation="1.2304" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1702" Variation="1" Position="133.6735,99.2133,8.0117" Rotation="1.2304" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3255,7 +3256,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1385" Pitch="1.3044" Position="37.889,164.65,1.0871" Rotation="5.8671" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1385" Variation="1" Position="37.889,164.65,1.0871" Rotation="5.8671" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="1.3044">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3264,38 +3265,38 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1778" Position="103.9602,33.6726,9.987" Rotation="0.6064" Scale="1.0788,1.0788,1.0788" Type="Void_CrackSplat" Variation="1">
+    <ObjectDoodad Id="1778" Variation="1" Position="103.9602,33.6726,9.987" Rotation="0.6064" Scale="1.0788,1.0788,1.0788" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1400" Position="33.5053,171.9582,11.8808" Rotation="1.5317" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1400" Variation="4" Position="33.5053,171.9582,11.8808" Rotation="1.5317" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1299" Position="44.6083,64.8132,9.9611" Rotation="1.8308" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1299" Variation="4" Position="44.6083,64.8132,9.9611" Rotation="1.8308" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1366" Position="71.75,73.4597,11.987" Rotation="4.164" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1341" Position="26.033,55.7211,7.991" Rotation="0.209" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1341" Variation="5" Position="26.033,55.7211,7.991" Rotation="0.209" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1719" Position="157.1672,147.73,7.987" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="1719" Variation="1" Position="157.1672,147.73,7.987" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1756" Position="117.5,113.5,8.2104" Rotation="5.6765" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1756" Variation="1" Position="117.5,113.5,8.2104" Rotation="5.6765" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1377" Position="17.1923,139.9045,6.2873" Rotation="1.6013" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1377" Variation="2" Position="17.1923,139.9045,6.2873" Rotation="1.6013" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3305,7 +3306,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="653" Position="58.5187,229.5644,9.8134" Rotation="0.3813" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="653" Variation="4" Position="58.5187,229.5644,9.8134" Rotation="0.3813" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3314,38 +3315,38 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1771" Position="98.5,107.5,11.9897" Rotation="0.2226" Scale="0.9643,0.9643,0.9643" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1771" Variation="4" Position="98.5,107.5,11.9897" Rotation="0.2226" Scale="0.9643,0.9643,0.9643" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1710" Position="144,96,11.9873" Rotation="4.6313" Scale="0.913,0.913,0.913" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1710" Variation="2" Position="144,96,11.9873" Rotation="4.6313" Scale="0.913,0.913,0.913" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1733" Position="91.7368,112.929,10.0007" Rotation="3.6618" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1733" Variation="4" Position="91.7368,112.929,10.0007" Rotation="3.6618" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1359" Position="37.563,47.658,7.9941" Rotation="1.6315" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1359" Variation="5" Position="37.563,47.658,7.9941" Rotation="1.6315" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1316" Position="28.2084,86.712,10.198" Rotation="1.6545" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1316" Variation="3" Position="28.2084,86.712,10.198" Rotation="1.6545" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1295" Position="25.313,60.179,11.788" Rotation="3.003" Scale="0.5,0.5,0.5" Type="TheVoid_RockPointy" Variation="1">
+    <ObjectDoodad Id="1295" Variation="1" Position="25.313,60.179,11.788" Rotation="3.003" Scale="0.5,0.5,0.5" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1380" Position="15.6064,158.2175,6.294" Rotation="1.0917" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1380" Variation="1" Position="15.6064,158.2175,6.294" Rotation="1.0917" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1774" Position="114.1826,109.828,8.015" Rotation="3.185" Scale="1.0456,1.0456,1.0456" Type="Void_CrackSplat" Variation="4">
+    <ObjectDoodad Id="1774" Variation="4" Position="114.1826,109.828,8.015" Rotation="3.185" Scale="1.0456,1.0456,1.0456" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1669" Pitch="1.3256" Position="137.5,52,-0.9125" Rotation="0.0522" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1669" Variation="1" Position="137.5,52,-0.9125" Rotation="0.0522" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.3256">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3355,11 +3356,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1707" Position="134.374,100.6904,7.9763" Scale="0.9074,0.9074,0.9074" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1707" Variation="1" Position="134.374,100.6904,7.9763" Scale="0.9074,0.9074,0.9074" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1313" Position="53.0273,74.1118,9.9868" Rotation="1.8308" Scale="0.7597,0.7597,0.7597" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1313" Variation="1" Position="53.0273,74.1118,9.9868" Rotation="1.8308" Scale="0.7597,0.7597,0.7597" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1354" Position="17.0375,55.4294,11.9877" Rotation="4.6726" Scale="1,1,1" Type="TheVoid_RubblePile">
@@ -3375,16 +3376,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1302" Position="32.9692,74.327,9.9455" Rotation="6.2341" Scale="1,1,1" Type="TheVoid_RockPointy" Variation="4">
+    <ObjectDoodad Id="1302" Variation="4" Position="32.9692,74.327,9.9455" Rotation="6.2341" Scale="1,1,1" Type="TheVoid_RockPointy">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1405" Position="38.2097,174.5007,11.8872" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1405" Variation="1" Position="38.2097,174.5007,11.8872" Rotation="5.8762" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1336" Position="43.97,113.8198,12.003" Rotation="0.6174" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1336" Variation="3" Position="43.97,113.8198,12.003" Rotation="0.6174" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3393,24 +3394,24 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1753" Position="117.5,119.5,12.0017" Rotation="1.1018" Scale="0.8498,0.8498,0.8498" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1753" Variation="4" Position="117.5,119.5,12.0017" Rotation="1.1018" Scale="0.8498,0.8498,0.8498" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1714" Position="161.5,137.5,7.9057" Rotation="0.642" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1714" Variation="2" Position="161.5,137.5,7.9057" Rotation="0.642" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1764" Position="118.2385,118.504,11.9853" Rotation="1.391" Scale="0.9272,0.9272,0.9272" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1764" Variation="2" Position="118.2385,118.504,11.9853" Rotation="1.391" Scale="0.9272,0.9272,0.9272" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1679" Position="140.9975,53.9135,7.9633" Rotation="3.5034" Scale="0.9411,0.9411,0.9411" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1679" Variation="2" Position="140.9975,53.9135,7.9633" Rotation="3.5034" Scale="0.9411,0.9411,0.9411" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1390" Position="31.0378,164.287,7.8874" Rotation="4.5395" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1390" Variation="4" Position="31.0378,164.287,7.8874" Rotation="4.5395" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3420,7 +3421,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1344" Position="45.1354,61.6132,7.988" Rotation="0.3967" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat" Variation="1">
+    <ObjectDoodad Id="1344" Variation="1" Position="45.1354,61.6132,7.988" Rotation="0.3967" Scale="0.9868,0.9868,0.9868" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -3433,49 +3434,49 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1308" Position="62.367,70.8632,7.9768" Rotation="0.8166" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1308" Variation="2" Position="62.367,70.8632,7.9768" Rotation="0.8166" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1399" Position="37.9104,175.635,11.971" Rotation="0.621" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1789" Position="124.2424,69.755,9.98" Rotation="5.6452" Scale="0.9326,0.9326,0.9326" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1399" Variation="1" Position="37.9104,175.635,11.971" Rotation="0.621" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1686" Position="117,203.5,9.9873" Scale="1.0214,1.0214,1.0214" Type="TheVoid_RubblePile" Variation="3">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1747" Pitch="1.0424" Position="115.5,118,0.9228" Rotation="0.3244" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Variation="1">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="1789" Variation="3" Position="124.2424,69.755,9.98" Rotation="5.6452" Scale="0.9326,0.9326,0.9326" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1330" Position="64.8317,73.8784,11.9875" Rotation="1.4733" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1686" Variation="3" Position="117,203.5,9.9873" Scale="1.0214,1.0214,1.0214" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1369" Position="70.8605,76.8344,12.0043" Rotation="5.906" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1747" Variation="1" Position="115.5,118,0.9228" Rotation="0.3244" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1394" Pitch="5.8466" Position="35.5598,173.0698,11.9865" Rotation="0.7204" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1330" Variation="4" Position="64.8317,73.8784,11.9875" Rotation="1.4733" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1369" Variation="2" Position="70.8605,76.8344,12.0043" Rotation="5.906" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1305" Position="37.4465,75.5537,9.987" Rotation="1.8305" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1683" Position="110.0651,59.405,9.987" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="1394" Position="35.5598,173.0698,11.9865" Rotation="0.7204" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="5.8466">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1784" Position="128.262,74,9.987" Scale="0.9423,0.9423,0.9423" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="1305" Variation="1" Position="37.4465,75.5537,9.987" Rotation="1.8305" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1683" Variation="1" Position="110.0651,59.405,9.987" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1784" Variation="1" Position="128.262,74,9.987" Scale="0.9423,0.9423,0.9423" Type="TheVoid_GroundScar">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1725" Position="151.5927,144.2712,11.9865" Rotation="1.8188" Scale="1.0722,1.0722,1.0722" Type="TheVoid_RubblePile">
@@ -3487,49 +3488,49 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1372" Position="69.661,69.4978,9.987" Rotation="4.1638" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1372" Variation="1" Position="69.661,69.4978,9.987" Rotation="4.1638" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1335" Position="37.8818,120.0234,11.987" Rotation="1.2294" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1335" Variation="2" Position="37.8818,120.0234,11.987" Rotation="1.2294" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1674" Position="140.136,41.102,7.993" Rotation="1.7692" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="1">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1761" Position="113,133.5,7.9711" Rotation="6.2221" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1674" Variation="1" Position="140.136,41.102,7.993" Rotation="1.7692" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1387" Position="36.6604,157.9211,6.8" Rotation="5.9531" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1761" Variation="2" Position="113,133.5,7.9711" Rotation="6.2221" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1349" Position="36.2636,67.2604,8.1252" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1326" Position="19.0502,110.256,7.9775" Rotation="1.0461" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1387" Variation="1" Position="36.6604,157.9211,6.8" Rotation="5.9531" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1700" Position="139.6335,92.9455,7.9792" Rotation="6.1936" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1349" Variation="1" Position="36.2636,67.2604,8.1252" Rotation="5.957" Scale="0.991,0.991,0.991" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1743" Position="98.8703,103.3251,1.687" Rotation="3.2395" Scale="1.25,1.25,1.25" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1326" Variation="2" Position="19.0502,110.256,7.9775" Rotation="1.0461" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1915" Position="113.8347,199.5637,9.9853" Rotation="0.772" Scale="2,2,2" Type="Void_Temple_Small" Variation="4">
+    <ObjectDoodad Id="1700" Variation="1" Position="139.6335,92.9455,7.9792" Rotation="6.1936" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1743" Variation="4" Position="98.8703,103.3251,1.687" Rotation="3.2395" Scale="1.25,1.25,1.25" Type="Void_SmallRocks">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1915" Variation="4" Position="113.8347,199.5637,9.9853" Rotation="0.772" Scale="2,2,2" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3538,7 +3539,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1808" Position="78,132.5,9.989" Rotation="4.0192" Scale="0.5998,0.5998,0.5998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1808" Variation="1" Position="78,132.5,9.989" Rotation="4.0192" Scale="0.5998,0.5998,0.5998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3546,7 +3547,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1877" Position="80,191,9.9731" Rotation="5.3623" Scale="0.75,0.75,0.75" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1877" Variation="2" Position="80,191,9.9731" Rotation="5.3623" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3554,36 +3555,36 @@
     <ObjectDoodad Id="1854" Position="67.5,169,11.9948" Scale="0.8498,0.8498,0.8498" Type="TheVoid_RockPointy2">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2089" Position="92.2153,220.599,11.9853" Rotation="5.1738" Scale="1.0881,1.0881,1.0881" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2089" Variation="5" Position="92.2153,220.599,11.9853" Rotation="5.1738" Scale="1.0881,1.0881,1.0881" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1890" Position="77.8913,230.1452,11.9743" Scale="1,1,1" Type="Void_Temple_Small" Variation="6">
+    <ObjectDoodad Id="1890" Variation="6" Position="77.8913,230.1452,11.9743" Scale="1,1,1" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2114" Position="51.7062,71.7468,10.016" Rotation="1.6313" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2114" Variation="5" Position="51.7062,71.7468,10.016" Rotation="1.6313" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1801" Position="111,64,11.987" Rotation="1.4731" Scale="0.9174,0.9174,0.9174" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1801" Variation="1" Position="111,64,11.987" Rotation="1.4731" Scale="0.9174,0.9174,0.9174" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1868" Position="81,177.5,9.9855" Rotation="6.0651" Scale="1.0146,1.0146,1.0146" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1868" Variation="2" Position="81,177.5,9.9855" Rotation="6.0651" Scale="1.0146,1.0146,1.0146" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2055" Position="63.1035,227.9636,9.985" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2055" Variation="3" Position="63.1035,227.9636,9.985" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1831" Position="69.7314,121.0466,7.9863" Scale="1.091,1.091,1.091" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1831" Variation="3" Position="69.7314,121.0466,7.9863" Scale="1.091,1.091,1.091" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2119" Position="96,90,7.9812" Rotation="0.7258" Scale="1.0998,1,1" Type="TheVoid_Ramp" Variation="1">
+    <ObjectDoodad Id="2119" Variation="1" Position="96,90,7.9812" Rotation="0.7258" Scale="1.0998,1,1" Type="TheVoid_Ramp">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2092" Position="94.3608,231.1994,6.385" Rotation="0.0051" Scale="0.944,0.944,0.944" Type="LightOmniRedLarge">
@@ -3591,23 +3592,27 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1895" Position="96.9865,227.94,11.985" Scale="1,1,1" TintColor="NULL 6.000000" Type="Void_Temple_Small" Variation="3">
+    <ObjectDoodad Id="1895" Variation="3" Position="96.9865,227.94,11.985" Scale="1,1,1" Type="Void_Temple_Small" TintColor="NULL 6.000000">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1826" Position="61.9584,146.0732,8.005" Scale="0.9855,0.9855,0.9855" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1826" Variation="3" Position="61.9584,146.0732,8.005" Scale="0.9855,0.9855,0.9855" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2153" Position="173.7001,61.885,9.9826" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="4">
+    <ObjectDoodad Id="815" Variation="6" Position="78.6423,237.242,11.9853" Rotation="5.492" Scale="1,1,1" Type="Slayn_CliffTemples_Lit">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="815" Position="78.6423,237.242,11.9853" Rotation="5.492" Scale="1,1,1" Type="Slayn_CliffTemples_Lit" Variation="6">
+    <ObjectDoodad Id="2153" Variation="4" Position="173.7001,61.885,9.9826" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1865" Position="78.2473,180.8044,11.9855" Scale="1.0202,1.0202,1.0202" Type="TheVoid_RubblePile">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2050" Position="51.5017,199.8752,9.9772" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3616,19 +3621,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2050" Position="51.5017,199.8752,9.9772" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
+    <ObjectDoodad Id="1813" Variation="1" Position="117.1582,66.4792,9.9858" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1813" Position="117.1582,66.4792,9.9858" Scale="1,1,1" Type="Void_Crystals" Variation="1">
+    <ObjectDoodad Id="2142" Variation="2" Position="169.9765,57.385,9.9826" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2142" Position="169.9765,57.385,9.9826" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1918" Pitch="1.0424" Position="112.5256,242.3537,-1.0122" Rotation="0.9958" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1918" Position="112.5256,242.3537,-1.0122" Rotation="0.9958" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3647,7 +3648,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1872" Pitch="1.0424" Position="87.5,197,-0.9118" Rotation="5.917" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1872" Position="87.5,197,-0.9118" Rotation="5.917" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3656,14 +3657,14 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1798" Position="119.927,75.0427,11.989" Scale="1.0378,1.0378,1.0378" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1798" Variation="4" Position="119.927,75.0427,11.989" Scale="1.0378,1.0378,1.0378" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2086" Position="97.0551,231.3146,11.985" Rotation="6.2421" Scale="0.913,0.913,0.913" Type="LightOmniBlueLarge">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1901" Position="77.8757,229.1391,11.9785" Scale="1,1,1" Type="Void_Temple_Small" Variation="3">
+    <ObjectDoodad Id="1901" Variation="3" Position="77.8757,229.1391,11.9785" Scale="1,1,1" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3671,27 +3672,27 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1859" Position="88.5,180,11.9968" Scale="1.064,1.064,1.064" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1859" Variation="1" Position="88.5,180,11.9968" Scale="1.064,1.064,1.064" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2056" Position="59.2224,227.4921,9.985" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1186" Position="21.276,111.0688,10.2795" Rotation="0.8171" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1186" Variation="4" Position="21.276,111.0688,10.2795" Rotation="0.8171" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1823" Position="59,145.5,8.0053" Rotation="1.5107" Scale="1.0288,1.0288,1.0288" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1823" Variation="1" Position="59,145.5,8.0053" Rotation="1.5107" Scale="1.0288,1.0288,1.0288" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1908" Pitch="1.0424" Position="104.635,234.1784,-0.9123" Rotation="0.7331" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1908" Position="104.635,234.1784,-0.9123" Rotation="0.7331" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2111" Position="60,122.5,8.0812" Rotation="3.8618" Scale="1.0998,1,1" Type="TheVoid_Ramp" Variation="1">
+    <ObjectDoodad Id="2111" Variation="1" Position="60,122.5,8.0812" Rotation="3.8618" Scale="1.0998,1,1" Type="TheVoid_Ramp">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -3700,23 +3701,23 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2170" Position="170.865,46.7033,11.9677" Rotation="1.108" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="4">
+    <ObjectDoodad Id="2170" Variation="4" Position="170.865,46.7033,11.9677" Rotation="1.108" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1841" Position="81.988,148.3193,9.9853" Scale="0.9604,0.9604,0.9604" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1841" Variation="2" Position="81.988,148.3193,9.9853" Scale="0.9604,0.9604,0.9604" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2065" Position="95.731,190.302,10.0078" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2065" Variation="3" Position="95.731,190.302,10.0078" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1882" Position="82.607,208.6406,11.9863" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="7">
+    <ObjectDoodad Id="1882" Variation="7" Position="82.607,208.6406,11.9863" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1905" Position="80.74,216.9814,11.9853" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="17">
+    <ObjectDoodad Id="1905" Variation="17" Position="80.74,216.9814,11.9853" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3725,7 +3726,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1818" Position="77,127.5,9.9907" Rotation="0.8212" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1818" Variation="1" Position="77,127.5,9.9907" Rotation="0.8212" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3734,7 +3735,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2068" Position="70.0925,214.9636,11.986" Rotation="5.8735" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2068" Variation="4" Position="70.0925,214.9636,11.986" Rotation="5.8735" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3743,11 +3744,11 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2175" Position="178.014,52.2246,11.9677" Rotation="1.6835" Scale="1.186,1.186,1.186" Type="IceWorldAmbientCrystals" Variation="3">
+    <ObjectDoodad Id="2175" Variation="3" Position="178.014,52.2246,11.9677" Rotation="1.6835" Scale="1.186,1.186,1.186" Type="IceWorldAmbientCrystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1844" Position="90.5,148.5,9.9846" Rotation="3.6291" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1844" Variation="1" Position="90.5,148.5,9.9846" Rotation="3.6291" Scale="0.7998,0.7998,0.7998" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3755,7 +3756,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1896" Position="74.256,190.928,9.9863" Rotation="5.4843" Scale="2,2,2" Type="Void_Temple_Small" Variation="4">
+    <ObjectDoodad Id="1896" Variation="4" Position="74.256,190.928,9.9863" Rotation="5.4843" Scale="2,2,2" Type="Void_Temple_Small">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3767,22 +3768,22 @@
     <ObjectDoodad Id="1862" Position="79.5,181.5,11.9855" Scale="1.0051,1.0051,1.0051" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2061" Position="70.9211,222.165,11.9702" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2061" Variation="3" Position="70.9211,222.165,11.9702" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1837" Position="72.5573,113.6762,9.9863" Scale="0.9023,0.9023,0.9023" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1837" Variation="2" Position="72.5573,113.6762,9.9863" Scale="0.9023,0.9023,0.9023" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1852" Position="109.5,146,11.9865" Rotation="1.4631" Scale="1.0617,1.0617,1.0617" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1852" Variation="3" Position="109.5,146,11.9865" Rotation="1.4631" Scale="1.0617,1.0617,1.0617" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2167" Position="174.2265,61.8234,9.9985" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="2">
+    <ObjectDoodad Id="2167" Variation="2" Position="174.2265,61.8234,9.9985" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1879" Position="78.5,190.5,9.9785" Scale="0.9406,0.9406,0.9406" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1879" Variation="1" Position="78.5,190.5,9.9785" Scale="0.9406,0.9406,0.9406" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3790,12 +3791,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1206" Position="14.915,155.8527,3.386" Rotation="1.1367" Scale="0.5,0.5,0.5" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1206" Variation="2" Position="14.915,155.8527,3.386" Rotation="1.1367" Scale="0.5,0.5,0.5" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1810" Position="109,40.5,3.7861" Scale="1,1,1" Type="Void_Crystals" Variation="3">
+    <ObjectDoodad Id="1810" Variation="3" Position="109,40.5,3.7861" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3804,7 +3805,7 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1913" Position="102.4697,188.6967,9.9863" Rotation="0.88" Scale="0.7597,0.7597,0.7597" Type="XelNaga_GroundPlates_Amon" Variation="1">
+    <ObjectDoodad Id="1913" Variation="1" Position="102.4697,188.6967,9.9863" Rotation="0.88" Scale="0.7597,0.7597,0.7597" Type="XelNaga_GroundPlates_Amon">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3812,23 +3813,23 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2053" Position="47.9401,224.8388,10.0002" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2053" Variation="3" Position="47.9401,224.8388,10.0002" Rotation="2.8967" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1870" Position="95.721,152.5346,12.0014" Scale="1.0522,1.0522,1.0522" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="1870" Variation="3" Position="95.721,152.5346,12.0014" Scale="1.0522,1.0522,1.0522" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1803" Position="104.0146,81.7258,9.9836" Rotation="0.6516" Scale="0.9328,0.9328,0.9328" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1803" Variation="4" Position="104.0146,81.7258,9.9836" Rotation="0.6516" Scale="0.9328,0.9328,0.9328" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2112" Position="56.7067,68.119,8.021" Rotation="4.745" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="2112" Variation="2" Position="56.7067,68.119,8.021" Rotation="4.745" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1888" Position="79.615,228.0312,11.985" Scale="1,1,1" TintColor="NULL 6.000000" Type="Void_Temple_Small" Variation="3">
+    <ObjectDoodad Id="1888" Variation="3" Position="79.615,228.0312,11.985" Scale="1,1,1" Type="Void_Temple_Small" TintColor="NULL 6.000000">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3837,7 +3838,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2048" Position="104.5944,244.3596,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="2048" Variation="1" Position="104.5944,244.3596,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3845,15 +3846,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="813" Position="90.2312,236.6491,11.9853" Scale="1,1,1" Type="Slayn_CliffTemples_Lit" Variation="2">
+    <ObjectDoodad Id="813" Variation="2" Position="90.2312,236.6491,11.9853" Scale="1,1,1" Type="Slayn_CliffTemples_Lit">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1824" Position="63.5,149.5,10.003" Rotation="3.868" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1824" Variation="1" Position="63.5,149.5,10.003" Rotation="3.868" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1893" Position="81.6442,227.3,11.9853" Scale="1,1,1" Type="Void_Temple_Small" Variation="7">
+    <ObjectDoodad Id="1893" Variation="7" Position="81.6442,227.3,11.9853" Scale="1,1,1" Type="Void_Temple_Small">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -3861,16 +3862,16 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1806" Position="105.964,77.2644,9.9995" Rotation="2.7126" Scale="1.0463,1.0463,1.0463" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1806" Variation="2" Position="105.964,77.2644,9.9995" Rotation="2.7126" Scale="1.0463,1.0463,1.0463" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2117" Position="45.8254,65.2465,9.9912" Rotation="5.8615" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="2117" Variation="5" Position="45.8254,65.2465,9.9912" Rotation="5.8615" Scale="0.9277,0.9277,0.9277" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1874" Pitch="1.0424" Position="84.5,196,0.405" Rotation="1.898" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1874" Position="84.5,196,0.405" Rotation="1.898" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3878,11 +3879,11 @@
     <ObjectDoodad Id="2073" Position="90.4096,211.6794,11.985" Rotation="0.904" Scale="0.9384,0.9384,0.9384" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1849" Position="87.576,154.976,11.9904" Scale="1.07,1.07,1.07" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1849" Variation="1" Position="87.576,154.976,11.9904" Scale="1.07,1.07,1.07" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1240" Position="171.9013,44.842,11.9897" Rotation="6.2094" Scale="0.9316,0.9316,0.9316" Type="Void_GoldPiles" Variation="5">
+    <ObjectDoodad Id="1240" Variation="5" Position="171.9013,44.842,11.9897" Rotation="6.2094" Scale="0.9316,0.9316,0.9316" Type="Void_GoldPiles">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -3895,7 +3896,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1815" Position="106.6572,75.4375,9.9897" Scale="1,1,1" Type="Void_Crystals" Variation="3">
+    <ObjectDoodad Id="1815" Variation="3" Position="106.6572,75.4375,9.9897" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3903,7 +3904,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1857" Position="70.5,164.5,11.9865" Rotation="3.3532" Scale="0.9145,0.9145,0.9145" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1857" Variation="2" Position="70.5,164.5,11.9865" Rotation="3.3532" Scale="0.9145,0.9145,0.9145" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3911,7 +3912,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1903" Position="84.3583,221.8828,11.9853" Rotation="0.116" Scale="1.0881,1.0881,1.0881" Type="Void_CrackSplat" Variation="5">
+    <ObjectDoodad Id="1903" Variation="5" Position="84.3583,221.8828,11.9853" Rotation="0.116" Scale="1.0881,1.0881,1.0881" Type="Void_CrackSplat">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3920,7 +3921,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1796" Position="108,66.5,11.987" Rotation="1.4731" Scale="0.9174,0.9174,0.9174" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1796" Variation="4" Position="108,66.5,11.987" Rotation="1.4731" Scale="0.9174,0.9174,0.9174" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1880" Position="88.0334,211.5874,11.9855" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
@@ -3949,20 +3950,20 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1821" Position="62.5,147.5,7.9865" Rotation="3.3098" Scale="1.0288,1.0288,1.0288" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1821" Variation="2" Position="62.5,147.5,7.9865" Rotation="3.3098" Scale="1.0288,1.0288,1.0288" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1239" Name="809" Position="148.6923,143.3552,11.9902" Rotation="0.772" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1239" Variation="2" Position="148.6923,143.3552,11.9902" Rotation="0.772" Scale="0.7998,0.7998,0.7998" Name="809" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1846" Position="89.5,151.5,8.0046" Rotation="1.8244" Scale="1.0256,1.0256,1.0256" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1846" Variation="2" Position="89.5,151.5,8.0046" Rotation="1.8244" Scale="1.0256,1.0256,1.0256" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2173" Position="169.5964,45.992,10.9633" Rotation="5.4091" Scale="0.9858,0.9858,0.9858" Type="IceWorldAmbientCrystals" Variation="4">
+    <ObjectDoodad Id="2173" Variation="4" Position="169.5964,45.992,10.9633" Rotation="5.4091" Scale="0.9858,0.9858,0.9858" Type="IceWorldAmbientCrystals">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -3975,7 +3976,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1816" Position="40.0615,36.023,7.978" Rotation="3.4045" Scale="1,1,1" Type="Void_Crystals" Variation="1">
+    <ObjectDoodad Id="1816" Variation="1" Position="40.0615,36.023,7.978" Rotation="3.4045" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -3984,23 +3985,23 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1907" Position="74.4892,191.0747,9.9863" Rotation="5.5922" Scale="0.7597,0.7597,0.7597" Type="XelNaga_GroundPlates_Amon" Variation="1">
+    <ObjectDoodad Id="1907" Variation="1" Position="74.4892,191.0747,9.9863" Rotation="5.5922" Scale="0.7597,0.7597,0.7597" Type="XelNaga_GroundPlates_Amon">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1839" Position="112.6977,133.507,7.9707" Scale="1.0461,1.0461,1.0461" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1839" Variation="1" Position="112.6977,133.507,7.9707" Scale="1.0461,1.0461,1.0461" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2063" Position="95.897,191.4753,12.0024" Rotation="5.4777" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile" Variation="3">
+    <ObjectDoodad Id="2063" Variation="3" Position="95.897,191.4753,12.0024" Rotation="5.4777" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RubblePile">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1860" Position="86.5,182.5,11.9882" Rotation="0.5361" Scale="1.046,1.046,1.046" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="1860" Variation="2" Position="86.5,182.5,11.9882" Rotation="0.5361" Scale="1.046,1.046,1.046" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1793" Position="124.4916,75.6992,9.983" Rotation="4.9467" Scale="1.0527,1.0527,1.0527" Type="TheVoid_RockPointy" Variation="5">
+    <ObjectDoodad Id="1793" Variation="5" Position="124.4916,75.6992,9.983" Rotation="4.9467" Scale="1.0527,1.0527,1.0527" Type="TheVoid_RockPointy">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4012,16 +4013,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2192" Position="168.5881,55.5224,9.941" Rotation="1.108" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="982" Pitch="1.0424" Position="100,99,0.6228" Rotation="4.9995" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="982" Variation="1" Position="100,99,0.6228" Rotation="4.9995" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2011" Position="149.5642,197.6862,9.9846" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="3">
+    <ObjectDoodad Id="2192" Position="168.5881,55.5224,9.941" Rotation="1.108" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2011" Variation="3" Position="149.5642,197.6862,9.9846" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4029,16 +4030,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1105" Pitch="5.8466" Position="17.1098,56.94,11.865" Rotation="1.013" Scale="1.25,1.25,1.25" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1105" Variation="2" Position="17.1098,56.94,11.865" Rotation="1.013" Scale="1.25,1.25,1.25" Type="Void_Cliff_Rocks" Pitch="5.8466">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1044" Position="36.968,35.3774,11.9877" Rotation="5.1857" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1044" Variation="4" Position="36.968,35.3774,11.9877" Rotation="5.1857" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2037" Position="74.1342,239.1362,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2037" Variation="4" Position="74.1342,239.1362,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1950" Position="84.3632,196.428,11.6025" Rotation="1.783" Scale="0.75,0.75,0.75" Type="Void_SmallRocks">
@@ -4046,7 +4047,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1096" Position="43.6281,18.9296,10.9804" Rotation="2.8273" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1096" Variation="2" Position="43.6281,18.9296,10.9804" Rotation="2.8273" Scale="0.5998,0.5998,0.5998" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4055,18 +4056,15 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2185" Position="179.7968,47.692,12.0205" Scale="1,1,1" Type="Void_Crystals" Variation="4">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="975" Position="104.5,108,11.987" Rotation="0.059" Scale="0.9453,0.9453,0.9453" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1961" Position="129.49,195.39,11.9895" Rotation="0.6572" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2185" Variation="4" Position="179.7968,47.692,12.0205" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="993" Position="96.3024,154.9584,11.9897" Rotation="5.3977" Scale="1.003,1.003,1.003" Type="TheVoid_RockPointy" Variation="4">
+    <ObjectDoodad Id="1961" Variation="4" Position="129.49,195.39,11.9895" Rotation="0.6572" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2215" Position="107.5415,230.6833,10.1838" Rotation="0.8486" Scale="1.2,1.2,1.2" Type="TheVoid_FloatingRocks">
@@ -4074,15 +4072,18 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="993" Variation="4" Position="96.3024,154.9584,11.9897" Rotation="5.3977" Scale="1.003,1.003,1.003" Type="TheVoid_RockPointy">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="2028" Position="44.5495,179.3908,9.985" Rotation="1.8166" Scale="1.062,1.062,1.062" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1927" Position="81.1274,227.6391,11.9853" Rotation="4.1682" Scale="1,1,1" Type="Blast_Craters" Variation="3">
+    <ObjectDoodad Id="1927" Variation="3" Position="81.1274,227.6391,11.9853" Rotation="4.1682" Scale="1,1,1" Type="Blast_Craters">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1037" Position="150.1054,107.1743,9.9748" Rotation="1.2302" Scale="0.9,0.9,0.9" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="1037" Variation="1" Position="150.1054,107.1743,9.9748" Rotation="1.2302" Scale="0.9,0.9,0.9" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4091,18 +4092,18 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1964" Position="133.073,192.94,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="1964" Variation="2" Position="133.073,192.94,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1991" Position="112.9631,227.7946,9.9965" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2188" Position="172.219,54.5031,12.1896" Rotation="5.582" Scale="1.0874,1.0874,1.0874" Type="IceWorldAmbientCrystals" Variation="2">
+    <ObjectDoodad Id="1991" Variation="2" Position="112.9631,227.7946,9.9965" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1922" Position="100.48,226.3698,11.8923" Rotation="5.3562" Scale="1,1,1" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="2188" Variation="2" Position="172.219,54.5031,12.1896" Rotation="5.582" Scale="1.0874,1.0874,1.0874" Type="IceWorldAmbientCrystals">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1922" Variation="2" Position="100.48,226.3698,11.8923" Rotation="5.3562" Scale="1,1,1" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4112,18 +4113,18 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2025" Position="38.2832,175.1967,11.985" Scale="0.901,0.901,0.901" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="2025" Variation="2" Position="38.2832,175.1967,11.985" Scale="0.901,0.901,0.901" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1973" Position="68.658,225.8332,-0.015" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="1973" Variation="2" Position="68.658,225.8332,-0.015" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="979" Position="55.3583,74.8061,7.984" Rotation="5.1213" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks" Variation="4">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2197" Position="175.2416,42.7673,9.9826" Rotation="3.2026" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="979" Variation="4" Position="55.3583,74.8061,7.984" Rotation="5.1213" Scale="1.0827,1.0827,1.0827" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4132,7 +4133,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1108" Position="15.8652,56.3637,11.9604" Rotation="5.858" Scale="1.0827,1.0827,1.0827" Type="TheVoid_RockPointy" Variation="2">
+    <ObjectDoodad Id="1108" Variation="2" Position="15.8652,56.3637,11.9604" Rotation="5.858" Scale="1.0827,1.0827,1.0827" Type="TheVoid_RockPointy">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -4141,7 +4142,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1947" Position="82.415,223.6501,11.9855" Rotation="3.07" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="4">
+    <ObjectDoodad Id="1947" Variation="4" Position="82.415,223.6501,11.9855" Rotation="3.07" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4150,20 +4151,20 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1958" Position="130.7551,191.1394,11.9853" Scale="1.06,1.06,1.06" Type="TheVoid_RubblePile" Variation="1">
+    <ObjectDoodad Id="1958" Variation="1" Position="130.7551,191.1394,11.9853" Scale="1.06,1.06,1.06" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1997" Pitch="6.0212" Position="158.3198,156.5197,9.5732" Rotation="5.9812" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1997" Position="158.3198,156.5197,9.5732" Rotation="5.9812" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="6.0212">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2182" Position="176.4753,45.409,12.1723" Scale="1,1,1" Type="Void_Crystals" Variation="3">
+    <ObjectDoodad Id="2182" Variation="3" Position="176.4753,45.409,12.1723" Scale="1,1,1" Type="Void_Crystals">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1095" Position="36.871,20.0146,11.989" Rotation="3.4663" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1095" Variation="1" Position="36.871,20.0146,11.989" Rotation="3.4663" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4176,11 +4177,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2019" Position="135.147,187.0146,9.9777" Scale="1.0407,1.0407,1.0407" Type="Void_SmallRocks" Variation="2">
+    <ObjectDoodad Id="2019" Variation="2" Position="135.147,187.0146,9.9777" Scale="1.0407,1.0407,1.0407" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1983" Position="154.1853,116.5908,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="1983" Variation="1" Position="154.1853,116.5908,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2207" Position="61.6716,80.7001,-5.915" Rotation="5.9033" Scale="3,3,3" Type="Void_Nebula_Storm">
@@ -4188,22 +4189,22 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2004" Position="151.253,171.8022,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="3">
+    <ObjectDoodad Id="2004" Variation="3" Position="151.253,171.8022,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1937" Position="98.805,236.7473,11.9853" Rotation="4.7253" Scale="1,1,1" Type="Slayn_CliffTemples_Lit" Variation="6">
+    <ObjectDoodad Id="1937" Variation="6" Position="98.805,236.7473,11.9853" Rotation="4.7253" Scale="1,1,1" Type="Slayn_CliffTemples_Lit">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2042" Position="65.155,249.007,11.985" Rotation="1.1743" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2042" Variation="4" Position="65.155,249.007,11.985" Rotation="1.1743" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1051" Position="88.1,220.0505,11.985" Rotation="6.2604" Scale="0.9,0.9,0.9" Type="XelNaga_GroundPlates_Amon">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2202" Pitch="4.9233" Position="176.2734,43.745,10.0566" Rotation="3.9645" Scale="1,1,1" Type="MarSaraMineCart">
+    <ObjectDoodad Id="2202" Position="176.2734,43.745,10.0566" Rotation="3.9645" Scale="1,1,1" Type="MarSaraMineCart" Pitch="4.9233">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4211,11 +4212,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1978" Position="162.7,131.16,11.9897" Rotation="1.892" Scale="1,1,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1978" Variation="4" Position="162.7,131.16,11.9897" Rotation="1.892" Scale="1,1,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2047" Position="109.3752,248.5173,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="3">
+    <ObjectDoodad Id="2047" Variation="3" Position="109.3752,248.5173,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4224,7 +4225,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1054" Position="33.8061,43.6357,7.988" Rotation="0.1235" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1054" Variation="3" Position="33.8061,43.6357,7.988" Rotation="0.1235" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4243,96 +4244,96 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2022" Position="41.4191,182.399,11.985" Rotation="0.9777" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="2022" Variation="2" Position="41.4191,182.399,11.985" Rotation="0.9777" Scale="1.09,1.09,1.09" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1933" Position="63.5434,202.9887,9.6853" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="1933" Variation="2" Position="63.5434,202.9887,9.6853" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1046" Position="17.727,48.046,7.9865" Rotation="1.325" Scale="1.25,1.25,1.25" Type="Void_Cliff_Rocks" Variation="2">
+    <ObjectDoodad Id="1046" Variation="2" Position="17.727,48.046,7.9865" Rotation="1.325" Scale="1.25,1.25,1.25" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1948" Position="94.1354,223.355,11.9855" Rotation="3.07" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid" Variation="18">
+    <ObjectDoodad Id="1948" Variation="18" Position="94.1354,223.355,11.9855" Rotation="3.07" Scale="1,1,1" Type="XelNaga_GroundPlates_TheVoid">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2236" Position="163.0842,49.624,9.979" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="4">
+    <ObjectDoodad Id="2236" Variation="4" Position="163.0842,49.624,9.979" Rotation="3.278" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2039" Position="67.3801,241.5754,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1970" Position="61.0388,227.9545,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="1970" Variation="1" Position="61.0388,227.9545,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2009" Position="159.5356,188.4516,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2009" Variation="4" Position="159.5356,188.4516,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2194" Position="169.338,42.7304,10.0385" Rotation="2.6787" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="1">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="980" Pitch="6.1086" Position="17.0498,90.89,10.6035" Rotation="1.7163" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="980" Variation="1" Position="17.0498,90.89,10.6035" Rotation="1.7163" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Pitch="6.1086">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1107" Position="17.5197,60.4475,11.9843" Rotation="5.3188" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RockPointy" Variation="5">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="1925" Position="77.9184,228.8525,11.982" Rotation="3.8962" Scale="1,1,1" Type="Blast_Craters" Variation="3">
+    <ObjectDoodad Id="2194" Variation="1" Position="169.338,42.7304,10.0385" Rotation="2.6787" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2030" Position="41.67,180.2697,11.991" Scale="0.8498,0.8498,0.8498" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1107" Variation="5" Position="17.5197,60.4475,11.9843" Rotation="5.3188" Scale="0.7998,0.7998,0.7998" Type="TheVoid_RockPointy">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="1925" Variation="3" Position="77.9184,228.8525,11.982" Rotation="3.8962" Scale="1,1,1" Type="Blast_Craters">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2030" Variation="4" Position="41.67,180.2697,11.991" Scale="0.8498,0.8498,0.8498" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2213" Position="40.1198,170.5498,13.981" Rotation="2.4196" Scale="0.8996,0.8996,0.5998" Type="TheVoid_FloatingRocks" Variation="2">
+    <ObjectDoodad Id="2213" Variation="2" Position="40.1198,170.5498,13.981" Rotation="2.4196" Scale="0.8996,0.8996,0.5998" Type="TheVoid_FloatingRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1039" Position="68.8234,166.1005,11.9875" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="1039" Variation="1" Position="68.8234,166.1005,11.9875" Rotation="2.2443" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1963" Position="130.137,194.5292,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="3">
+    <ObjectDoodad Id="1963" Variation="3" Position="130.137,194.5292,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2187" Position="172.1972,54.8034,12.2084" Rotation="3.2026" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1984" Position="150.8847,108.4846,9.9877" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="3">
+    <ObjectDoodad Id="1984" Variation="3" Position="150.8847,108.4846,9.9877" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2027" Position="44.1652,173.02,9.985" Rotation="1.817" Scale="1.062,1.062,1.062" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="998" Position="101.201,150.8928,11.9855" Rotation="4.1582" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2208" Position="51.8837,105.3618,-4.7307" Rotation="5.9033" Scale="3,3,3" Type="Void_Nebula_Storm">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="998" Variation="4" Position="101.201,150.8928,11.9855" Rotation="4.1582" Scale="1,1,1" Type="Void_XelNaga_Structure">
+        <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1920" Position="98.122,229.6977,11.4865" Rotation="5.4931" Scale="1,1,1" Type="Void_Cliff_Rocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1103" Position="19.5983,52.8681,10.0041" Rotation="0.2832" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="4">
+    <ObjectDoodad Id="1103" Variation="4" Position="19.5983,52.8681,10.0041" Rotation="0.2832" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4345,11 +4346,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1966" Position="66.0087,206.0893,10.0356" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="1966" Variation="4" Position="66.0087,206.0893,10.0356" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1043" Position="122.838,8.04,11.9873" Rotation="5.4213" Scale="0.934,0.934,0.934" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="1043" Variation="1" Position="122.838,8.04,11.9873" Rotation="5.4213" Scale="0.934,0.934,0.934" Type="TheVoid_GroundScar">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4357,33 +4358,33 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2034" Position="81.49,196.3298,11.9907" Rotation="5.1186" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2034" Variation="4" Position="81.49,196.3298,11.9907" Rotation="5.1186" Scale="0.7998,0.7998,0.7998" Type="Void_XelNaga_Structure">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1945" Position="81.7207,236.6491,11.9853" Scale="1,1,1" Type="Slayn_CliffTemples_Lit" Variation="2">
+    <ObjectDoodad Id="1945" Variation="2" Position="81.7207,236.6491,11.9853" Scale="1,1,1" Type="Slayn_CliffTemples_Lit">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2012" Pitch="5.934" Position="149.68,195.95,9.8901" Rotation="5.9904" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="2012" Position="149.68,195.95,9.8901" Rotation="5.9904" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="5.934">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2199" Position="179.3767,48.8693,12.0058" Rotation="6.0073" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="1">
+    <ObjectDoodad Id="977" Variation="1" Position="20.4213,59.4133,12.041" Rotation="2.2446" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="977" Position="20.4213,59.4133,12.041" Rotation="2.2446" Scale="0.5998,0.5998,0.5998" Type="TheVoid_GroundScar" Variation="1">
+    <ObjectDoodad Id="2199" Variation="1" Position="179.3767,48.8693,12.0058" Rotation="6.0073" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1975" Position="94.665,106.515,11.9877" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="2">
+    <ObjectDoodad Id="1975" Variation="2" Position="94.665,106.515,11.9877" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1110" Position="36.4755,66.5732,8.1613" Rotation="0.2893" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks" Variation="1">
+    <ObjectDoodad Id="1110" Variation="1" Position="36.4755,66.5732,8.1613" Rotation="0.2893" Scale="0.75,0.75,0.75" Type="Void_Cliff_Rocks">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1024" Position="134.8581,164.891,11.4853" Scale="1,1,1" Type="Void_XelNaga_Structure">
@@ -4409,21 +4410,21 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1999" Pitch="5.934" Position="159.6098,187.5197,9.8901" Rotation="5.1787" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1999" Position="159.6098,187.5197,9.8901" Rotation="5.1787" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="5.934">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1956" Position="128.9953,184.172,11.9863" Rotation="3.9001" Scale="1.0571,1.0571,1.0571" Type="TheVoid_RubblePile" Variation="2">
+    <ObjectDoodad Id="1956" Variation="2" Position="128.9953,184.172,11.9863" Rotation="3.9001" Scale="1.0571,1.0571,1.0571" Type="TheVoid_RubblePile">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1093" Position="17.0544,33.082,8.497" Rotation="0.779" Scale="0.976,0.976,0.976" Type="Void_CrackSplat" Variation="2">
+    <ObjectDoodad Id="1093" Variation="2" Position="17.0544,33.082,8.497" Rotation="0.779" Scale="0.976,0.976,0.976" Type="Void_CrackSplat">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2040" Position="66.505,244.545,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="3">
+    <ObjectDoodad Id="2040" Variation="3" Position="66.505,244.545,11.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1939" Pitch="5.934" Position="130.0798,228.0698,9.8891" Rotation="5.9816" Scale="1,1,1" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="1939" Position="130.0798,228.0698,9.8891" Rotation="5.9816" Scale="1,1,1" Type="Void_Cliff_Rocks" Pitch="5.934">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4436,10 +4437,10 @@
     <ObjectDoodad Id="2006" Position="153.293,177.035,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1981" Position="169.6564,131.5495,11.985" Rotation="1.5344" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="1">
+    <ObjectDoodad Id="1981" Variation="1" Position="169.6564,131.5495,11.985" Rotation="1.5344" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1942" Pitch="0.039" Position="105.944,195.7553,10.939" Roll="0.3315" Rotation="5.5998" Scale="1.5,1.5,0.75" Type="XelNaga_GroundPlates_TheVoid" Variation="5">
+    <ObjectDoodad Id="1942" Variation="5" Position="105.944,195.7553,10.939" Rotation="5.5998" Scale="1.5,1.5,0.75" Type="XelNaga_GroundPlates_TheVoid" Pitch="0.039" Roll="0.3315">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -4447,7 +4448,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1052" Position="18.1511,43.3376,7.988" Rotation="2.2834" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1052" Variation="3" Position="18.1511,43.3376,7.988" Rotation="2.2834" Scale="0.9631,0.9631,0.9631" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4459,16 +4460,16 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2003" Position="155.4887,163.6623,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure" Variation="4">
+    <ObjectDoodad Id="2003" Variation="4" Position="155.4887,163.6623,9.985" Scale="1,1,1" Type="Void_XelNaga_Structure">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2200" Position="177.357,48.1115,11.9677" Rotation="0.2875" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles" Variation="2">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="990" Pitch="1.0424" Position="75.5,130.5,0.223" Rotation="0.325" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks">
+    <ObjectDoodad Id="990" Position="75.5,130.5,0.223" Rotation="0.325" Scale="0.7998,0.7998,0.7998" Type="Void_Cliff_Rocks" Pitch="1.0424">
         <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2200" Variation="2" Position="177.357,48.1115,11.9677" Rotation="0.2875" Scale="0.5998,0.5998,0.5998" Type="Void_GoldPiles">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4481,7 +4482,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2020" Position="128.1596,199.865,11.985" Scale="0.933,0.933,0.933" Type="Void_SmallRocks" Variation="1">
+    <ObjectDoodad Id="2020" Variation="1" Position="128.1596,199.865,11.985" Scale="0.933,0.933,0.933" Type="Void_SmallRocks">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4489,7 +4490,7 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="1953" Position="131.026,197.6796,11.9853" Rotation="0.7836" Scale="1.064,1.064,1.064" Type="Void_SmallRocks" Variation="3">
+    <ObjectDoodad Id="1953" Variation="3" Position="131.026,197.6796,11.9853" Rotation="0.7836" Scale="1.064,1.064,1.064" Type="Void_SmallRocks">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4502,263 +4503,263 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectPoint Color="0,0,0,0" Id="2357" Name="Pathing Cliff Fill 054" Position="166.9011,134.2282,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="313" Name="Mid_KerriganDropPod01" Position="87.2038,39.5456,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2139" Name="Pathing Cliff Fill 020" Position="145.1577,96.2395,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="444" Name="Start Location 002" Position="83.5,22.5,0" Rotation="3.1413" Scale="1,1,1" Type="StartLoc"/>
-    <ObjectPoint Color="0,0,0,0" Id="1140" Name="BonusObjective02_Factory02" Position="33.5,153.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="605" Name="Kerrigan_Waypoint" Position="147.0712,121.888,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2348" Name="Pathing Cliff Fill 045" Position="43.4045,120.1333,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1197" Name="BonusObjective04_Lair" Position="150.5,189,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1222" Name="Victory_Stukov" Position="87.8112,215.4721,0" Rotation="3.0153" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="357" Name="Narud_vsKerrigan_07" Position="139.839,114.494,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="313" Position="87.2038,39.5456,0" Scale="1,1,1" Type="Normal" Name="Mid_KerriganDropPod01" Color="0,0,0,0"/>
+    <ObjectPoint Id="2357" Position="166.9011,134.2282,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 054" Color="0,0,0,0"/>
+    <ObjectPoint Id="2139" Position="145.1577,96.2395,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 020" Color="0,0,0,0"/>
+    <ObjectPoint Id="444" Position="83.5,22.5,0" Rotation="3.1413" Scale="1,1,1" Type="StartLoc" Name="Start Location 002" Color="0,0,0,0"/>
+    <ObjectPoint Id="1140" Position="33.5,153.5,0" Scale="1,1,1" Type="Normal" Name="BonusObjective02_Factory02" Color="0,0,0,0"/>
+    <ObjectPoint Id="605" Position="147.0712,121.888,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_Waypoint" Color="0,0,0,0"/>
+    <ObjectPoint Id="2348" Position="43.4045,120.1333,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 045" Color="0,0,0,0"/>
+    <ObjectPoint Id="1197" Position="150.5,189,0" Scale="1,1,1" Type="Normal" Name="BonusObjective04_Lair" Color="0,0,0,0"/>
+    <ObjectPoint Id="357" Position="139.839,114.494,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_07" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="398" Name="Kerrigan_ForwardBase02_DropPod03" Position="146.5,124.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="334" Name="Narud_vsKerrigan_03" Position="107.5783,185.6835,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="1222" Position="87.8112,215.4721,0" Rotation="3.0153" Scale="1,1,1" Type="Normal" Name="Victory_Stukov" Color="0,0,0,0"/>
+    <ObjectPoint Id="398" Position="146.5,124.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase02_DropPod03" Color="0,0,0,0"/>
+    <ObjectPoint Id="334" Position="107.5783,185.6835,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_03" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2345" Name="Pathing Cliff Fill 042" Position="115.5566,68.0314,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="459" Name="Intro Warp Prism 01 Spawn" Position="10.5197,12.75,0" Rotation="1.6066" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="416" Name="Victory Artanis Charge" Position="84.8032,221.9028,0" Rotation="2.7521" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2352" Name="Pathing Cliff Fill 049" Position="103.3518,106.607,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="377" Name="Raynor_ForwardBase03_DropPod01" Position="54.4343,182.399,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="324" Name="Kerrigan_ForwardBase02_CreepTumor01" Position="139.5,120.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2339" Name="Pathing Cliff Fill 036" Position="21.746,56.138,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2125" Name="Pathing Cliff Fill 006" Position="149.9401,33.7395,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="42" Name="BonusObjective04_Gather" Position="142.161,181.1843,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1122" Name="BonusObjective01" Position="30.8488,102.8884,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2147" Name="Pathing Cliff Fill 028" Position="54.5095,111.4533,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="544" Name="Victory_Raynor" Position="90.1284,216.601,0" Rotation="3.6137" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="362" Name="Narud_vsKerrigan_12" Position="126.4174,50.6174,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2345" Position="115.5566,68.0314,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 042" Color="0,0,0,0"/>
+    <ObjectPoint Id="459" Position="10.5197,12.75,0" Rotation="1.6066" Scale="1,1,1" Type="Normal" Name="Intro Warp Prism 01 Spawn" Color="0,0,0,0"/>
+    <ObjectPoint Id="416" Position="84.8032,221.9028,0" Rotation="2.7521" Scale="1,1,1" Type="Normal" Name="Victory Artanis Charge" Color="0,0,0,0"/>
+    <ObjectPoint Id="2352" Position="103.3518,106.607,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 049" Color="0,0,0,0"/>
+    <ObjectPoint Id="377" Position="54.4343,182.399,0" Scale="1,1,1" Type="Normal" Name="Raynor_ForwardBase03_DropPod01" Color="0,0,0,0"/>
+    <ObjectPoint Id="324" Position="139.5,120.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase02_CreepTumor01" Color="0,0,0,0"/>
+    <ObjectPoint Id="2339" Position="21.746,56.138,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 036" Color="0,0,0,0"/>
+    <ObjectPoint Id="2125" Position="149.9401,33.7395,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 006" Color="0,0,0,0"/>
+    <ObjectPoint Id="42" Position="142.161,181.1843,0" Scale="1,1,1" Type="Normal" Name="BonusObjective04_Gather" Color="0,0,0,0"/>
+    <ObjectPoint Id="1122" Position="30.8488,102.8884,0" Scale="1,1,1" Type="Normal" Name="BonusObjective01" Color="0,0,0,0"/>
+    <ObjectPoint Id="2147" Position="54.5095,111.4533,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 028" Color="0,0,0,0"/>
+    <ObjectPoint Id="362" Position="126.4174,50.6174,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_12" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="175" Name="KerriganCoccoon" Position="137,24.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2132" Name="Pathing Cliff Fill 013" Position="103.2534,104.6604,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="535" Name="Kerrigan_ForwardBase03_DropPod03" Position="108.5,173.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2362" Name="Pathing Cliff Fill 059" Position="155.588,150.0852,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1232" Name="No Fly Zone 010" PathingRadiusHard="7" PathingRadiusSoft="7.75" Position="83.829,232.6574,0" Scale="1,1,1" Type="NoFlyZone"/>
-    <ObjectPoint Color="0,0,0,0" Id="371" Name="Narud_vsRaynor_08" Position="93.408,92.827,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="544" Position="90.1284,216.601,0" Rotation="3.6137" Scale="1,1,1" Type="Normal" Name="Victory_Raynor" Color="0,0,0,0"/>
+    <ObjectPoint Id="175" Position="137,24.5,0" Scale="1,1,1" Type="Normal" Name="KerriganCoccoon" Color="0,0,0,0"/>
+    <ObjectPoint Id="2132" Position="103.2534,104.6604,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 013" Color="0,0,0,0"/>
+    <ObjectPoint Id="535" Position="108.5,173.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase03_DropPod03" Color="0,0,0,0"/>
+    <ObjectPoint Id="2362" Position="155.588,150.0852,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 059" Color="0,0,0,0"/>
+    <ObjectPoint Id="371" Position="93.408,92.827,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_08" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="1083" Name="Mid_StalkerWarpIn03" Position="56.6596,40.2558,0" Rotation="2.5292" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2129" Name="Pathing Cliff Fill 010" Position="110.2346,59.2907,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2367" Name="Pathing Cliff Fill 061" Position="67.4787,70.4621,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2239" Name="Raynor&amp;Kerrigan_AttackPoint" Position="88.1052,220.6684,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="374" Name="Narud_vsRaynor_11" Position="97.346,59.6132,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="1232" Position="83.829,232.6574,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 010" Color="0,0,0,0" PathingRadiusSoft="7.75" PathingRadiusHard="7"/>
+    <ObjectPoint Id="1083" Position="56.6596,40.2558,0" Rotation="2.5292" Scale="1,1,1" Type="Normal" Name="Mid_StalkerWarpIn03" Color="0,0,0,0"/>
+    <ObjectPoint Id="2129" Position="110.2346,59.2907,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 010" Color="0,0,0,0"/>
+    <ObjectPoint Id="2367" Position="67.4787,70.4621,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 061" Color="0,0,0,0"/>
+    <ObjectPoint Id="2239" Position="88.1052,220.6684,0" Scale="1,1,1" Type="Normal" Name="Raynor&amp;Kerrigan_AttackPoint" Color="0,0,0,0"/>
+    <ObjectPoint Id="374" Position="97.346,59.6132,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_11" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2342" Name="Pathing Cliff Fill 039" Position="152.5893,28.9941,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="321" Name="Kerrigan_ForwardBase01_CreepTumor03" Position="137.5,82.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1058" Name="Mid_ZealotWarpIn02" Position="57.084,43.6904,0" Rotation="2.5295" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2120" Name="Pathing Cliff Fill 001" Position="19.283,57.3144,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1097" Name="Mid_WarpPrism" Position="54.8144,38.1518,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2150" Name="Intro Warp Prism 02 Target" Position="21,13.7797,0" Rotation="2.2734" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="170" Name="Victory_Kerrigan" Position="92.9101,217.928,0" Rotation="3.8681" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1228" Name="No Fly Zone 008" PathingRadiusHard="7" PathingRadiusSoft="7.75" Position="81.5793,235.7001,0" Scale="1,1,1" Type="NoFlyZone"/>
-    <ObjectPoint Color="0,0,0,0" Id="367" Name="Narud_vsRaynor_04" Position="58.4746,170.9506,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2342" Position="152.5893,28.9941,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 039" Color="0,0,0,0"/>
+    <ObjectPoint Id="321" Position="137.5,82.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase01_CreepTumor03" Color="0,0,0,0"/>
+    <ObjectPoint Id="1058" Position="57.084,43.6904,0" Rotation="2.5295" Scale="1,1,1" Type="Normal" Name="Mid_ZealotWarpIn02" Color="0,0,0,0"/>
+    <ObjectPoint Id="2120" Position="19.283,57.3144,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 001" Color="0,0,0,0"/>
+    <ObjectPoint Id="1097" Position="54.8144,38.1518,0" Scale="1,1,1" Type="Normal" Name="Mid_WarpPrism" Color="0,0,0,0"/>
+    <ObjectPoint Id="2150" Position="21,13.7797,0" Rotation="2.2734" Scale="1,1,1" Type="Normal" Name="Intro Warp Prism 02 Target" Color="0,0,0,0"/>
+    <ObjectPoint Id="170" Position="92.9101,217.928,0" Rotation="3.8681" Scale="1,1,1" Type="Normal" Name="Victory_Kerrigan" Color="0,0,0,0"/>
+    <ObjectPoint Id="367" Position="58.4746,170.9506,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_04" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="446" Name="Start Location 004" Position="81.5,244.5,0" Rotation="1.5705" Scale="1,1,1" Type="StartLoc"/>
-    <ObjectPoint Color="0,0,0,0" Id="336" Name="Narud_vsKerrigan_05" Position="118.4323,155.9047,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="1228" Position="81.5793,235.7001,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 008" Color="0,0,0,0" PathingRadiusSoft="7.75" PathingRadiusHard="7"/>
+    <ObjectPoint Id="446" Position="81.5,244.5,0" Rotation="1.5705" Scale="1,1,1" Type="StartLoc" Name="Start Location 004" Color="0,0,0,0"/>
+    <ObjectPoint Id="336" Position="118.4323,155.9047,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_05" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2359" Name="Pathing Cliff Fill 056" Position="159.889,135.1835,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1176" Name="BonusObjecive01_Barracks01" Position="19.4985,97.4985,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="315" Name="Kerrigan_ForwardBase01_DropPod01" Position="143.5,81.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2137" Name="Pathing Cliff Fill 018" Position="177.9377,124.348,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="359" Name="Narud_vsKerrigan_09" Position="129.688,94.6472,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="315" Position="143.5,81.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase01_DropPod01" Color="0,0,0,0"/>
+    <ObjectPoint Id="1176" Position="19.4985,97.4985,0" Scale="1,1,1" Type="Normal" Name="BonusObjecive01_Barracks01" Color="0,0,0,0"/>
+    <ObjectPoint Id="2359" Position="159.889,135.1835,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 056" Color="0,0,0,0"/>
+    <ObjectPoint Id="2137" Position="177.9377,124.348,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 018" Color="0,0,0,0"/>
+    <ObjectPoint Id="359" Position="129.688,94.6472,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_09" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="1135" Name="BonusObjective01_Barracks02" Position="28.5,96.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="39" Name="BonusObjective02_Gather" Position="36.782,144.8195,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2350" Name="Pathing Cliff Fill 047" Position="44.7324,120.8801,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="418" Name="Victory Kerrigan 2" Position="92.207,222.845,0" Rotation="3.868" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="396" Name="Kerrigan_ForwardBase02_DropPod01" Position="139.5,120.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="34" Name="Narud_vsRaynor_14" Position="87.602,31.643,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="1135" Position="28.5,96.5,0" Scale="1,1,1" Type="Normal" Name="BonusObjective01_Barracks02" Color="0,0,0,0"/>
+    <ObjectPoint Id="39" Position="36.782,144.8195,0" Scale="1,1,1" Type="Normal" Name="BonusObjective02_Gather" Color="0,0,0,0"/>
+    <ObjectPoint Id="2350" Position="44.7324,120.8801,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 047" Color="0,0,0,0"/>
+    <ObjectPoint Id="418" Position="92.207,222.845,0" Rotation="3.868" Scale="1,1,1" Type="Normal" Name="Victory Kerrigan 2" Color="0,0,0,0"/>
+    <ObjectPoint Id="396" Position="139.5,120.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase02_DropPod01" Color="0,0,0,0"/>
+    <ObjectPoint Id="34" Position="87.602,31.643,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_14" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="487" Name="Stage 02 Player Start" Position="53.5,35.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2347" Name="Pathing Cliff Fill 044" Position="68.94,73.1936,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="332" Name="Narud_vsKerrigan_01" Position="87.6228,212.1196,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="487" Position="53.5,35.5,0" Scale="1,1,1" Type="Normal" Name="Stage 02 Player Start" Color="0,0,0,0"/>
+    <ObjectPoint Id="2347" Position="68.94,73.1936,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 044" Color="0,0,0,0"/>
+    <ObjectPoint Id="332" Position="87.6228,212.1196,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_01" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="443" Name="Start Location 001" Position="20.5,15.5,0" Scale="1,1,1" Type="StartLoc"/>
-    <ObjectPoint Color="0,0,0,0" Id="1139" Name="BonusObjective02_Factory01" Position="23.5,143.5097,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="443" Position="20.5,15.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location 001" Color="0,0,0,0"/>
+    <ObjectPoint Id="1139" Position="23.5,143.5097,0" Scale="1,1,1" Type="Normal" Name="BonusObjective02_Factory01" Color="0,0,0,0">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="602" Name="Kerrigan_Gather" Position="128.792,36.0937,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2226" Name="Intro Pan To" Position="21.8076,17.5402,0" Rotation="2.2614" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="379" Name="Raynor_ForwardBase03_DropPod02" Position="60.4665,177.4602,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2354" Name="Pathing Cliff Fill 051" Position="84.4196,88.6044,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="318" Name="Kerrigan_ForwardBase01_DropPod03" Position="137.5,82.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1078" Name="Raynor_Waypoint02" Position="89.4897,129.835,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2140" Name="Pathing Cliff Fill 021" Position="145.6142,90.515,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2145" Name="Pathing Cliff Fill 026" Position="35.24,126.4936,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1120" Name="StukovCoccoon" Position="135.9882,22.2878,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="360" Name="Narud_vsKerrigan_10" Position="136.9233,83.9133,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="602" Position="128.792,36.0937,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_Gather" Color="0,0,0,0"/>
+    <ObjectPoint Id="2226" Position="21.8076,17.5402,0" Rotation="2.2614" Scale="1,1,1" Type="Normal" Name="Intro Pan To" Color="0,0,0,0"/>
+    <ObjectPoint Id="379" Position="60.4665,177.4602,0" Scale="1,1,1" Type="Normal" Name="Raynor_ForwardBase03_DropPod02" Color="0,0,0,0"/>
+    <ObjectPoint Id="318" Position="137.5,82.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase01_DropPod03" Color="0,0,0,0"/>
+    <ObjectPoint Id="2354" Position="84.4196,88.6044,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 051" Color="0,0,0,0"/>
+    <ObjectPoint Id="1078" Position="89.4897,129.835,0" Scale="1,1,1" Type="Normal" Name="Raynor_Waypoint02" Color="0,0,0,0"/>
+    <ObjectPoint Id="2140" Position="145.6142,90.515,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 021" Color="0,0,0,0"/>
+    <ObjectPoint Id="2145" Position="35.24,126.4936,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 026" Color="0,0,0,0"/>
+    <ObjectPoint Id="1120" Position="135.9882,22.2878,0" Scale="1,1,1" Type="Normal" Name="StukovCoccoon" Color="0,0,0,0"/>
+    <ObjectPoint Id="360" Position="136.9233,83.9133,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_10" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2337" Name="Pathing Cliff Fill 034" Position="104.6428,13.0585,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="326" Name="Kerrigan_ForwardBase02_CreepTumor03" Position="146.5,124.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="40" Name="BonusObjective01_Gather" Position="38.3935,95.5031,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2127" Name="Pathing Cliff Fill 008" Position="128.3745,73.8828,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="369" Name="Narud_vsRaynor_06" Position="90.5478,126.212,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2337" Position="104.6428,13.0585,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 034" Color="0,0,0,0"/>
+    <ObjectPoint Id="326" Position="146.5,124.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase02_CreepTumor03" Color="0,0,0,0"/>
+    <ObjectPoint Id="40" Position="38.3935,95.5031,0" Scale="1,1,1" Type="Normal" Name="BonusObjective01_Gather" Color="0,0,0,0"/>
+    <ObjectPoint Id="2127" Position="128.3745,73.8828,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 008" Color="0,0,0,0"/>
+    <ObjectPoint Id="369" Position="90.5478,126.212,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_06" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="830" Name="No Fly Zone 003" PathingRadiusHard="1.75" PathingRadiusSoft="2.25" Position="110.6235,202.3793,0" Scale="1,1,1" Type="NoFlyZone"/>
-    <ObjectPoint Color="0,0,0,0" Id="2134" Name="Pathing Cliff Fill 015" Position="106.8317,148.4846,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2360" Name="Pathing Cliff Fill 057" Position="175.5095,123.3322,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="308" Name="Raynor_SCVRespawn" Position="85.9621,25.7165,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="372" Name="Narud_vsRaynor_09" Position="96.4597,80.8217,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="830" Position="110.6235,202.3793,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 003" Color="0,0,0,0" PathingRadiusSoft="2.25" PathingRadiusHard="1.75"/>
+    <ObjectPoint Id="2134" Position="106.8317,148.4846,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 015" Color="0,0,0,0"/>
+    <ObjectPoint Id="308" Position="85.9621,25.7165,0" Scale="1,1,1" Type="Normal" Name="Raynor_SCVRespawn" Color="0,0,0,0"/>
+    <ObjectPoint Id="2360" Position="175.5095,123.3322,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 057" Color="0,0,0,0"/>
+    <ObjectPoint Id="372" Position="96.4597,80.8217,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_09" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2131" Name="Pathing Cliff Fill 012" Position="100.4875,111.6857,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="699" Name="Start Location 007" Position="93.5,244.5,0" Rotation="1.5705" Scale="1,1,1" Type="StartLoc"/>
-    <ObjectPoint Color="0,0,0,0" Id="1081" Name="FirstNarudShade_SpawnPoint" Position="87.59,216.0756,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="346" Name="Narud_vsKerrigan_06" Position="133.522,135.258,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2131" Position="100.4875,111.6857,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 012" Color="0,0,0,0"/>
+    <ObjectPoint Id="699" Position="93.5,244.5,0" Rotation="1.5705" Scale="1,1,1" Type="StartLoc" Name="Start Location 007" Color="0,0,0,0"/>
+    <ObjectPoint Id="1081" Position="87.59,216.0756,0" Scale="1,1,1" Type="Normal" Name="FirstNarudShade_SpawnPoint" Color="0,0,0,0"/>
+    <ObjectPoint Id="346" Position="133.522,135.258,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_06" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2148" Name="Pathing Cliff Fill 029" Position="54.0373,108.4165,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1125" Name="BonusObjective04" Position="148,185,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="429" Name="Kerrigan_ForwardBase03_CreepTumor03" Position="108.5,173.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1230" Name="No Fly Zone 007" PathingRadiusHard="7" PathingRadiusSoft="7.75" Position="88.1723,232.3317,0" Scale="1,1,1" Type="NoFlyZone"/>
-    <ObjectPoint Color="0,0,0,0" Id="365" Name="Narud_vsRaynor_02" Position="73.8293,201.3393,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2148" Position="54.0373,108.4165,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 029" Color="0,0,0,0"/>
+    <ObjectPoint Id="1125" Position="148,185,0" Scale="1,1,1" Type="Normal" Name="BonusObjective04" Color="0,0,0,0"/>
+    <ObjectPoint Id="429" Position="108.5,173.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase03_CreepTumor03" Color="0,0,0,0"/>
+    <ObjectPoint Id="365" Position="73.8293,201.3393,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_02" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="1189" Name="BonusObjective02_Factory03" Position="28.5,148.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2340" Name="Pathing Cliff Fill 037" Position="22.542,53.3671,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1099" Name="Mid_HyperionStart" Position="78.8586,18.0561,0" Rotation="2.4072" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2122" Name="Pathing Cliff Fill 003" Position="55.8146,19.5375,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2366" Name="Pathing Cliff Fill 060" Position="80.5256,46.8337,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2107" Name="Intro Warp Prism 02 Spawn" Position="14.5498,8.94,0" Rotation="2.416" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1082" Name="Mid_StalkerWarpIn02" Position="55.8315,41.7653,0" Rotation="2.5292" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2128" Name="Pathing Cliff Fill 009" Position="119.5627,72.2065,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="439" Name="Victory_Stukov_WalkEnd2" Position="88.1394,221.4074,0" Rotation="2.991" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="662" Name="No Fly Zone 002" PathingRadiusHard="1.75" PathingRadiusSoft="2.25" Position="99.2434,191.6218,0" Scale="1,1,1" Type="NoFlyZone"/>
-    <ObjectPoint Color="0,0,0,0" Id="375" Name="Narud_vsRaynor_12" Position="100.863,48.752,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="1230" Position="88.1723,232.3317,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 007" Color="0,0,0,0" PathingRadiusSoft="7.75" PathingRadiusHard="7"/>
+    <ObjectPoint Id="1189" Position="28.5,148.5,0" Scale="1,1,1" Type="Normal" Name="BonusObjective02_Factory03" Color="0,0,0,0"/>
+    <ObjectPoint Id="2340" Position="22.542,53.3671,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 037" Color="0,0,0,0"/>
+    <ObjectPoint Id="1099" Position="78.8586,18.0561,0" Rotation="2.4072" Scale="1,1,1" Type="Normal" Name="Mid_HyperionStart" Color="0,0,0,0"/>
+    <ObjectPoint Id="2122" Position="55.8146,19.5375,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 003" Color="0,0,0,0"/>
+    <ObjectPoint Id="2366" Position="80.5256,46.8337,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 060" Color="0,0,0,0"/>
+    <ObjectPoint Id="2107" Position="14.5498,8.94,0" Rotation="2.416" Scale="1,1,1" Type="Normal" Name="Intro Warp Prism 02 Spawn" Color="0,0,0,0"/>
+    <ObjectPoint Id="1082" Position="55.8315,41.7653,0" Rotation="2.5292" Scale="1,1,1" Type="Normal" Name="Mid_StalkerWarpIn02" Color="0,0,0,0"/>
+    <ObjectPoint Id="2128" Position="119.5627,72.2065,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 009" Color="0,0,0,0"/>
+    <ObjectPoint Id="439" Position="88.1394,221.4074,0" Rotation="2.991" Scale="1,1,1" Type="Normal" Name="Victory_Stukov_WalkEnd2" Color="0,0,0,0"/>
+    <ObjectPoint Id="662" Position="99.2434,191.6218,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 002" Color="0,0,0,0" PathingRadiusSoft="2.25" PathingRadiusHard="1.75"/>
+    <ObjectPoint Id="375" Position="100.863,48.752,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_12" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2121" Name="Pathing Cliff Fill 002" Position="54.962,14.3054,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2343" Name="Pathing Cliff Fill 040" Position="151.0908,56.6933,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="320" Name="Kerrigan_ForwardBase01_CreepTumor02" Position="131.5,81.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1229" Name="No Fly Zone 006" PathingRadiusHard="7" PathingRadiusSoft="7.75" Position="95.1625,235.426,0" Scale="1,1,1" Type="NoFlyZone"/>
-    <ObjectPoint Color="0,0,0,0" Id="548" Name="vsRaynor_Waypoint02" Position="96.1806,85.5273,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="366" Name="Narud_vsRaynor_03" Position="58.475,183.3691,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2121" Position="54.962,14.3054,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 002" Color="0,0,0,0"/>
+    <ObjectPoint Id="2343" Position="151.0908,56.6933,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 040" Color="0,0,0,0"/>
+    <ObjectPoint Id="320" Position="131.5,81.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase01_CreepTumor02" Color="0,0,0,0"/>
+    <ObjectPoint Id="366" Position="58.475,183.3691,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_03" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2151" Name="Intro Warp Prism 01 Target" Position="18.2246,16.72,0" Rotation="2.2385" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="107" Name="Start Location 005" Position="85.5,244.5,0" Rotation="1.5705" Scale="1,1,1" Type="StartLoc"/>
-    <ObjectPoint Color="0,0,0,0" Id="2124" Name="Pathing Cliff Fill 005" Position="151.6037,43.3771,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="325" Name="Kerrigan_ForwardBase02_CreepTumor02" Position="135.5,126.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2338" Name="Pathing Cliff Fill 035" Position="45.9155,25.7343,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="612" Name="Raynor_Waypoint03" Position="55.3867,173.267,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="363" Name="Narud_vsKerrigan_13" Position="133.6955,27.5476,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="548" Position="96.1806,85.5273,0" Scale="1,1,1" Type="Normal" Name="vsRaynor_Waypoint02" Color="0,0,0,0"/>
+    <ObjectPoint Id="1229" Position="95.1625,235.426,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 006" Color="0,0,0,0" PathingRadiusSoft="7.75" PathingRadiusHard="7"/>
+    <ObjectPoint Id="107" Position="85.5,244.5,0" Rotation="1.5705" Scale="1,1,1" Type="StartLoc" Name="Start Location 005" Color="0,0,0,0"/>
+    <ObjectPoint Id="2151" Position="18.2246,16.72,0" Rotation="2.2385" Scale="1,1,1" Type="Normal" Name="Intro Warp Prism 01 Target" Color="0,0,0,0"/>
+    <ObjectPoint Id="2124" Position="151.6037,43.3771,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 005" Color="0,0,0,0"/>
+    <ObjectPoint Id="325" Position="135.5,126.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase02_CreepTumor02" Color="0,0,0,0"/>
+    <ObjectPoint Id="612" Position="55.3867,173.267,0" Scale="1,1,1" Type="Normal" Name="Raynor_Waypoint03" Color="0,0,0,0"/>
+    <ObjectPoint Id="2338" Position="45.9155,25.7343,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 035" Color="0,0,0,0"/>
+    <ObjectPoint Id="363" Position="133.6955,27.5476,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_13" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2146" Name="Pathing Cliff Fill 027" Position="49.6364,115.643,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1123" Name="BonusObjective02" Position="27,148,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="427" Name="Kerrigan_ForwardBase03_CreepTumor01" Position="108.5,177.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="534" Name="Kerrigan_ForwardBase03_DropPod02" Position="113.4985,170.499,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2133" Name="Pathing Cliff Fill 014" Position="120.019,119.5207,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="370" Name="Narud_vsRaynor_07" Position="83.1726,106.309,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2146" Position="49.6364,115.643,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 027" Color="0,0,0,0"/>
+    <ObjectPoint Id="1123" Position="27,148,0" Scale="1,1,1" Type="Normal" Name="BonusObjective02" Color="0,0,0,0"/>
+    <ObjectPoint Id="427" Position="108.5,177.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase03_CreepTumor01" Color="0,0,0,0"/>
+    <ObjectPoint Id="534" Position="113.4985,170.499,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase03_DropPod02" Color="0,0,0,0"/>
+    <ObjectPoint Id="2133" Position="120.019,119.5207,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 014" Color="0,0,0,0"/>
+    <ObjectPoint Id="370" Position="83.1726,106.309,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_07" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="335" Name="Narud_vsKerrigan_04" Position="110.1252,170.2841,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="335" Position="110.1252,170.2841,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_04" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2344" Name="Pathing Cliff Fill 041" Position="123.4113,72.3666,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2152" Name="Pathing Cliff Fill 031" Position="88.332,155.2102,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="417" Name="Victory Raynor 2" Position="90.195,221.5822,0" Rotation="3.6135" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2143" Name="Pathing Cliff Fill 024" Position="127.4738,186.1533,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1077" Name="Mid_ZealotWarpIn03" Position="57.9826,41.7922,0" Rotation="2.5295" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="248" Name="vsRaynor_Gather" Position="66.988,194.5622,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2353" Name="Pathing Cliff Fill 050" Position="84.3708,90.3554,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="317" Name="Kerrigan_ForwardBase01_DropPod02" Position="131.5,81.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="376" Name="Raynor_ForwardBase02_DropPod01" Position="84.5092,131.4055,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="601" Name="Raynor_Gather" Position="86.6196,31.7763,0" Rotation="3.1413" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2225" Name="Intro Pan From" Position="11.9453,11.5324,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1136" Name="BonusObjective01_Starport" Position="33.499,102.4985,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="22" Name="Narud_vsRaynor_13" Position="97.2514,43.0686,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2344" Position="123.4113,72.3666,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 041" Color="0,0,0,0"/>
+    <ObjectPoint Id="2152" Position="88.332,155.2102,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 031" Color="0,0,0,0"/>
+    <ObjectPoint Id="417" Position="90.195,221.5822,0" Rotation="3.6135" Scale="1,1,1" Type="Normal" Name="Victory Raynor 2" Color="0,0,0,0"/>
+    <ObjectPoint Id="2143" Position="127.4738,186.1533,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 024" Color="0,0,0,0"/>
+    <ObjectPoint Id="1077" Position="57.9826,41.7922,0" Rotation="2.5295" Scale="1,1,1" Type="Normal" Name="Mid_ZealotWarpIn03" Color="0,0,0,0"/>
+    <ObjectPoint Id="248" Position="66.988,194.5622,0" Scale="1,1,1" Type="Normal" Name="vsRaynor_Gather" Color="0,0,0,0"/>
+    <ObjectPoint Id="317" Position="131.5,81.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase01_DropPod02" Color="0,0,0,0"/>
+    <ObjectPoint Id="2353" Position="84.3708,90.3554,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 050" Color="0,0,0,0"/>
+    <ObjectPoint Id="376" Position="84.5092,131.4055,0" Scale="1,1,1" Type="Normal" Name="Raynor_ForwardBase02_DropPod01" Color="0,0,0,0"/>
+    <ObjectPoint Id="601" Position="86.6196,31.7763,0" Rotation="3.1413" Scale="1,1,1" Type="Normal" Name="Raynor_Gather" Color="0,0,0,0"/>
+    <ObjectPoint Id="2225" Position="11.9453,11.5324,0" Scale="1,1,1" Type="Normal" Name="Intro Pan From" Color="0,0,0,0"/>
+    <ObjectPoint Id="1136" Position="33.499,102.4985,0" Scale="1,1,1" Type="Normal" Name="BonusObjective01_Starport" Color="0,0,0,0"/>
+    <ObjectPoint Id="22" Position="97.2514,43.0686,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_13" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2138" Name="Pathing Cliff Fill 019" Position="176.9001,132.3073,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2356" Name="Pathing Cliff Fill 053" Position="164.219,135.975,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="445" Name="Start Location 003" Position="133.5,25.5,0" Scale="1,1,1" Type="StartLoc"/>
-    <ObjectPoint Color="0,0,0,0" Id="2349" Name="Pathing Cliff Fill 046" Position="37.5822,129.038,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="330" Name="Raynor_ForwardBase01_DropPod01" Position="97.495,73.2011,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="36" Name="Narud_vsRaynor_15" Position="83.346,22.6533,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2138" Position="176.9001,132.3073,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 019" Color="0,0,0,0"/>
+    <ObjectPoint Id="2356" Position="164.219,135.975,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 053" Color="0,0,0,0"/>
+    <ObjectPoint Id="445" Position="133.5,25.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location 003" Color="0,0,0,0"/>
+    <ObjectPoint Id="2349" Position="37.5822,129.038,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 046" Color="0,0,0,0"/>
+    <ObjectPoint Id="330" Position="97.495,73.2011,0" Scale="1,1,1" Type="Normal" Name="Raynor_ForwardBase01_DropPod01" Color="0,0,0,0"/>
+    <ObjectPoint Id="36" Position="83.346,22.6533,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_15" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="832" Name="No Fly Zone 005" PathingRadiusHard="1.75" PathingRadiusSoft="2.25" Position="67.9206,203.488,0" Scale="1,1,1" Type="NoFlyZone">
+    <ObjectPoint Id="832" Position="67.9206,203.488,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 005" Color="0,0,0,0" PathingRadiusSoft="2.25" PathingRadiusHard="1.75">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="1223" Name="Victory_Stukov_WalkEnd" Position="88.073,219.5671,0" Rotation="2.9912" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="373" Name="Narud_vsRaynor_10" Position="91.4692,71.9157,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="1223" Position="88.073,219.5671,0" Rotation="2.9912" Scale="1,1,1" Type="Normal" Name="Victory_Stukov_WalkEnd" Color="0,0,0,0"/>
+    <ObjectPoint Id="373" Position="91.4692,71.9157,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_10" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="245" Name="vsKerrigan_Gather" Position="108.9294,193.1782,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="698" Name="Start Location 006" Position="89.5,244.5,0" Rotation="1.5705" Scale="1,1,1" Type="StartLoc"/>
-    <ObjectPoint Color="0,0,0,0" Id="2130" Name="Pathing Cliff Fill 011" Position="105.7353,77.856,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1080" Name="Mid_StalkerWarpIn01" Position="53.2927,41.7297,0" Rotation="2.5295" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1231" Name="No Fly Zone 009" PathingRadiusHard="7" PathingRadiusSoft="7.75" Position="91.922,232.9306,0" Scale="1,1,1" Type="NoFlyZone"/>
-    <ObjectPoint Color="0,0,0,0" Id="364" Name="Narud_vsRaynor_01" Position="82.7993,212.1066,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="245" Position="108.9294,193.1782,0" Scale="1,1,1" Type="Normal" Name="vsKerrigan_Gather" Color="0,0,0,0"/>
+    <ObjectPoint Id="698" Position="89.5,244.5,0" Rotation="1.5705" Scale="1,1,1" Type="StartLoc" Name="Start Location 006" Color="0,0,0,0"/>
+    <ObjectPoint Id="2130" Position="105.7353,77.856,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 011" Color="0,0,0,0"/>
+    <ObjectPoint Id="1080" Position="53.2927,41.7297,0" Rotation="2.5295" Scale="1,1,1" Type="Normal" Name="Mid_StalkerWarpIn01" Color="0,0,0,0"/>
+    <ObjectPoint Id="364" Position="82.7993,212.1066,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_01" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="1124" Name="BonusObjective03" Position="163,96,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2149" Name="Pathing Cliff Fill 030" Position="51.0727,111.0893,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="428" Name="Kerrigan_ForwardBase03_CreepTumor02" Position="113.4985,170.499,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2123" Name="Pathing Cliff Fill 004" Position="108.6723,23.6872,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1057" Name="Mid_ZealotWarpIn01" Position="54.3852,43.8015,0" Rotation="2.5297" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="520" Name="Kerrigan_ForwardBase03_DropPod01" Position="108.5,177.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2341" Name="Pathing Cliff Fill 038" Position="150.357,28.3352,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="547" Name="vsKerrigan_Waypoint" Position="129.3576,103.3188,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="361" Name="Narud_vsKerrigan_11" Position="140.9274,70.057,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="1231" Position="91.922,232.9306,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 009" Color="0,0,0,0" PathingRadiusSoft="7.75" PathingRadiusHard="7"/>
+    <ObjectPoint Id="1124" Position="163,96,0" Scale="1,1,1" Type="Normal" Name="BonusObjective03" Color="0,0,0,0"/>
+    <ObjectPoint Id="2149" Position="51.0727,111.0893,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 030" Color="0,0,0,0"/>
+    <ObjectPoint Id="428" Position="113.4985,170.499,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase03_CreepTumor02" Color="0,0,0,0"/>
+    <ObjectPoint Id="2123" Position="108.6723,23.6872,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 004" Color="0,0,0,0"/>
+    <ObjectPoint Id="1057" Position="54.3852,43.8015,0" Rotation="2.5297" Scale="1,1,1" Type="Normal" Name="Mid_ZealotWarpIn01" Color="0,0,0,0"/>
+    <ObjectPoint Id="520" Position="108.5,177.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase03_DropPod01" Color="0,0,0,0"/>
+    <ObjectPoint Id="2341" Position="150.357,28.3352,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 038" Color="0,0,0,0"/>
+    <ObjectPoint Id="361" Position="140.9274,70.057,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_11" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2144" Name="Pathing Cliff Fill 025" Position="40.1096,117.9755,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="41" Name="BonusObjective03_Gather" Position="161.303,93.1147,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2126" Name="Pathing Cliff Fill 007" Position="150.9162,58.8454,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="678" Name="Narud_SpawnPoint" Position="88,228,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="547" Position="129.3576,103.3188,0" Scale="1,1,1" Type="Normal" Name="vsKerrigan_Waypoint" Color="0,0,0,0"/>
+    <ObjectPoint Id="2144" Position="40.1096,117.9755,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 025" Color="0,0,0,0"/>
+    <ObjectPoint Id="41" Position="161.303,93.1147,0" Scale="1,1,1" Type="Normal" Name="BonusObjective03_Gather" Color="0,0,0,0"/>
+    <ObjectPoint Id="2126" Position="150.9162,58.8454,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 007" Color="0,0,0,0"/>
+    <ObjectPoint Id="678" Position="88,228,0" Scale="1,1,1" Type="Normal" Name="Narud_SpawnPoint" Color="0,0,0,0">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2336" Name="Pathing Cliff Fill 033" Position="75.3605,17.216,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="1167" Name="BonusObjective03_Lair" Position="165.5,101.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="831" Name="No Fly Zone 004" PathingRadiusHard="1.75" PathingRadiusSoft="2.25" Position="77.205,194.3188,0" Scale="1,1,1" Type="NoFlyZone">
+    <ObjectPoint Id="1167" Position="165.5,101.5,0" Scale="1,1,1" Type="Normal" Name="BonusObjective03_Lair" Color="0,0,0,0"/>
+    <ObjectPoint Id="2336" Position="75.3605,17.216,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 033" Color="0,0,0,0"/>
+    <ObjectPoint Id="831" Position="77.205,194.3188,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 004" Color="0,0,0,0" PathingRadiusSoft="2.25" PathingRadiusHard="1.75">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="1208" Name="Start Location 009" Position="165.5,101.5,0" Rotation="1.5703" Scale="1,1,1" Type="StartLoc"/>
-    <ObjectPoint Color="0,0,0,0" Id="368" Name="Narud_vsRaynor_05" Position="83.2668,139.6896,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="1208" Position="165.5,101.5,0" Rotation="1.5703" Scale="1,1,1" Type="StartLoc" Name="Start Location 009" Color="0,0,0,0"/>
+    <ObjectPoint Id="368" Position="83.2668,139.6896,0" Scale="1,1,1" Type="Normal" Name="Narud_vsRaynor_05" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2361" Name="Pathing Cliff Fill 058" Position="158.0322,148.1542,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="240" Name="vsPlayer_Waypoint" Position="53.2634,86.0964,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2135" Name="Pathing Cliff Fill 016" Position="150.2297,143.3745,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2346" Name="Pathing Cliff Fill 043" Position="106.6442,70.6574,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="333" Name="Narud_vsKerrigan_02" Position="95.3393,202.0183,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="2361" Position="158.0322,148.1542,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 058" Color="0,0,0,0"/>
+    <ObjectPoint Id="240" Position="53.2634,86.0964,0" Scale="1,1,1" Type="Normal" Name="vsPlayer_Waypoint" Color="0,0,0,0"/>
+    <ObjectPoint Id="2135" Position="150.2297,143.3745,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 016" Color="0,0,0,0"/>
+    <ObjectPoint Id="2346" Position="106.6442,70.6574,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 043" Color="0,0,0,0"/>
+    <ObjectPoint Id="333" Position="95.3393,202.0183,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_02" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="397" Name="Kerrigan_ForwardBase02_DropPod02" Position="135.5,126.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="378" Name="Raynor_ForwardBase02_DropPod02" Position="88.7446,137.0588,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1138" Name="BonusObjective02_CommandCenter" Position="25.5,154.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1079" Name="vsRaynor_Waypoint01" Position="47.6855,170.2033,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2141" Name="Pathing Cliff Fill 022" Position="40.2285,172.2331,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="2355" Name="Pathing Cliff Fill 052" Position="84.2788,86.8305,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="319" Name="Kerrigan_ForwardBase01_CreepTumor01" Position="143.5,81.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1207" Name="Start Location 008" Position="25.5,103.5,0" Rotation="1.5703" Scale="1,1,1" Type="StartLoc"/>
-    <ObjectPoint Color="0,0,0,0" Id="606" Name="Raynor_Waypoint01" Position="88.2045,100.69,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2136" Name="Pathing Cliff Fill 017" Position="169.604,129.2094,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="401" Name="vsPlayer_Gather" Position="85.9843,208.1667,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="337" Name="Raynor_ForwardBase01_DropPod02" Position="88.6674,77.3225,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="2358" Name="Pathing Cliff Fill 055" Position="160.7495,135.5351,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectPoint Color="0,0,0,0" Id="314" Name="Mid_KerriganDropPod02" Position="96.8745,33.599,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="1134" Name="BonusObjective01_CommandCenter" Position="25.5,103.5,0" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="834" Name="Victory_Artanis" Position="83.6716,216.9423,0" Rotation="2.7524" Scale="1,1,1" Type="Normal"/>
-    <ObjectPoint Color="0,0,0,0" Id="358" Name="Narud_vsKerrigan_08" Position="134.798,109.6657,0" Scale="1,1,1" Type="Normal">
+    <ObjectPoint Id="397" Position="135.5,126.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase02_DropPod02" Color="0,0,0,0"/>
+    <ObjectPoint Id="378" Position="88.7446,137.0588,0" Scale="1,1,1" Type="Normal" Name="Raynor_ForwardBase02_DropPod02" Color="0,0,0,0"/>
+    <ObjectPoint Id="1138" Position="25.5,154.5,0" Scale="1,1,1" Type="Normal" Name="BonusObjective02_CommandCenter" Color="0,0,0,0"/>
+    <ObjectPoint Id="1079" Position="47.6855,170.2033,0" Scale="1,1,1" Type="Normal" Name="vsRaynor_Waypoint01" Color="0,0,0,0"/>
+    <ObjectPoint Id="2141" Position="40.2285,172.2331,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 022" Color="0,0,0,0"/>
+    <ObjectPoint Id="319" Position="143.5,81.5,0" Scale="1,1,1" Type="Normal" Name="Kerrigan_ForwardBase01_CreepTumor01" Color="0,0,0,0"/>
+    <ObjectPoint Id="2355" Position="84.2788,86.8305,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 052" Color="0,0,0,0"/>
+    <ObjectPoint Id="606" Position="88.2045,100.69,0" Scale="1,1,1" Type="Normal" Name="Raynor_Waypoint01" Color="0,0,0,0"/>
+    <ObjectPoint Id="1207" Position="25.5,103.5,0" Rotation="1.5703" Scale="1,1,1" Type="StartLoc" Name="Start Location 008" Color="0,0,0,0"/>
+    <ObjectPoint Id="2136" Position="169.604,129.2094,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 017" Color="0,0,0,0"/>
+    <ObjectPoint Id="401" Position="85.9843,208.1667,0" Scale="1,1,1" Type="Normal" Name="vsPlayer_Gather" Color="0,0,0,0"/>
+    <ObjectPoint Id="337" Position="88.6674,77.3225,0" Scale="1,1,1" Type="Normal" Name="Raynor_ForwardBase01_DropPod02" Color="0,0,0,0"/>
+    <ObjectPoint Id="314" Position="96.8745,33.599,0" Scale="1,1,1" Type="Normal" Name="Mid_KerriganDropPod02" Color="0,0,0,0"/>
+    <ObjectPoint Id="2358" Position="160.7495,135.5351,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 055" Color="0,0,0,0"/>
+    <ObjectPoint Id="1134" Position="25.5,103.5,0" Scale="1,1,1" Type="Normal" Name="BonusObjective01_CommandCenter" Color="0,0,0,0"/>
+    <ObjectPoint Id="834" Position="83.6716,216.9423,0" Rotation="2.7524" Scale="1,1,1" Type="Normal" Name="Victory_Artanis" Color="0,0,0,0"/>
+    <ObjectPoint Id="358" Position="134.798,109.6657,0" Scale="1,1,1" Type="Normal" Name="Narud_vsKerrigan_08" Color="0,0,0,0">
         <Flag Index="PointHidden" Value="1"/>
     </ObjectPoint>
-    <ObjectPoint Color="0,0,0,0" Id="2351" Name="Pathing Cliff Fill 048" Position="47.2851,118.243,0" Scale="1,1,1" Type="BlockPathing"/>
-    <ObjectCamera CameraTarget="79.1376,17.6142" Color="0,0,0,0" Id="1100" Name="Mid_HyperionStart" Position="79.1376,17.6142,0" Rotation="3.14" Scale="1,1,1">
+    <ObjectPoint Id="2351" Position="47.2851,118.243,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 048" Color="0,0,0,0"/>
+    <ObjectCamera Id="1100" Position="79.1376,17.6142,0" Rotation="3.14" Scale="1,1,1" Name="Mid_HyperionStart" Color="0,0,0,0" CameraTarget="79.1376,17.6142">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4769,7 +4770,7 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="81.5852,163.552" Color="0,0,0,0" Id="2231" Name="Mid Cine 3" Position="81.5852,163.552,0" Rotation="2.9755" Scale="1,1,1">
+    <ObjectCamera Id="2231" Position="81.5852,163.552,0" Rotation="2.9755" Scale="1,1,1" Name="Mid Cine 3" Color="0,0,0,0" CameraTarget="81.5852,163.552">
         <CameraValue Index="FieldOfView" Value="27.7995"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4787,7 +4788,7 @@
         <CameraValue Index="BokehFStop" Value="0.0175"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="20.5,15.5" Color="0,0,0,0" Id="449" Name="Intro_PlayerForces" Position="20.5,15.5,0" Rotation="3.14" Scale="1,1,1">
+    <ObjectCamera Id="449" Position="20.5,15.5,0" Rotation="3.14" Scale="1,1,1" Name="Intro_PlayerForces" Color="0,0,0,0" CameraTarget="20.5,15.5">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4798,7 +4799,7 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="140.9343,246.4477" Color="0,0,0,0" Id="111" Name="Intro_Fleet01" Position="140.9343,246.4477,0" Rotation="2.9145" Scale="1,1,1">
+    <ObjectCamera Id="111" Position="140.9343,246.4477,0" Rotation="2.9145" Scale="1,1,1" Name="Intro_Fleet01" Color="0,0,0,0" CameraTarget="140.9343,246.4477">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4809,20 +4810,7 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="60.2553,49.202" Color="0,0,0,0" Id="471" Name="Mid Tassadar Intro 1" Position="60.2553,49.202,0" Rotation="3.2744" Scale="1,1,1">
-        <CameraValue Index="FieldOfView" Value="27.7998"/>
-        <CameraValue Index="NearClip" Value="0.0998"/>
-        <CameraValue Index="FarClip" Value="20000"/>
-        <CameraValue Index="ShadowClip" Value="300"/>
-        <CameraValue Index="Distance" Value="34"/>
-        <CameraValue Index="Pitch" Value="39.6674"/>
-        <CameraValue Index="Yaw" Value="187.61"/>
-        <CameraValue Index="FocalDepth" Value="8"/>
-        <CameraValue Index="FalloffEnd" Value="8"/>
-        <CameraValue Index="BokehFStop" Value="0.0097"/>
-        <CameraValue Index="BokehMaxCoC" Value="1"/>
-    </ObjectCamera>
-    <ObjectCamera CameraTarget="90.0656,216.189" Color="0,0,0,0" Id="158" Name="Outro Stukov 1" Position="90.0656,216.189,0" Rotation="3.3916" Scale="1,1,1">
+    <ObjectCamera Id="158" Position="90.0656,216.189,0" Rotation="3.3916" Scale="1,1,1" Name="Outro Stukov 1" Color="0,0,0,0" CameraTarget="90.0656,216.189">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4836,7 +4824,31 @@
         <CameraValue Index="BokehFStop" Value="0.0187"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="99.9162,115.427" Color="0,0,0,0" Id="2229" Name="Mid Cine 1" Position="99.9162,115.427,0" Rotation="3.6235" Scale="1,1,1">
+    <ObjectCamera Id="471" Position="60.2553,49.202,0" Rotation="3.2744" Scale="1,1,1" Name="Mid Tassadar Intro 1" Color="0,0,0,0" CameraTarget="60.2553,49.202">
+        <CameraValue Index="FieldOfView" Value="27.7998"/>
+        <CameraValue Index="NearClip" Value="0.0998"/>
+        <CameraValue Index="FarClip" Value="20000"/>
+        <CameraValue Index="ShadowClip" Value="300"/>
+        <CameraValue Index="Distance" Value="34"/>
+        <CameraValue Index="Pitch" Value="39.6674"/>
+        <CameraValue Index="Yaw" Value="187.61"/>
+        <CameraValue Index="FocalDepth" Value="8"/>
+        <CameraValue Index="FalloffEnd" Value="8"/>
+        <CameraValue Index="BokehFStop" Value="0.0097"/>
+        <CameraValue Index="BokehMaxCoC" Value="1"/>
+    </ObjectCamera>
+    <ObjectCamera Id="35" Position="84.2336,23.116,0" Rotation="3.14" Scale="1,1,1" Name="Mid_RaynorBase" Color="0,0,0,0" CameraTarget="84.2336,23.116">
+        <CameraValue Index="FieldOfView" Value="27.7998"/>
+        <CameraValue Index="NearClip" Value="0.0998"/>
+        <CameraValue Index="FarClip" Value="20000"/>
+        <CameraValue Index="ShadowClip" Value="300"/>
+        <CameraValue Index="Distance" Value="34"/>
+        <CameraValue Index="Pitch" Value="56"/>
+        <CameraValue Index="Yaw" Value="179.9025"/>
+        <CameraValue Index="FocalDepth" Value="8"/>
+        <CameraValue Index="FalloffEnd" Value="8"/>
+    </ObjectCamera>
+    <ObjectCamera Id="2229" Position="99.9162,115.427,0" Rotation="3.6235" Scale="1,1,1" Name="Mid Cine 1" Color="0,0,0,0" CameraTarget="99.9162,115.427">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4850,18 +4862,7 @@
         <CameraValue Index="BokehFStop" Value="0.0097"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="84.2336,23.116" Color="0,0,0,0" Id="35" Name="Mid_RaynorBase" Position="84.2336,23.116,0" Rotation="3.14" Scale="1,1,1">
-        <CameraValue Index="FieldOfView" Value="27.7998"/>
-        <CameraValue Index="NearClip" Value="0.0998"/>
-        <CameraValue Index="FarClip" Value="20000"/>
-        <CameraValue Index="ShadowClip" Value="300"/>
-        <CameraValue Index="Distance" Value="34"/>
-        <CameraValue Index="Pitch" Value="56"/>
-        <CameraValue Index="Yaw" Value="179.9025"/>
-        <CameraValue Index="FocalDepth" Value="8"/>
-        <CameraValue Index="FalloffEnd" Value="8"/>
-    </ObjectCamera>
-    <ObjectCamera CameraTarget="88.312,252.8388" Color="0,0,0,0" Id="2232" Name="Mid Cine Narud 1" Position="88.312,252.8388,0" Rotation="3.1357" Scale="1,1,1">
+    <ObjectCamera Id="2232" Position="88.312,252.8388,0" Rotation="3.1357" Scale="1,1,1" Name="Mid Cine Narud 1" Color="0,0,0,0" CameraTarget="88.312,252.8388">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4875,7 +4876,7 @@
         <CameraValue Index="BokehFStop" Value="0.0178"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="179.4743,245.142" Color="0,0,0,0" Id="1234" Name="Intro_Fleet03" Position="179.4743,245.142,0" Rotation="1.5278" Scale="1,1,1">
+    <ObjectCamera Id="1234" Position="179.4743,245.142,0" Rotation="1.5278" Scale="1,1,1" Name="Intro_Fleet03" Color="0,0,0,0" CameraTarget="179.4743,245.142">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4886,7 +4887,7 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="60.538,43.0007" Color="0,0,0,0" Id="1091" Name="Mid Tassadar Intro 2" Position="60.538,43.0007,0" Rotation="3.281" Scale="1,1,1">
+    <ObjectCamera Id="1091" Position="60.538,43.0007,0" Rotation="3.281" Scale="1,1,1" Name="Mid Tassadar Intro 2" Color="0,0,0,0" CameraTarget="60.538,43.0007">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4899,7 +4900,7 @@
         <CameraValue Index="BokehFStop" Value="0.0178"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="149.176,246.3312" Color="0,0,0,0" Id="1251" Name="Intro_Fleet00" Position="149.176,246.3312,0" Rotation="2.9145" Scale="1,1,1">
+    <ObjectCamera Id="1251" Position="149.176,246.3312,0" Rotation="2.9145" Scale="1,1,1" Name="Intro_Fleet00" Color="0,0,0,0" CameraTarget="149.176,246.3312">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4910,7 +4911,7 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="42.842,22.3854" Color="0,0,0,0" Id="1098" Name="Mid_WarpPrismStart" Position="42.842,22.3854,0" Rotation="3.14" Scale="1,1,1">
+    <ObjectCamera Id="1098" Position="42.842,22.3854,0" Rotation="3.14" Scale="1,1,1" Name="Mid_WarpPrismStart" Color="0,0,0,0" CameraTarget="42.842,22.3854">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4921,7 +4922,7 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="88.7016,216.3876" Color="0,0,0,0" Id="2234" Name="Outro Narud 1" Position="88.7016,216.3876,0" Rotation="3.2744" Scale="1,1,1">
+    <ObjectCamera Id="2234" Position="88.7016,216.3876,0" Rotation="3.2744" Scale="1,1,1" Name="Outro Narud 1" Color="0,0,0,0" CameraTarget="88.7016,216.3876">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4935,7 +4936,7 @@
         <CameraValue Index="BokehFStop" Value="0.0187"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="133.344,37.579" Color="0,0,0,0" Id="472" Name="Mid_KerriganBase" Position="133.344,37.579,0" Rotation="3.14" Scale="1,1,1">
+    <ObjectCamera Id="472" Position="133.344,37.579,0" Rotation="3.14" Scale="1,1,1" Name="Mid_KerriganBase" Color="0,0,0,0" CameraTarget="133.344,37.579">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4946,7 +4947,7 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="82.0297,195.7976" Color="0,0,0,0" Id="2230" Name="Mid Cine 2" Position="82.0297,195.7976,0" Rotation="3.0012" Scale="1,1,1">
+    <ObjectCamera Id="2230" Position="82.0297,195.7976,0" Rotation="3.0012" Scale="1,1,1" Name="Mid Cine 2" Color="0,0,0,0" CameraTarget="82.0297,195.7976">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4960,7 +4961,7 @@
         <CameraValue Index="BokehFStop" Value="0.0178"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="82.855,209.1757" Color="0,0,0,0" Id="312" Name="Mid_Narud 02" Position="82.855,209.1757,0" Rotation="3.1357" Scale="1,1,1">
+    <ObjectCamera Id="312" Position="82.855,209.1757,0" Rotation="3.1357" Scale="1,1,1" Name="Mid_Narud 02" Color="0,0,0,0" CameraTarget="82.855,209.1757">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4971,7 +4972,7 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="88.0717,225.5444" Color="0,0,0,0" Id="470" Name="Mid_Narud 01" Position="88.0717,225.5444,0" Rotation="3.14" Scale="1,1,1">
+    <ObjectCamera Id="470" Position="88.0717,225.5444,0" Rotation="3.14" Scale="1,1,1" Name="Mid_Narud 01" Color="0,0,0,0" CameraTarget="88.0717,225.5444">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4982,7 +4983,7 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="88.4724,244.862" Color="0,0,0,0" Id="2233" Name="Mid Cine Narud 2" Position="88.4724,244.862,0" Rotation="3.1357" Scale="1,1,1">
+    <ObjectCamera Id="2233" Position="88.4724,244.862,0" Rotation="3.1357" Scale="1,1,1" Name="Mid Cine Narud 2" Color="0,0,0,0" CameraTarget="88.4724,244.862">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -4996,7 +4997,7 @@
         <CameraValue Index="BokehFStop" Value="0.0178"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="88.1962,230.77" Color="0,0,0,0" Id="155" Name="Outro Artanis 2" Position="88.1962,230.77,0" Rotation="3.0664" Scale="1,1,1">
+    <ObjectCamera Id="155" Position="88.1962,230.77,0" Rotation="3.0664" Scale="1,1,1" Name="Outro Artanis 2" Color="0,0,0,0" CameraTarget="88.1962,230.77">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -5009,18 +5010,7 @@
         <CameraValue Index="BokehFStop" Value="0.0097"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="154.1665,244.38" Color="0,0,0,0" Id="1233" Name="Intro_Fleet02" Position="154.1665,244.38,0" Rotation="1.5278" Scale="1,1,1">
-        <CameraValue Index="FieldOfView" Value="27.7998"/>
-        <CameraValue Index="NearClip" Value="0.0998"/>
-        <CameraValue Index="FarClip" Value="20000"/>
-        <CameraValue Index="ShadowClip" Value="300"/>
-        <CameraValue Index="Distance" Value="45.254"/>
-        <CameraValue Index="Pitch" Value="28.224"/>
-        <CameraValue Index="Yaw" Value="87.5383"/>
-        <CameraValue Index="FocalDepth" Value="8"/>
-        <CameraValue Index="FalloffEnd" Value="8"/>
-    </ObjectCamera>
-    <ObjectCamera CameraTarget="90.0656,216.189" Color="0,0,0,0" Id="414" Name="Outro Stukov 2" Position="90.0656,216.189,0" Rotation="3.3916" Scale="1,1,1">
+    <ObjectCamera Id="414" Position="90.0656,216.189,0" Rotation="3.3916" Scale="1,1,1" Name="Outro Stukov 2" Color="0,0,0,0" CameraTarget="90.0656,216.189">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -5034,7 +5024,18 @@
         <CameraValue Index="BokehFStop" Value="0.0187"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="87.4621,228.507" Color="0,0,0,0" Id="80" Name="Outro Artanis 1" Position="87.4621,228.507,0" Rotation="3.0622" Scale="1,1,1">
+    <ObjectCamera Id="1233" Position="154.1665,244.38,0" Rotation="1.5278" Scale="1,1,1" Name="Intro_Fleet02" Color="0,0,0,0" CameraTarget="154.1665,244.38">
+        <CameraValue Index="FieldOfView" Value="27.7998"/>
+        <CameraValue Index="NearClip" Value="0.0998"/>
+        <CameraValue Index="FarClip" Value="20000"/>
+        <CameraValue Index="ShadowClip" Value="300"/>
+        <CameraValue Index="Distance" Value="45.254"/>
+        <CameraValue Index="Pitch" Value="28.224"/>
+        <CameraValue Index="Yaw" Value="87.5383"/>
+        <CameraValue Index="FocalDepth" Value="8"/>
+        <CameraValue Index="FalloffEnd" Value="8"/>
+    </ObjectCamera>
+    <ObjectCamera Id="80" Position="87.4621,228.507,0" Rotation="3.0622" Scale="1,1,1" Name="Outro Artanis 1" Color="0,0,0,0" CameraTarget="87.4621,228.507">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -5047,7 +5048,7 @@
         <CameraValue Index="BokehFStop" Value="0.0097"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera CameraTarget="89.2421,216.169" Color="0,0,0,0" Id="2235" Name="Outro Narud 2" Position="89.2421,216.169,0" Rotation="3.2744" Scale="1,1,1">
+    <ObjectCamera Id="2235" Position="89.2421,216.169,0" Rotation="3.2744" Scale="1,1,1" Name="Outro Narud 2" Color="0,0,0,0" CameraTarget="89.2421,216.169">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="20000"/>
@@ -5061,139 +5062,129 @@
         <CameraValue Index="BokehFStop" Value="0.0187"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectUnit Id="989" Player="6" Position="89.3793,108.304,0" Rotation="0.57" Scale="1,1,1" UnitType="Viper">
+    <ObjectUnit Id="989" Position="89.3793,108.304,0" Rotation="0.57" Scale="1,1,1" UnitType="Viper" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="950" Player="7" Position="144.48,75.5097,0" Rotation="5.532" Scale="1,1,1" UnitType="Archon">
+    <ObjectUnit Id="950" Position="144.48,75.5097,0" Rotation="5.532" Scale="1,1,1" UnitType="Archon" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1073" Player="5" Position="141.1791,184.0573,0" Rotation="6.023" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1073" Position="141.1791,184.0573,0" Rotation="6.023" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="60" Player="6" Position="87.5,67.5,0" Rotation="0.822" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="60" Position="87.5,67.5,0" Rotation="0.822" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="87" Position="47,32.5,0" Scale="1,1,1" UnitType="MineralField" Variation="7">
+    <ObjectUnit Id="87" Variation="7" Position="47,32.5,0" Scale="1,1,1" UnitType="MineralField">
         <Resources Index="1" Value="3000"/>
         <Resources Index="2" Value="3000"/>
     </ObjectUnit>
-    <ObjectUnit Id="18" Player="1" Position="53,49,0" Scale="1,1,1" UnitType="AP_Pylon"/>
-    <ObjectUnit Id="121" Player="3" Position="128.6257,41.794,0" Rotation="3.4033" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="18" Position="53,49,0" Scale="1,1,1" UnitType="AP_Pylon" Player="1"/>
+    <ObjectUnit Id="121" Position="128.6257,41.794,0" Rotation="3.4033" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1011" Player="5" Position="45.9038,130.5012,0" Rotation="0.5031" Scale="1,1,1" UnitType="Liberator">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="920" Player="5" Position="48.0927,139.1613,0" Rotation="0.8056" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="1011" Position="45.9038,130.5012,0" Rotation="0.5031" Scale="1,1,1" UnitType="Liberator" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1978466315" Position="22,160.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField"/>
-    <ObjectUnit Id="37" Player="5" Position="72,98,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="920" Position="48.0927,139.1613,0" Rotation="0.8056" Scale="1,1,1" UnitType="Stalker" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1978466315" Position="22,160.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="37" Position="72,98,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="1064" Player="5" Position="145.147,181.4211,0" Rotation="5.5922" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1064" Position="145.147,181.4211,0" Rotation="5.5922" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="78" Player="1" Position="52.15,31.9384,0" Rotation="1.1633" Scale="1,1,1" UnitType="AP_Probe"/>
-    <ObjectUnit Id="943" Player="7" Position="123.6967,61.7055,0" Rotation="5.7766" Scale="1,1,1" UnitType="Archon">
+    <ObjectUnit Id="78" Position="52.15,31.9384,0" Rotation="1.1633" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
+    <ObjectUnit Id="943" Position="123.6967,61.7055,0" Rotation="5.7766" Scale="1,1,1" UnitType="Archon" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1002" Player="7" Position="135.94,118.6198,0" Rotation="5.3403" Scale="1,1,1" UnitType="Archon">
+    <ObjectUnit Id="1002" Position="135.94,118.6198,0" Rotation="5.3403" Scale="1,1,1" UnitType="Archon" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2247" Player="6" Position="30.1137,229.629,0" Rotation="5.571" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="897" Position="67.5632,155.5244,0" Rotation="1.0695" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2247" Position="30.1137,229.629,0" Rotation="5.571" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="897" Player="6" Position="67.5632,155.5244,0" Rotation="1.0695" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="11" Position="34.209,97.1372,0" Rotation="1.1523" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="11" Player="5" Position="34.209,97.1372,0" Rotation="1.1523" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1472824811" Position="24,160.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="1"/>
-    <ObjectUnit Id="1133" Player="5" Position="22.5,102.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1133" Position="22.5,102.5,0" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="96" Player="5" Position="34.4096,102.7785,0" Rotation="0.712" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="1472824811" Variation="1" Position="24,160.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="96" Position="34.4096,102.7785,0" Rotation="0.712" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="75" Player="1" Position="49.2797,31.8937,0" Rotation="4.5922" Scale="1,1,1" UnitType="AP_Probe"/>
-    <ObjectUnit Id="32" Player="6" Position="105.106,50.2197,0" Rotation="5.6364" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="75" Position="49.2797,31.8937,0" Rotation="4.5922" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
+    <ObjectUnit Id="32" Position="105.106,50.2197,0" Rotation="5.6364" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1069" Player="5" Position="143.476,185.3527,0" Rotation="5.8808" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1069" Position="143.476,185.3527,0" Rotation="5.8808" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -5203,44 +5194,42 @@
     <ObjectUnit Id="938" Position="109.5,87.5,0" Scale="1,1,1" UnitType="VespeneGeyser">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="961" Player="5" Position="34.029,100.3591,0" Rotation="0.9421" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="961" Position="34.029,100.3591,0" Rotation="0.9421" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="900" Player="6" Position="67.8581,157.0966,0" Rotation="1.0693" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="2242" Player="6" Position="35.5827,229.7075,0" Rotation="5.4995" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="2242" Position="35.5827,229.7075,0" Rotation="5.4995" Scale="1,1,1" UnitType="Carrier" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1007" Player="6" Position="86.96,127.92,0" Rotation="0.6682" Scale="1,1,1" UnitType="Phoenix">
+    <ObjectUnit Id="900" Position="67.8581,157.0966,0" Rotation="1.0693" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1007" Position="86.96,127.92,0" Rotation="0.6682" Scale="1,1,1" UnitType="Phoenix" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1128" Player="8" Position="37.3498,99.4743,0" Rotation="0.8464" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1128" Position="37.3498,99.4743,0" Rotation="0.8464" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="101" Player="5" Position="70.069,94.987,0" Rotation="5.2062" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="101" Position="70.069,94.987,0" Rotation="5.2062" Scale="1,1,1" UnitType="Ghost" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -5248,49 +5237,45 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="14" Player="1" Position="61.5,41.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_WarpGate"/>
-    <ObjectUnit Id="947" Player="7" Position="136.69,80.6098,0" Rotation="5.5322" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="14" Position="61.5,41.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_WarpGate" Player="1"/>
+    <ObjectUnit Id="947" Position="136.69,80.6098,0" Rotation="5.5322" Scale="1,1,1" UnitType="Mutalisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="984" Player="6" Position="98.9426,50.973,0" Rotation="6.2243" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="984" Position="98.9426,50.973,0" Rotation="6.2243" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1119" Player="5" Position="26.5,92.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1119" Position="26.5,92.5,0" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="82" Position="58.5,28.5,0" Resources="2000" Scale="1,1,1" UnitType="VespeneGeyser">
+    <ObjectUnit Id="82" Position="58.5,28.5,0" Scale="1,1,1" UnitType="VespeneGeyser" Resources="2000">
         <Resources Index="1" Value="4000"/>
         <Resources Index="2" Value="4000"/>
     </ObjectUnit>
-    <ObjectUnit Id="1076" Player="5" Position="142.416,183.6816,0" Rotation="5.9091" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1076" Position="142.416,183.6816,0" Rotation="5.9091" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="57" Player="3" Position="138,36,0" Rotation="5.4975" Scale="1,1,1" UnitType="Spire">
+    <ObjectUnit Id="57" Position="138,36,0" Rotation="5.4975" Scale="1,1,1" UnitType="Spire" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="124" Player="3" Position="140,87,0" Rotation="4.0058" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="124" Position="140,87,0" Rotation="4.0058" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -5298,7 +5283,7 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1137" Player="8" Position="25.5,154.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="CommandCenter">
+    <ObjectUnit Id="1137" Position="25.5,154.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="CommandCenter" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -5308,190 +5293,182 @@
     <ObjectUnit Id="23" Position="72,98,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="925" Player="5" Position="53.1035,135.0402,0" Rotation="0.6125" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="925" Position="53.1035,135.0402,0" Rotation="0.6125" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1014" Player="5" Position="21.706,143.2248,0" Rotation="0.933" Scale="1,1,1" UnitType="Stalker">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="928" Player="5" Position="47.8408,133.1923,0" Rotation="0.9475" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1014" Position="21.706,143.2248,0" Rotation="0.933" Scale="1,1,1" UnitType="Stalker" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="971" Position="95,145.5,0" Resources="2650" Scale="1,1,1" UnitType="MineralField" Variation="2">
+    <ObjectUnit Id="928" Position="47.8408,133.1923,0" Rotation="0.9475" Scale="1,1,1" UnitType="Zergling" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="971" Variation="2" Position="95,145.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2650">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="65" Player="5" Position="47.6572,75.775,0" Rotation="0.6381" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="65" Position="47.6572,75.775,0" Rotation="0.6381" Scale="1,1,1" UnitType="Hydralisk" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1063" Player="5" Position="145.0854,183.084,0" Rotation="5.6838" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1063" Position="145.0854,183.084,0" Rotation="5.6838" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1033" Player="5" Position="23.1826,151.905,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="1033" Position="23.1826,151.905,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="4" Player="2" Position="81.5,30.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Barracks">
+    <ObjectUnit Id="4" Position="81.5,30.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Barracks" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="2248" Player="6" Position="36.704,222.7714,0" Rotation="5.6542" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="910" Position="86.167,167.4943,0" Rotation="1.182" Scale="1,1,1" UnitType="Banshee" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2248" Position="36.704,222.7714,0" Rotation="5.6542" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="910" Player="5" Position="86.167,167.4943,0" Rotation="1.182" Scale="1,1,1" UnitType="Banshee">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="88" Position="48,30.5,0" Resources="1800" Scale="1,1,1" UnitType="MineralField" Variation="1">
+    <ObjectUnit Id="88" Variation="1" Position="48,30.5,0" Scale="1,1,1" UnitType="MineralField" Resources="1800">
         <Resources Index="1" Value="3400"/>
         <Resources Index="2" Value="3400"/>
     </ObjectUnit>
-    <ObjectUnit Id="1086" Player="6" Position="74.5,153.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1086" Position="74.5,153.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="51" Player="3" Position="130.013,38.455,0" Rotation="3.6447" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="51" Position="130.013,38.455,0" Rotation="3.6447" Scale="1,1,1" UnitType="InfestedAbomination" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="953" Player="5" Position="110.636,95.025,0" Rotation="5.6977" Scale="1,1,1" UnitType="Ghost">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="919" Player="5" Position="49.032,134.6926,0" Rotation="0.8303" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="953" Position="110.636,95.025,0" Rotation="5.6977" Scale="1,1,1" UnitType="Ghost" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2257" Player="7" Position="145.5666,228.0214,0" Rotation="0.7277" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="2257" Position="145.5666,228.0214,0" Rotation="0.7277" Scale="1,1,1" UnitType="Mutalisk" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1020" Player="8" Position="31,96,0" Rotation="5.4975" Scale="1,1,1" UnitType="BarracksTechReactor">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="118" Player="3" Position="127.904,42.0241,0" Rotation="3.359" Scale="1,1,1" UnitType="HotSRaptor">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1147" Player="8" Position="25.0334,147.6052,0" Rotation="1.8481" Scale="1,1,1" UnitType="Goliath">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="29" Player="7" Position="119.1633,60.361,0" Rotation="6.2783" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="919" Position="49.032,134.6926,0" Rotation="0.8303" Scale="1,1,1" UnitType="SiegeTankSieged" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="54" Player="6" Position="95.7956,52.81,0" Rotation="6.1884" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1020" Position="31,96,0" Rotation="5.4975" Scale="1,1,1" UnitType="BarracksTechReactor" Player="8">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="118" Position="127.904,42.0241,0" Rotation="3.359" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1147" Position="25.0334,147.6052,0" Rotation="1.8481" Scale="1,1,1" UnitType="Goliath" Player="8">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="29" Position="119.1633,60.361,0" Rotation="6.2783" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="93" Position="46,33.5,0" Resources="1650" Scale="1,1,1" UnitType="MineralField" Variation="8">
+    <ObjectUnit Id="54" Position="95.7956,52.81,0" Rotation="6.1884" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="93" Variation="8" Position="46,33.5,0" Scale="1,1,1" UnitType="MineralField" Resources="1650">
         <Resources Index="1" Value="3200"/>
         <Resources Index="2" Value="3200"/>
     </ObjectUnit>
-    <ObjectUnit Id="956" Player="6" Position="94.25,67.8098,0" Rotation="0.8342" Scale="1,1,1" UnitType="Immortal">
+    <ObjectUnit Id="956" Position="94.25,67.8098,0" Rotation="0.8342" Scale="1,1,1" UnitType="Immortal" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1017" Player="6" Position="73.3195,157.147,0" Rotation="1.009" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="1017" Position="73.3195,157.147,0" Rotation="1.009" Scale="1,1,1" UnitType="Ghost" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2260" Player="7" Position="146.2885,231.767,0" Rotation="0.4912" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="914" Position="82.265,170.2138,0" Rotation="4.743" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2260" Position="146.2885,231.767,0" Rotation="0.4912" Scale="1,1,1" UnitType="Mutalisk" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="914" Player="5" Position="82.265,170.2138,0" Rotation="4.743" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="24" Position="121.7158,65.6176,0" Rotation="0.3754" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="24" Player="7" Position="121.7158,65.6176,0" Rotation="0.3754" Scale="1,1,1" UnitType="Stalker">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="115" Player="3" Position="142.648,83.6533,0" Rotation="3.9577" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="115" Position="142.648,83.6533,0" Rotation="3.9577" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -5499,13 +5476,20 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1150" Player="5" Position="23,148,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="1150" Position="23,148,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="974" Position="103.5,138.5,0" Scale="1,1,1" UnitType="VespeneGeyser">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="2275" Player="8" Position="25.5,100,0" Rotation="0.9797" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="933" Position="45.9101,77.451,0" Rotation="0.2143" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2275" Position="25.5,100,0" Rotation="0.9797" Scale="1,1,1" UnitType="SCV" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -5513,63 +5497,56 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="933" Player="5" Position="45.9101,77.451,0" Rotation="0.2143" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="47" Player="6" Position="82.5,129.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="47" Position="82.5,129.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="68" Player="5" Position="50.7863,76.1506,0" Rotation="0.13" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="68" Position="50.7863,76.1506,0" Rotation="0.13" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="425450477" Position="144,185.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="5"/>
-    <ObjectUnit Id="1" Player="1" Position="53.5,35.5,0" Rotation="6.0832" Scale="1,1,1" UnitType="AP_Nexus"/>
-    <ObjectUnit Id="1127" Player="8" Position="38.5185,100.2863,0" Rotation="0.7944" Scale="1,1,1" UnitType="Medivac">
+    <ObjectUnit Id="425450477" Variation="5" Position="144,185.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="1" Position="53.5,35.5,0" Rotation="6.0832" Scale="1,1,1" UnitType="AP_Nexus" Player="1"/>
+    <ObjectUnit Id="1127" Position="38.5185,100.2863,0" Rotation="0.7944" Scale="1,1,1" UnitType="Medivac" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="106" Player="3" Position="135.7893,83.6933,0" Rotation="3.5908" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="106" Position="135.7893,83.6933,0" Rotation="3.5908" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="907" Player="5" Position="87.5654,168.8334,0" Rotation="0.4616" Scale="1,1,1" UnitType="Mutalisk">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="2253" Player="7" Position="141.6962,230.7321,0" Rotation="0.6232" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="2253" Position="141.6962,230.7321,0" Rotation="0.6232" Scale="1,1,1" UnitType="Carrier" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1142" Player="8" Position="26,143,0" Rotation="5.4975" Scale="1,1,1" UnitType="FactoryTechReactor">
+    <ObjectUnit Id="907" Position="87.5654,168.8334,0" Rotation="0.4616" Scale="1,1,1" UnitType="Mutalisk" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1142" Position="26,143,0" Rotation="5.4975" Scale="1,1,1" UnitType="FactoryTechReactor" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="123" Player="3" Position="141.4843,81.4316,0" Rotation="3.8232" Scale="1,1,1" UnitType="RoachVile">
+    <ObjectUnit Id="123" Position="141.4843,81.4316,0" Rotation="3.8232" Scale="1,1,1" UnitType="RoachVile" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -5577,64 +5554,60 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="16" Player="1" Position="58,38,0" Scale="1,1,1" UnitType="AP_Pylon"/>
-    <ObjectUnit Id="922" Player="5" Position="45.1623,134.6713,0" Rotation="0.9335" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="16" Position="58,38,0" Scale="1,1,1" UnitType="AP_Pylon" Player="1"/>
+    <ObjectUnit Id="922" Position="45.1623,134.6713,0" Rotation="0.9335" Scale="1,1,1" UnitType="Stalker" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1009" Player="5" Position="53.5898,140.3127,0" Rotation="0.3596" Scale="1,1,1" UnitType="Liberator">
+    <ObjectUnit Id="1009" Position="53.5898,140.3127,0" Rotation="0.3596" Scale="1,1,1" UnitType="Liberator" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="948" Player="5" Position="164.1198,92.64,0" Rotation="5.6762" Scale="1,1,1" UnitType="Archon">
+    <ObjectUnit Id="948" Position="164.1198,92.64,0" Rotation="5.6762" Scale="1,1,1" UnitType="Archon" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="85" Position="52,29.5,0" Resources="1800" Scale="1,1,1" UnitType="MineralField">
+    <ObjectUnit Id="85" Position="52,29.5,0" Scale="1,1,1" UnitType="MineralField" Resources="1800">
         <Resources Index="1" Value="3400"/>
         <Resources Index="2" Value="3400"/>
     </ObjectUnit>
-    <ObjectUnit Id="62" Player="6" Position="98.5,70.5,0" Rotation="5.8056" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="62" Position="98.5,70.5,0" Rotation="5.8056" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1075" Player="5" Position="140.2473,184.399,0" Rotation="6.109" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1075" Position="140.2473,184.399,0" Rotation="6.109" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2245" Player="6" Position="37.2763,227.2727,0" Rotation="5.6826" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="899" Position="68.8562,147.4377,0" Rotation="1.0095" Scale="1,1,1" UnitType="Ghost" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2245" Position="37.2763,227.2727,0" Rotation="5.6826" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="899" Player="6" Position="68.8562,147.4377,0" Rotation="1.0095" Scale="1,1,1" UnitType="Ghost">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="98" Player="5" Position="67.496,94.5354,0" Rotation="5.1987" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="98" Position="67.496,94.5354,0" Rotation="5.1987" Scale="1,1,1" UnitType="Hydralisk" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -5642,102 +5615,97 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="9" Player="1" Position="46.5,36.5,0" Resources="2000" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Assimilator">
+    <ObjectUnit Id="9" Position="46.5,36.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Assimilator" Player="1" Resources="2000">
         <Resources Index="1" Value="4000"/>
         <Resources Index="2" Value="4000"/>
     </ObjectUnit>
-    <ObjectUnit Id="1089" Player="7" Position="129.5,47.5,0" Rotation="0.324" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1089" Position="129.5,47.5,0" Rotation="0.324" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="76" Player="1" Position="50.2358,32.9897,0" Rotation="5.3452" Scale="1,1,1" UnitType="AP_Probe"/>
-    <ObjectUnit Id="1066" Player="5" Position="144.215,181.7624,0" Rotation="5.6813" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="76" Position="50.2358,32.9897,0" Rotation="5.3452" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
+    <ObjectUnit Id="1066" Position="144.215,181.7624,0" Rotation="5.6813" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="941" Player="5" Position="94.3488,207.0263,0" Rotation="0.3872" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="941" Position="94.3488,207.0263,0" Rotation="0.3872" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="966" Position="94,144.5,0" Resources="2500" Scale="1,1,1" UnitType="MineralField" Variation="1">
+    <ObjectUnit Id="966" Variation="1" Position="94,144.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2500">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="1005" Player="6" Position="88.0151,125.8876,0" Rotation="0.352" Scale="1,1,1" UnitType="Ultralisk">
+    <ObjectUnit Id="1005" Position="88.0151,125.8876,0" Rotation="0.352" Scale="1,1,1" UnitType="Ultralisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2240" Player="6" Position="37.5666,233.7124,0" Rotation="5.303" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="902" Position="69.421,143.688,0" Rotation="1.0693" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2240" Position="37.5666,233.7124,0" Rotation="5.303" Scale="1,1,1" UnitType="Raven" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="902" Player="6" Position="69.421,143.688,0" Rotation="1.0693" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="12" Player="3" Position="124.5,28.5,0" Scale="1,1,1" UnitType="Hatchery">
+    <ObjectUnit Id="12" Position="124.5,28.5,0" Scale="1,1,1" UnitType="Hatchery" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1025" Player="2" Position="90.7805,34.309,0" Rotation="2.4843" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="1025" Position="90.7805,34.309,0" Rotation="2.4843" Scale="1,1,1" UnitType="Banshee" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="103" Player="3" Position="130.5,54.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="103" Position="130.5,54.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1130" Player="8" Position="37.4787,100.54,0" Rotation="0.8461" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1130" Position="37.4787,100.54,0" Rotation="0.8461" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1071" Player="5" Position="143.6242,183.2375,0" Rotation="5.7968" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1071" Position="143.6242,183.2375,0" Rotation="5.7968" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="73" Player="1" Position="20.5908,15.206,0" Rotation="2.3747" Scale="1,1,1" UnitType="AP_StalkerShakuras"/>
-    <ObjectUnit Id="963" Player="5" Position="29.97,99.8498,0" Rotation="0.7988" Scale="1,1,1" UnitType="Ultralisk">
+    <ObjectUnit Id="73" Position="20.5908,15.206,0" Rotation="2.3747" Scale="1,1,1" UnitType="AP_StalkerShakuras" Player="1"/>
+    <ObjectUnit Id="963" Position="29.97,99.8498,0" Rotation="0.7988" Scale="1,1,1" UnitType="Ultralisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1003909742" Position="148,23.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="3"/>
-    <ObjectUnit Id="936" Player="5" Position="63.4736,97.6728,0" Rotation="5.532" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="936" Position="63.4736,97.6728,0" Rotation="5.532" Scale="1,1,1" UnitType="Hydralisk" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -5745,37 +5713,29 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="21" Player="7" Position="120.8642,62.4645,0" Rotation="6.0332" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="1003909742" Variation="3" Position="148,23.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="21" Position="120.8642,62.4645,0" Rotation="6.0332" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="126" Player="6" Position="97.4848,88.9025,0" Rotation="5.8117" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="126" Position="97.4848,88.9025,0" Rotation="5.8117" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1012" Player="5" Position="32.2597,152.98,0" Rotation="0.5761" Scale="1,1,1" UnitType="BroodLord">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="927" Player="5" Position="56.5776,130.977,0" Rotation="0.554" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1012" Position="32.2597,152.98,0" Rotation="0.5761" Scale="1,1,1" UnitType="BroodLord" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2265" Player="8" Position="34.4353,98.3537,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="2265" Position="34.4353,98.3537,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -5783,31 +5743,34 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="986" Player="5" Position="25.7998,97.41,0" Rotation="0.7988" Scale="1,1,1" UnitType="Ultralisk">
-        <AIRebuild Index="1" Value="0"/>
-        <AIRebuild Index="2" Value="0"/>
-        <AIRebuild Index="3" Value="0"/>
-        <AIRebuild Index="4" Value="0"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="945" Player="7" Position="137.038,60.868,0" Rotation="5.532" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="927" Position="56.5776,130.977,0" Rotation="0.554" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="59" Player="6" Position="98.5,126.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="986" Position="25.7998,97.41,0" Rotation="0.7988" Scale="1,1,1" UnitType="Ultralisk" Player="5">
+        <AIRebuild Index="1" Value="0"/>
+        <AIRebuild Index="2" Value="0"/>
+        <AIRebuild Index="3" Value="0"/>
+        <AIRebuild Index="4" Value="0"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="945" Position="137.038,60.868,0" Rotation="5.532" Scale="1,1,1" UnitType="Hydralisk" Player="7">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="59" Position="98.5,126.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1117" Player="6" Position="84.5527,21.4204,0" Rotation="5.5876" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1117" Position="84.5527,21.4204,0" Rotation="5.5876" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
@@ -5815,153 +5778,151 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="6" Player="7" Position="131.9606,65.2297,0" Rotation="5.5322" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="6" Position="131.9606,65.2297,0" Rotation="5.5322" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1035" Player="5" Position="29.1423,157.3132,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="1035" Position="29.1423,157.3132,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="109" Player="3" Position="137.094,84.124,0" Rotation="3.6938" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="109" Position="137.094,84.124,0" Rotation="3.6938" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1491490323" Position="167,108.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="4"/>
-    <ObjectUnit Id="2250" Player="4" Position="150.7504,229.2375,0" Rotation="0.482" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="908" Player="5" Position="83.6538,166.1657,0" Rotation="1.6335" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="1491490323" Variation="4" Position="167,108.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="908" Position="83.6538,166.1657,0" Rotation="1.6335" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="969" Position="103,142.5,0" Resources="2650" Scale="1,1,1" UnitType="MineralField" Variation="7">
+    <ObjectUnit Id="2250" Position="150.7504,229.2375,0" Rotation="0.482" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="969" Variation="7" Position="103,142.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2650">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="930" Player="5" Position="46.5368,137.2922,0" Rotation="0.8183" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="930" Position="46.5368,137.2922,0" Rotation="0.8183" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1061" Player="5" Position="142.811,180.948,0" Rotation="5.758" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1061" Position="142.811,180.948,0" Rotation="5.758" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1102" Player="5" Position="55.5,50.5,0" Rotation="3.8586" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1102" Position="55.5,50.5,0" Rotation="3.8586" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="67" Player="5" Position="49.5097,75.0798,0" Rotation="0.3923" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="67" Position="49.5097,75.0798,0" Rotation="0.3923" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1022" Player="8" Position="36,102,0" Rotation="5.4975" Scale="1,1,1" UnitType="StarportTechReactor">
+    <ObjectUnit Id="1022" Position="36,102,0" Rotation="5.4975" Scale="1,1,1" UnitType="StarportTechReactor" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="2259" Player="7" Position="151.0905,227.0666,0" Rotation="0.6271" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="917" Position="84.7248,167.0336,0" Rotation="1.4301" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2259" Position="151.0905,227.0666,0" Rotation="0.6271" Scale="1,1,1" UnitType="Mutalisk" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="917" Player="5" Position="84.7248,167.0336,0" Rotation="1.4301" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="31" Position="105.5832,52.473,0" Rotation="5.7285" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="31" Player="6" Position="105.5832,52.473,0" Rotation="5.7285" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1145" Player="8" Position="33.9213,146.3154,0" Rotation="1.663" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="1145" Position="33.9213,146.3154,0" Rotation="1.663" Scale="1,1,1" UnitType="Goliath" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="116" Player="3" Position="129.1303,43.2067,0" Rotation="3.4667" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="116" Position="129.1303,43.2067,0" Rotation="3.4667" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="49" Player="1" Position="18.2634,15.0253,0" Rotation="2.2207" Scale="1,1,1" UnitType="AP_ImmortalShakuras"/>
-    <ObjectUnit Id="1084" Player="6" Position="101.5,89.5,0" Rotation="5.6694" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="49" Position="18.2634,15.0253,0" Rotation="2.2207" Scale="1,1,1" UnitType="AP_ImmortalShakuras" Player="1"/>
+    <ObjectUnit Id="1084" Position="101.5,89.5,0" Rotation="5.6694" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="90" Position="55,29.5,0" Resources="1650" Scale="1,1,1" UnitType="MineralField" Variation="8">
+    <ObjectUnit Id="90" Variation="8" Position="55,29.5,0" Scale="1,1,1" UnitType="MineralField" Resources="1650">
         <Resources Index="1" Value="3200"/>
         <Resources Index="2" Value="3200"/>
     </ObjectUnit>
-    <ObjectUnit Id="955" Player="6" Position="97.3498,85.48,0" Rotation="5.7397" Scale="1,1,1" UnitType="Thor">
+    <ObjectUnit Id="955" Position="97.3498,85.48,0" Rotation="5.7397" Scale="1,1,1" UnitType="Thor" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2262" Player="8" Position="33.0734,94.9328,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="912" Position="84.0288,168.546,0" Rotation="4.2253" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2262" Position="33.0734,94.9328,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="912" Player="5" Position="84.0288,168.546,0" Rotation="4.2253" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1019" Player="5" Position="144,193,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="1019" Position="144,193,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="1148" Player="8" Position="30.1994,143.8217,0" Rotation="1.6401" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="1148" Position="30.1994,143.8217,0" Rotation="1.6401" Scale="1,1,1" UnitType="Goliath" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="113" Player="3" Position="143.0368,84.8505,0" Rotation="4.0261" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="113" Position="143.0368,84.8505,0" Rotation="4.0261" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -5970,29 +5931,27 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="26" Position="114,98,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="95" Player="5" Position="36.411,98.9357,0" Rotation="0.5805" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="95" Position="36.411,98.9357,0" Rotation="0.5805" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="52" Player="6" Position="85.5,108.5,0" Rotation="0.4433" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="52" Position="85.5,108.5,0" Rotation="0.4433" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="958" Player="6" Position="100.1777,49.0881,0" Rotation="6.2243" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="958" Position="100.1777,49.0881,0" Rotation="6.2243" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="104" Player="3" Position="138.3867,79.6696,0" Rotation="3.689" Scale="1,1,1" UnitType="Queen">
+    <ObjectUnit Id="104" Position="138.3867,79.6696,0" Rotation="3.689" Scale="1,1,1" UnitType="Queen" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6000,37 +5959,41 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="3" Player="2" Position="86.5,134.5,0" Rotation="4.0268" Scale="1,1,1" UnitType="Bunker">
+    <ObjectUnit Id="3" Position="86.5,134.5,0" Rotation="4.0268" Scale="1,1,1" UnitType="Bunker" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="905" Player="6" Position="67.738,145.479,0" Rotation="0.631" Scale="1,1,1" UnitType="Stalker">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="2255" Player="7" Position="150.3234,235.0964,0" Rotation="0.3264" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="2255" Position="150.3234,235.0964,0" Rotation="0.3264" Scale="1,1,1" UnitType="Carrier" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="994" Player="6" Position="87.1755,102.2453,0" Rotation="0.4768" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="905" Position="67.738,145.479,0" Rotation="0.631" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="527360575" Position="147,22.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="7"/>
-    <ObjectUnit Id="2273" Player="8" Position="25.3132,150.743,0" Rotation="0.9797" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="994" Position="87.1755,102.2453,0" Rotation="0.4768" Scale="1,1,1" UnitType="Hydralisk" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="935" Position="47.6164,79.645,0" Rotation="0.2143" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2273" Position="25.3132,150.743,0" Rotation="0.9797" Scale="1,1,1" UnitType="SCV" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6038,52 +6001,44 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="935" Player="5" Position="47.6164,79.645,0" Rotation="0.2143" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="972" Position="103,141.5,0" Resources="2500" Scale="1,1,1" UnitType="MineralField" Variation="1">
+    <ObjectUnit Id="527360575" Variation="7" Position="147,22.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="972" Variation="1" Position="103,141.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2500">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="70" Player="6" Position="54.0717,207.3256,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="70" Position="54.0717,207.3256,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="45" Player="5" Position="38.5,54.5,0" Rotation="5.646" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="45" Position="38.5,54.5,0" Rotation="5.646" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="156" Player="6" Position="91.1401,104.3508,0" Rotation="6.24" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="156" Position="91.1401,104.3508,0" Rotation="6.24" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1169" Player="5" Position="78.0654,169.9147,0" Rotation="5.7592" Scale="1,1,1" UnitType="InfestedAbomination">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="247" Player="6" Position="96.4675,64.9616,0" Rotation="6.0314" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1169" Position="78.0654,169.9147,0" Rotation="5.7592" Scale="1,1,1" UnitType="InfestedAbomination" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1274" Player="3" Position="134.7385,82.6423,0" Rotation="3.4135" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="247" Position="96.4675,64.9616,0" Rotation="6.0314" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1274" Position="134.7385,82.6423,0" Rotation="3.4135" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6091,46 +6046,46 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="893" Player="6" Position="70.0441,145.1196,0" Rotation="0.9843" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="893" Position="70.0441,145.1196,0" Rotation="0.9843" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="790" Player="6" Position="61.8457,216.4921,0" Rotation="0.2216" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="790" Position="61.8457,216.4921,0" Rotation="0.2216" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="851" Player="6" Position="89.078,105.1486,0" Rotation="0.224" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="851" Position="89.078,105.1486,0" Rotation="0.224" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="824" Player="6" Position="100.1601,86.4743,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="824" Position="100.1601,86.4743,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1215" Player="9" Position="182,235,0" Rotation="5.9338" Scale="1,1,1" UnitType="GreaterSpire">
+    <ObjectUnit Id="1215" Position="182,235,0" Rotation="5.9338" Scale="1,1,1" UnitType="GreaterSpire" Player="9">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="178" Position="43,79,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="217" Player="3" Position="141.3906,124.0224,0" Rotation="3.6811" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="217" Position="141.3906,124.0224,0" Rotation="3.6811" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="868" Player="6" Position="91.744,123.9868,0" Rotation="5.971" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="868" Position="91.744,123.9868,0" Rotation="5.971" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -6138,73 +6093,73 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="783" Player="6" Position="56.7753,210.8955,0" Rotation="0.6416" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="783" Position="56.7753,210.8955,0" Rotation="0.6416" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1160" Player="9" Position="161.207,93.7607,0" Rotation="5.2448" Scale="1,1,1" UnitType="MutaliskBroodlord">
+    <ObjectUnit Id="1160" Position="161.207,93.7607,0" Rotation="5.2448" Scale="1,1,1" UnitType="MutaliskBroodlord" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="133" Player="6" Position="96.306,90.6682,0" Rotation="6.0612" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="133" Position="96.306,90.6682,0" Rotation="6.0612" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="238" Player="3" Position="137.5412,23.0871,0" Rotation="1.222" Scale="1,1,1" UnitType="Drone">
+    <ObjectUnit Id="238" Position="145.5,25,0" Rotation="1.222" Scale="1,1,1" UnitType="Drone" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="171" Player="3" Position="128.3198,36.64,0" Rotation="3.5935" Scale="1,1,1" UnitType="KerriganVoid">
+    <ObjectUnit Id="171" Position="128.3198,36.64,0" Rotation="3.5935" Scale="1,1,1" UnitType="KerriganVoid" Player="3">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1190" Player="9" Position="152.5,182.5,0" Rotation="0.5234" Scale="1,1,1" UnitType="UltraliskCavern">
+    <ObjectUnit Id="1190" Position="152.5,182.5,0" Rotation="0.5234" Scale="1,1,1" UnitType="UltraliskCavern" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="192" Player="6" Position="54.0227,168.0114,0" Rotation="0.7946" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="192" Position="54.0227,168.0114,0" Rotation="0.7946" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="842" Player="6" Position="96.7397,91.5952,0" Rotation="5.9833" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="842" Position="96.7397,91.5952,0" Rotation="5.9833" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="801" Player="5" Position="141.8698,155.97,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="801" Position="141.8698,155.97,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="778" Player="6" Position="46.006,213.2443,0" Rotation="1.2348" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="778" Position="46.006,213.2443,0" Rotation="1.2348" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="865" Player="6" Position="90.214,126.1005,0" Rotation="6.1496" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="865" Position="90.214,126.1005,0" Rotation="6.1496" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -6212,36 +6167,34 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1254" Player="7" Position="116.795,168.3903,0" Rotation="0.6503" Scale="1,1,1" UnitType="BroodLord">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="235" Player="3" Position="129.617,23.3122,0" Rotation="1.2221" Scale="1,1,1" UnitType="Drone">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1165" Player="9" Position="163.9831,94.0368,0" Rotation="5.2004" Scale="1,1,1" UnitType="HotSRaptor">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="197" Player="6" Position="56.6401,168.671,0" Rotation="0.603" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1254" Position="116.795,168.3903,0" Rotation="0.6503" Scale="1,1,1" UnitType="BroodLord" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1224" Player="2" Position="92.2785,74.6337,0" Rotation="2.4282" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="235" Position="140.5,23,0" Rotation="1.2221" Scale="1,1,1" UnitType="Drone" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1165" Position="163.9831,94.0368,0" Rotation="5.2004" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="197" Position="56.6401,168.671,0" Rotation="0.603" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1224" Position="92.2785,74.6337,0" Rotation="2.4282" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6249,46 +6202,43 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="174" Player="2" Position="86.41,26.96,0" Rotation="2.5134" Scale="1,1,1" UnitType="ThorAP">
+    <ObjectUnit Id="174" Position="86.41,26.96,0" Rotation="2.5134" Scale="1,1,1" UnitType="ThorAP" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1187" Player="6" Position="82.7507,123.7536,0" Rotation="0.134" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="1187" Position="82.7507,123.7536,0" Rotation="0.134" Scale="1,1,1" UnitType="Stalker" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="804" Player="5" Position="111.0483,92.631,0" Rotation="6.1682" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="804" Position="111.0483,92.631,0" Rotation="6.1682" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="847" Player="6" Position="97.1643,89.8513,0" Rotation="5.8984" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="847" Position="97.1643,89.8513,0" Rotation="5.8984" Scale="1,1,1" UnitType="Ghost" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="242" Player="6" Position="89.416,65.5756,0" Rotation="0.4797" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="242" Position="89.416,65.5756,0" Rotation="0.4797" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1279" Player="3" Position="115.0151,175.8608,0" Rotation="4.0131" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="1279" Position="115.0151,175.8608,0" Rotation="4.0131" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6296,33 +6246,33 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1307232379" Position="158.5,104.5,0" Resources="5000" Scale="1,1,1" UnitType="RichVespeneGeyser"/>
-    <ObjectUnit Id="153" Player="2" Position="84.5554,26.7895,0" Rotation="2.6264" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="153" Position="84.5554,26.7895,0" Rotation="2.6264" Scale="1,1,1" UnitType="SCV" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="787" Player="6" Position="48.8432,209.0317,0" Rotation="1.0856" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="1307232379" Position="158.5,104.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="5000"/>
+    <ObjectUnit Id="787" Position="48.8432,209.0317,0" Rotation="1.0856" Scale="1,1,1" UnitType="Zealot" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="888" Player="6" Position="71.339,156.6281,0" Rotation="0.4985" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="888" Position="71.339,156.6281,0" Rotation="0.4985" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="829" Player="2" Position="89.8132,37.8264,0" Rotation="2.7856" Scale="1,1,1" UnitType="Marauder">
+    <ObjectUnit Id="829" Position="89.8132,37.8264,0" Rotation="2.7856" Scale="1,1,1" UnitType="Marauder" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="854" Player="6" Position="90.6835,128.5131,0" Rotation="6.128" Scale="1,1,1" UnitType="Immortal">
+    <ObjectUnit Id="854" Position="90.6835,128.5131,0" Rotation="6.128" Scale="1,1,1" UnitType="Immortal" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -6330,18 +6280,18 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="220" Player="3" Position="138,128,0" Rotation="3.7944" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="220" Position="138,128,0" Rotation="3.7944" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1210" Player="9" Position="185.5,237.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="BanelingNest">
+    <ObjectUnit Id="1210" Position="185.5,237.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="BanelingNest" Player="9">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="183" Player="6" Position="89.7753,103.4348,0" Rotation="0.1875" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="183" Position="89.7753,103.4348,0" Rotation="0.1875" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -6349,122 +6299,127 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1260" Position="152.6848,104.854,0" Rotation="0.568" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="225" Player="5" Position="116.6362,92.7287,0" Rotation="5.7114" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="225" Position="116.6362,92.7287,0" Rotation="5.7114" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1159" Player="9" Position="165.348,92.022,0" Rotation="5.2238" Scale="1,1,1" UnitType="MutaliskBroodlord">
+    <ObjectUnit Id="1159" Position="165.348,92.022,0" Rotation="5.2238" Scale="1,1,1" UnitType="MutaliskBroodlord" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="138" Player="6" Position="100.4062,83.0888,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="138" Position="100.4062,83.0888,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="768" Player="7" Position="122.5402,218.7224,0" Rotation="5.847" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="768" Position="122.5402,218.7224,0" Rotation="5.847" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="875" Player="6" Position="55.5917,169.3554,0" Rotation="0.639" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="875" Position="55.5917,169.3554,0" Rotation="0.639" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="837" Player="5" Position="95.602,209.7502,0" Rotation="0.8413" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="837" Position="95.602,209.7502,0" Rotation="0.8413" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="207" Player="3" Position="135.678,123.314,0" Rotation="3.3586" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="207" Position="135.678,123.314,0" Rotation="3.3586" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1218" Player="9" Position="182.5,237.5,0" Rotation="5.707" Scale="1,1,1" UnitType="RoachWarren">
+    <ObjectUnit Id="1218" Position="182.5,237.5,0" Rotation="5.707" Scale="1,1,1" UnitType="RoachWarren" Player="9">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="164" Player="5" Position="74.2148,210.86,0" Rotation="5.3627" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="164" Position="74.2148,210.86,0" Rotation="5.3627" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1193" Player="9" Position="147,180,0" Rotation="5.3974" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="1193" Position="147,180,0" Rotation="5.3974" Scale="1,1,1" UnitType="SpineCrawler" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="793" Player="6" Position="55.9792,215.7883,0" Rotation="0.7436" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="793" Position="55.9792,215.7883,0" Rotation="0.7436" Scale="1,1,1" UnitType="Carrier" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="882" Player="6" Position="69.254,156.3652,0" Rotation="0.7458" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="882" Position="69.254,156.3652,0" Rotation="0.7458" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1269" Player="3" Position="131.8334,41.4521,0" Rotation="3.8051" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="1269" Position="131.8334,41.4521,0" Rotation="3.8051" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="147" Player="6" Position="56.3608,209.1032,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="147" Position="56.3608,209.1032,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1182" Player="6" Position="51.691,164.6733,0" Rotation="0.6132" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="1182" Position="51.691,164.6733,0" Rotation="0.6132" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1243" Position="41.1577,110.9743,0" Rotation="1.9802" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="214" Player="6" Position="95.86,51.3337,0" Rotation="6.1596" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="214" Position="95.86,51.3337,0" Rotation="6.1596" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1200" Player="9" Position="149.4777,182.812,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="1200" Position="149.4777,182.812,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="189" Player="6" Position="90.8071,67.1486,0" Rotation="0.094" Scale="1,1,1" UnitType="Immortal">
+    <ObjectUnit Id="189" Position="90.8071,67.1486,0" Rotation="0.094" Scale="1,1,1" UnitType="Immortal" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="823" Position="101.1293,85.143,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -6472,14 +6427,7 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2161" Position="75.4128,188.1718,0" Rotation="1.2602" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="823" Player="6" Position="101.1293,85.143,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="860" Player="6" Position="95.2395,127.6213,0" Rotation="5.821" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="860" Position="95.2395,127.6213,0" Rotation="5.821" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -6487,43 +6435,41 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="887" Player="6" Position="69.2163,157.9965,0" Rotation="0.6293" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="887" Position="69.2163,157.9965,0" Rotation="0.6293" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="796" Player="5" Position="147.1166,156.8122,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="796" Position="147.1166,156.8122,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="150" Player="2" Position="89.1062,39.229,0" Rotation="2.786" Scale="1,1,1" UnitType="Marauder">
+    <ObjectUnit Id="150" Position="89.1062,39.229,0" Rotation="2.786" Scale="1,1,1" UnitType="Marauder" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1179" Player="6" Position="59.4956,169.125,0" Rotation="0.6135" Scale="1,1,1" UnitType="Thor">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="253" Player="6" Position="105.195,51.0898,0" Rotation="5.6855" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1179" Position="59.4956,169.125,0" Rotation="0.6135" Scale="1,1,1" UnitType="Thor" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1264" Player="3" Position="109.3056,171.6025,0" Rotation="3.6445" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="253" Position="105.195,51.0898,0" Rotation="5.6855" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1264" Position="109.3056,171.6025,0" Rotation="3.6445" Scale="1,1,1" UnitType="InfestedAbomination" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6531,24 +6477,31 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="184" Player="6" Position="83.0937,103.6015,0" Rotation="0.5766" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="184" Position="83.0937,103.6015,0" Rotation="0.5766" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2138636298" Position="139,18.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="2"/>
     <ObjectUnit Id="1246" Position="71.7197,80.1984,0" Rotation="4.8608" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="211" Player="3" Position="135.4873,124.142,0" Rotation="3.3581" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="2138636298" Variation="2" Position="139,18.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="211" Position="135.4873,124.142,0" Rotation="3.3581" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="857" Player="6" Position="85.0751,127.5,0" Rotation="0.016" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="857" Position="85.0751,127.5,0" Rotation="0.016" Scale="1,1,1" UnitType="Stalker" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="818" Position="112.3464,91.8471,0" Rotation="5.6977" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -6556,103 +6509,92 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2164" Position="111.3842,209.1745,0" Rotation="4.4677" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="818" Player="5" Position="112.3464,91.8471,0" Rotation="5.6977" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1154" Position="65.1745,155.5998,0" Rotation="0.0063" Scale="1,1,1" UnitType="SiegeTankSieged" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1154" Player="6" Position="65.1745,155.5998,0" Rotation="0.0063" Scale="1,1,1" UnitType="SiegeTankSieged">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="143" Player="1" Position="50,45,0" Scale="1,1,1" UnitType="AP_Pylon"/>
+    <ObjectUnit Id="143" Position="50,45,0" Scale="1,1,1" UnitType="AP_Pylon" Player="1"/>
     <ObjectUnit Id="1257" Position="100.7331,154.9704,0" Rotation="5.4548" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="228" Player="5" Position="117.8132,91.8251,0" Rotation="5.518" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="228" Position="117.8132,91.8251,0" Rotation="5.518" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="878" Player="6" Position="52.7272,166.7382,0" Rotation="0.443" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="878" Position="52.7272,166.7382,0" Rotation="0.443" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="773" Player="7" Position="130.175,214.9655,0" Rotation="5.3957" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="773" Position="130.175,214.9655,0" Rotation="5.3957" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="811" Player="5" Position="75.8447,214.839,0" Rotation="0.5312" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="2157" Position="138.521,149.1967,0" Rotation="4.8903" Scale="1,1,1" UnitType="NaturalGas"/>
+    <ObjectUnit Id="811" Position="75.8447,214.839,0" Rotation="0.5312" Scale="1,1,1" UnitType="SiegeTankSieged" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2157" Position="138.521,149.1967,0" Rotation="4.8903" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="161" Player="4" Position="20.6462,21.0283,0" Rotation="5.4326" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="1196" Player="7" Position="121.6018,141.0043,0" Rotation="1.3376" Scale="1,1,1" UnitType="Banshee">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="202" Player="3" Position="139.5,120.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="826" Player="3" Position="138.9877,121.8774,0" Rotation="3.6447" Scale="1,1,1" UnitType="InfestedAbomination">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="849" Player="6" Position="83.4304,103.0051,0" Rotation="0.6215" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="161" Position="20.6462,21.0283,0" Rotation="5.4326" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="1196" Position="121.6018,141.0043,0" Rotation="1.3376" Scale="1,1,1" UnitType="Banshee" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="219" Player="3" Position="133.032,120.216,0" Rotation="3.262" Scale="1,1,1" UnitType="RoachVile">
+    <ObjectUnit Id="202" Position="139.5,120.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="176" Player="3" Position="130.5,62.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="826" Position="138.9877,121.8774,0" Rotation="3.6447" Scale="1,1,1" UnitType="InfestedAbomination" Player="3">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="849" Position="83.4304,103.0051,0" Rotation="0.6215" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="219" Position="133.032,120.216,0" Rotation="3.262" Scale="1,1,1" UnitType="RoachVile" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1213" Player="8" Position="182.5,231.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="FusionCore">
+    <ObjectUnit Id="176" Position="130.5,62.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1213" Position="182.5,231.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="FusionCore" Player="8">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="1272" Player="3" Position="135.6975,82.4211,0" Rotation="3.5275" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="1272" Position="135.6975,82.4211,0" Rotation="3.5275" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6660,70 +6602,65 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1171" Player="5" Position="172,96,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="1171" Position="172,96,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="788" Player="6" Position="54.7136,208.7177,0" Rotation="1.107" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="788" Position="54.7136,208.7177,0" Rotation="1.107" Scale="1,1,1" UnitType="Zealot" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="895" Player="6" Position="71.7731,146.2834,0" Rotation="0.7065" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="895" Position="71.7731,146.2834,0" Rotation="0.7065" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="194" Player="6" Position="61.7517,170.5556,0" Rotation="0.1462" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="194" Position="61.7517,170.5556,0" Rotation="0.1462" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1188" Player="6" Position="95.8256,124.2253,0" Rotation="5.8361" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="1188" Position="95.8256,124.2253,0" Rotation="5.8361" Scale="1,1,1" UnitType="Stalker" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="169" Player="2" Position="94.0942,32.4326,0" Rotation="2.084" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="169" Position="94.0942,32.4326,0" Rotation="2.084" Scale="1,1,1" UnitType="SiegeTankSieged" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="803" Player="7" Position="114.13,162.3251,0" Rotation="0.367" Scale="1,1,1" UnitType="Archon">
+    <ObjectUnit Id="803" Position="114.13,162.3251,0" Rotation="0.367" Scale="1,1,1" UnitType="Archon" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="840" Player="3" Position="133.6257,39.7624,0" Rotation="3.2624" Scale="1,1,1" UnitType="RoachVile">
+    <ObjectUnit Id="840" Position="133.6257,39.7624,0" Rotation="3.2624" Scale="1,1,1" UnitType="RoachVile" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="781" Player="5" Position="78.785,212.4672,0" Rotation="0.5307" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="781" Position="78.785,212.4672,0" Rotation="0.5307" Scale="1,1,1" UnitType="SiegeTankSieged" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="870" Player="6" Position="86.1745,124.2995,0" Rotation="6.2031" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="870" Position="86.1745,124.2995,0" Rotation="6.2031" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -6731,33 +6668,33 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="236" Player="3" Position="125.0671,24.3591,0" Rotation="1.222" Scale="1,1,1" UnitType="Drone">
+    <ObjectUnit Id="236" Position="138,21.5,0" Rotation="1.222" Scale="1,1,1" UnitType="Drone" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1249" Position="37.7307,134.6318,0" Rotation="1.1652" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="135" Player="3" Position="135.1782,43.1813,0" Rotation="3.4394" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="135" Position="135.1782,43.1813,0" Rotation="3.4394" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1162" Player="9" Position="166.0305,91.5634,0" Rotation="5.1594" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="1162" Position="166.0305,91.5634,0" Rotation="5.1594" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="172" Player="2" Position="90.5,21.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Starport">
+    <ObjectUnit Id="172" Position="90.5,21.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Starport" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1226" Player="2" Position="88.808,133.971,0" Rotation="4.1181" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1226" Position="88.808,133.971,0" Rotation="4.1181" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6765,31 +6702,28 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="199" Player="3" Position="138.5,66.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="199" Position="138.5,66.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="845" Player="6" Position="99.8256,91.655,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="845" Position="99.8256,91.655,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="806" Player="5" Position="79.7258,214.642,0" Rotation="5.363" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="806" Position="79.7258,214.642,0" Rotation="5.363" Scale="1,1,1" UnitType="Carrier" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="867" Player="6" Position="92.805,124.5852,0" Rotation="5.896" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="867" Position="92.805,124.5852,0" Rotation="5.896" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -6797,51 +6731,49 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="776" Player="7" Position="122.242,220.3945,0" Rotation="5.8774" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="776" Position="122.242,220.3945,0" Rotation="5.8774" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="130" Player="6" Position="99.0441,84.8801,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="130" Position="99.0441,84.8801,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1133779357" Position="146,21.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="8"/>
-    <ObjectUnit Id="233" Player="6" Position="90.7587,64.7395,0" Rotation="0.2126" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="233" Position="90.7587,64.7395,0" Rotation="0.2126" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1252" Player="7" Position="131.8845,142.8093,0" Rotation="0.6381" Scale="1,1,1" UnitType="Archon">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="852" Player="6" Position="90.4106,103.6281,0" Rotation="0.1533" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1133779357" Variation="8" Position="146,21.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="1252" Position="131.8845,142.8093,0" Rotation="0.6381" Scale="1,1,1" UnitType="Archon" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="181" Player="6" Position="81.5554,105.5183,0" Rotation="0.6682" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="852" Position="90.4106,103.6281,0" Rotation="0.1533" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="222" Player="5" Position="112.6726,96.4028,0" Rotation="5.7851" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="181" Position="81.5554,105.5183,0" Rotation="0.6682" Scale="1,1,1" UnitType="Hydralisk" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="222" Position="112.6726,96.4028,0" Rotation="5.7851" Scale="1,1,1" UnitType="Hydralisk" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -6849,7 +6781,7 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1174" Position="31,107,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="1277" Player="3" Position="138.4055,126.2233,0" Rotation="4.1105" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="1277" Position="138.4055,126.2233,0" Rotation="4.1105" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6857,21 +6789,21 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="890" Player="6" Position="69.248,159.1782,0" Rotation="0.5588" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="890" Position="69.248,159.1782,0" Rotation="0.5588" Scale="1,1,1" UnitType="Ghost" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="785" Player="6" Position="61.0014,213.6984,0" Rotation="0.6181" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="785" Position="61.0014,213.6984,0" Rotation="0.6181" Scale="1,1,1" UnitType="Zealot" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="449888724" Position="144,187.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="2"/>
-    <ObjectUnit Id="839" Player="3" Position="138.0615,40.003,0" Rotation="3.6745" Scale="1,1,1" UnitType="MutaliskBroodlord">
+    <ObjectUnit Id="449888724" Variation="2" Position="144,187.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="839" Position="138.0615,40.003,0" Rotation="3.6745" Scale="1,1,1" UnitType="MutaliskBroodlord" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6879,52 +6811,50 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="2154" Position="154.3894,68.871,0" Rotation="3.3681" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="1195" Player="7" Position="130.435,149.5554,0" Rotation="0.651" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="1195" Position="130.435,149.5554,0" Rotation="0.651" Scale="1,1,1" UnitType="Banshee" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="166" Player="5" Position="96.759,207.7236,0" Rotation="0.841" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="166" Position="96.759,207.7236,0" Rotation="0.841" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1216" Player="9" Position="185.5,234.5,0" Rotation="5.8117" Scale="1,1,1" UnitType="HydraliskDen">
+    <ObjectUnit Id="1216" Position="185.5,234.5,0" Rotation="5.8117" Scale="1,1,1" UnitType="HydraliskDen" Player="9">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="205" Player="5" Position="117.5,88.5,0" Rotation="5.9252" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="205" Position="117.5,88.5,0" Rotation="5.9252" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="136" Player="3" Position="133.8623,42.9321,0" Rotation="3.364" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="136" Position="133.8623,42.9321,0" Rotation="3.364" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1157" Player="5" Position="158.5,96.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1157" Position="158.5,96.5,0" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="227" Player="3" Position="143.5,81.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="227" Position="143.5,81.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1262" Player="2" Position="55.3503,181.2644,0" Rotation="2.2062" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1262" Position="55.3503,181.2644,0" Rotation="2.2062" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6932,7 +6862,7 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="873" Player="6" Position="94.1894,126.4074,0" Rotation="5.851" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="873" Position="94.1894,126.4074,0" Rotation="5.851" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -6940,14 +6870,14 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="770" Player="7" Position="114.875,224.1894,0" Rotation="6.1022" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="770" Position="114.875,224.1894,0" Rotation="6.1022" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
     <ObjectUnit Id="191" Position="52,137,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="1202" Player="9" Position="145.3486,183.2675,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="1202" Position="145.3486,183.2675,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6955,15 +6885,8 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="212" Position="144,118,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="862" Player="6" Position="91.2751,126.699,0" Rotation="6.0725" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="862" Position="91.2751,126.699,0" Rotation="6.0725" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="821" Player="6" Position="99.148,83.5698,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -6971,52 +6894,55 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2163" Position="110.641,211.135,0" Rotation="1.4287" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="880" Player="6" Position="56.9306,170.028,0" Rotation="0.5256" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="821" Position="99.148,83.5698,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="795" Player="5" Position="145.961,154.8593,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="880" Position="56.9306,170.028,0" Rotation="0.5256" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1180" Player="6" Position="55.4536,165.6193,0" Rotation="0.6132" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="795" Position="145.961,154.8593,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="145" Player="6" Position="48.7687,206.9011,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1180" Position="55.4536,165.6193,0" Rotation="0.6132" Scale="1,1,1" UnitType="Hydralisk" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="145" Position="48.7687,206.9011,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1271" Player="5" Position="145.8198,186.4,0" Rotation="5.565" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="1271" Position="145.8198,186.4,0" Rotation="5.565" Scale="1,1,1" UnitType="Banshee" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="250" Player="6" Position="93.406,51.6328,0" Rotation="0.2111" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="250" Position="93.406,51.6328,0" Rotation="0.2111" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="209" Player="3" Position="136.9826,123.7446,0" Rotation="3.4548" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="209" Position="136.9826,123.7446,0" Rotation="3.4548" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7024,7 +6950,7 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1244" Position="38.9987,112.9848,0" Rotation="0.1533" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="186" Player="6" Position="87.1853,103.918,0" Rotation="0.3498" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="186" Position="87.1853,103.918,0" Rotation="0.3498" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -7032,7 +6958,7 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2166" Position="70.2185,137.596,0" Rotation="6.1074" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="859" Player="6" Position="85.3364,129.4875,0" Rotation="0.1384" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="859" Position="85.3364,129.4875,0" Rotation="0.1384" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -7040,27 +6966,27 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="798" Player="5" Position="143.774,154.5998,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="798" Position="143.774,154.5998,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="885" Player="6" Position="72.0012,155.8374,0" Rotation="0.4645" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="885" Position="72.0012,155.8374,0" Rotation="0.4645" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1266" Player="3" Position="126.9465,40.3686,0" Rotation="3.26" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="1266" Position="126.9465,40.3686,0" Rotation="3.26" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="255" Player="2" Position="89.8796,133.1257,0" Rotation="4.1103" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="255" Position="89.8796,133.1257,0" Rotation="4.1103" Scale="1,1,1" UnitType="SCV" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7068,60 +6994,56 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1177" Player="5" Position="88.6645,169.1987,0" Rotation="0.7136" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="1177" Position="88.6645,169.1987,0" Rotation="0.7136" Scale="1,1,1" UnitType="InfestedAbomination" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="148" Player="2" Position="87,15,0" Rotation="5.4975" Scale="1,1,1" UnitType="FactoryTechReactor">
+    <ObjectUnit Id="148" Position="87,15,0" Rotation="5.4975" Scale="1,1,1" UnitType="FactoryTechReactor" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="809" Player="5" Position="98.947,210.8078,0" Rotation="0.41" Scale="1,1,1" UnitType="Ultralisk">
-        <AIRebuild Index="1" Value="0"/>
-        <AIRebuild Index="2" Value="0"/>
-        <AIRebuild Index="3" Value="0"/>
-        <AIRebuild Index="4" Value="0"/>
-        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2159" Position="133.5002,183.2595,0" Rotation="1.0683" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="1221" Player="7" Position="129.2045,141.6218,0" Rotation="0.6381" Scale="1,1,1" UnitType="Archon">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="200" Player="3" Position="138.5,74.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1198" Player="9" Position="145.8395,186.6684,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="163" Player="5" Position="74.4038,213.8242,0" Rotation="5.3627" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="809" Position="98.947,210.8078,0" Rotation="0.41" Scale="1,1,1" UnitType="Ultralisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="230" Player="3" Position="131.5,81.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="1221" Position="129.2045,141.6218,0" Rotation="0.6381" Scale="1,1,1" UnitType="Archon" Player="7">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="200" Position="138.5,74.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1198" Position="145.8395,186.6684,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="163" Position="74.4038,213.8242,0" Rotation="5.3627" Scale="1,1,1" UnitType="Mutalisk" Player="5">
+        <AIRebuild Index="1" Value="0"/>
+        <AIRebuild Index="2" Value="0"/>
+        <AIRebuild Index="3" Value="0"/>
+        <AIRebuild Index="4" Value="0"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="230" Position="131.5,81.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7129,65 +7051,65 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1259" Position="150.871,101.173,0" Rotation="0.1428" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="141" Player="3" Position="127.062,38.3806,0" Rotation="2.9475" Scale="1,1,1" UnitType="RoachVile">
+    <ObjectUnit Id="141" Position="127.062,38.3806,0" Rotation="2.9475" Scale="1,1,1" UnitType="RoachVile" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1152" Player="5" Position="26.5,142.5,0" Rotation="0.4758" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1152" Position="26.5,142.5,0" Rotation="0.4758" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="775" Player="7" Position="125.0214,213.5292,0" Rotation="5.73" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="775" Position="125.0214,213.5292,0" Rotation="5.73" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="878764207" Position="144,188.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="2"/>
-    <ObjectUnit Id="876" Player="6" Position="54.1494,166.5932,0" Rotation="0.3403" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="878764207" Variation="2" Position="144,188.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="876" Position="54.1494,166.5932,0" Rotation="0.3403" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="338" Player="5" Position="30.5397,145.3857,0" Rotation="0.9333" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="338" Position="30.5397,145.3857,0" Rotation="0.9333" Scale="1,1,1" UnitType="Stalker" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="728" Player="7" Position="118.4094,167.1591,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="728" Position="118.4094,167.1591,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="691" Player="7" Position="120.405,221.824,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="691" Position="120.405,221.824,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="758" Player="7" Position="130.7463,218.0917,0" Rotation="5.486" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="758" Position="130.7463,218.0917,0" Rotation="5.486" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="669" Player="6" Position="61.4553,220.0986,0" Rotation="0.7436" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="669" Position="61.4553,220.0986,0" Rotation="0.7436" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="279" Player="2" Position="94.1062,70.9504,0" Rotation="3.0004" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="279" Position="94.1062,70.9504,0" Rotation="3.0004" Scale="1,1,1" UnitType="SiegeTankSieged" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7195,134 +7117,134 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="380" Player="3" Position="132.5,114.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="380" Position="132.5,114.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="705" Player="7" Position="128.8632,147.8603,0" Rotation="0.525" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="705" Position="128.8632,147.8603,0" Rotation="0.525" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1573845000" Position="18,102.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="1"/>
-    <ObjectUnit Id="288" Player="7" Position="130.6542,101.5895,0" Rotation="5.9416" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="1573845000" Variation="1" Position="18,102.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="288" Position="130.6542,101.5895,0" Rotation="5.9416" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="331" Player="4" Position="88.071,228.1035,0" Scale="1,1,1" UnitType="NarudEpilogue">
+    <ObjectUnit Id="331" Position="88.071,228.1035,0" Scale="1,1,1" UnitType="NarudEpilogue" Player="4">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="270" Player="6" Position="89.8518,64.2421,0" Rotation="0.3286" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="270" Position="89.8518,64.2421,0" Rotation="0.3286" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1283" Player="3" Position="135.8388,78.258,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed">
+    <ObjectUnit Id="1283" Position="135.8388,78.258,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1103698672" Position="145,20.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="4"/>
-    <ObjectUnit Id="751" Player="5" Position="149.817,155.2138,0" Rotation="3.5158" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="751" Position="149.817,155.2138,0" Rotation="3.5158" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="644" Player="5" Position="140.5,159.5,0" Rotation="5.7756" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1103698672" Variation="4" Position="145,20.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="644" Position="140.5,159.5,0" Rotation="5.7756" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="687" Player="7" Position="135.0266,218.6538,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix">
+    <ObjectUnit Id="687" Position="135.0266,218.6538,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="708" Player="7" Position="127.8195,147.1127,0" Rotation="0.5861" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="708" Position="127.8195,147.1127,0" Rotation="0.5861" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="293" Player="7" Position="143.1643,115.1218,0" Rotation="5.2556" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="293" Position="143.1643,115.1218,0" Rotation="5.2556" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="352" Player="4" Position="108.4118,206.7263,0" Rotation="2.9733" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="267" Player="5" Position="51.5,80.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="352" Position="108.4118,206.7263,0" Rotation="2.9733" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="267" Position="51.5,80.5,0" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1286" Player="3" Position="142.793,121.3864,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed">
+    <ObjectUnit Id="1286" Position="142.793,121.3864,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="641" Player="7" Position="112.5,156.5,0" Rotation="0.4965" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="641" Position="112.5,156.5,0" Rotation="0.4965" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="746" Player="5" Position="145.8317,156.2531,0" Rotation="3.4482" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="746" Position="145.8317,156.2531,0" Rotation="3.4482" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="343" Player="4" Position="19.1357,201.7634,0" Rotation="4.1875" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
+    <ObjectUnit Id="343" Position="19.1357,201.7634,0" Rotation="4.1875" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
     <ObjectUnit Id="316" Position="91,70,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="694" Player="7" Position="129.5854,219.494,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="694" Position="129.5854,219.494,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="733" Player="7" Position="115.016,159.4716,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="733" Position="115.016,159.4716,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="664" Player="6" Position="59.37,214.5578,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="664" Position="59.37,214.5578,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="755" Player="7" Position="117.3261,223.892,0" Rotation="6.0024" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="755" Position="117.3261,223.892,0" Rotation="6.0024" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="274" Player="2" Position="89.3562,75.6823,0" Rotation="2.718" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="274" Position="89.3562,75.6823,0" Rotation="2.718" Scale="1,1,1" UnitType="Goliath" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7330,34 +7252,34 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="303" Player="7" Position="139.3544,117.6901,0" Rotation="5.5378" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="303" Position="139.3544,117.6901,0" Rotation="5.5378" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="677" Player="5" Position="84.5,215.5,0" Rotation="0.5092" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="677" Position="84.5,215.5,0" Rotation="0.5092" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="718" Player="7" Position="130.4787,144.026,0" Rotation="0.5561" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="718" Position="130.4787,144.026,0" Rotation="0.5561" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="736" Player="7" Position="119.3117,161.7497,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="736" Position="119.3117,161.7497,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="257" Player="2" Position="89.7788,131.3208,0" Rotation="4.2487" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="257" Position="89.7788,131.3208,0" Rotation="4.2487" Scale="1,1,1" UnitType="Goliath" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7365,29 +7287,29 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="700" Player="3" Position="137.5505,27.5908,0" Rotation="3.6892" Scale="1,1,1" UnitType="Queen">
+    <ObjectUnit Id="700" Position="137.5505,27.5908,0" Rotation="3.6892" Scale="1,1,1" UnitType="Queen" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="727" Player="7" Position="118.1496,165.2023,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="727" Position="118.1496,165.2023,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="349" Player="4" Position="64.1691,232.307,0" Rotation="2.4816" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="310" Player="5" Position="99.8876,213.8383,0" Rotation="0.841" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="349" Position="64.1691,232.307,0" Rotation="2.4816" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="310" Position="99.8876,213.8383,0" Rotation="0.841" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="280" Player="2" Position="91.0012,73.3913,0" Rotation="2.732" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="280" Position="91.0012,73.3913,0" Rotation="2.732" Scale="1,1,1" UnitType="Goliath" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7395,13 +7317,13 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="761" Player="7" Position="126.8254,209.9396,0" Rotation="5.721" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="761" Position="126.8254,209.9396,0" Rotation="5.721" Scale="1,1,1" UnitType="InfestedAbomination" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="722" Player="7" Position="115.1796,165.219,0" Rotation="0.651" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="722" Position="115.1796,165.219,0" Rotation="0.651" Scale="1,1,1" UnitType="Banshee" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -7409,67 +7331,63 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="697" Player="7" Position="124.4128,224.9665,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="697" Position="124.4128,224.9665,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="307" Player="7" Position="122.5,108.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="307" Position="122.5,108.5,0" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="344" Player="4" Position="19.4775,226.2841,0" Rotation="2.9082" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="285" Player="7" Position="131.3896,98.2565,0" Rotation="5.8991" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="344" Position="19.4775,226.2841,0" Rotation="2.9082" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="285" Position="131.3896,98.2565,0" Rotation="5.8991" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="764" Player="5" Position="97.7482,213.6062,0" Rotation="0.5307" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="764" Position="97.7482,213.6062,0" Rotation="0.5307" Scale="1,1,1" UnitType="SiegeTankSieged" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="663" Player="4" Position="178.4987,228.1362,0" Rotation="6.0742" Scale="1,1,1" UnitType="ShadowCloudEpilogue01">
+    <ObjectUnit Id="663" Position="178.4987,228.1362,0" Rotation="6.0742" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="298" Player="7" Position="125.5,139.5,0" Rotation="0.816" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="298" Position="125.5,139.5,0" Rotation="0.816" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="715" Player="7" Position="127.1354,141.274,0" Rotation="0.8132" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="715" Position="127.1354,141.274,0" Rotation="0.8132" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="672" Player="6" Position="65.059,214.8115,0" Rotation="0.618" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="672" Position="65.059,214.8115,0" Rotation="0.618" Scale="1,1,1" UnitType="Zealot" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="741" Player="5" Position="152.013,156.2104,0" Rotation="3.585" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="741" Position="152.013,156.2104,0" Rotation="3.585" Scale="1,1,1" UnitType="SiegeTankSieged" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="260" Player="2" Position="86.034,131.8581,0" Rotation="3.811" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="260" Position="86.034,131.8581,0" Rotation="3.811" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7477,246 +7395,246 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="671" Player="6" Position="62.9074,218.493,0" Rotation="0.618" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="671" Position="62.9074,218.493,0" Rotation="0.618" Scale="1,1,1" UnitType="Zealot" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="756" Player="7" Position="127.3078,221.3837,0" Rotation="5.6923" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="756" Position="127.3078,221.3837,0" Rotation="5.6923" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="382" Player="5" Position="91.5,214.5,0" Rotation="5.9248" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="382" Position="91.5,214.5,0" Rotation="5.9248" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="277" Player="7" Position="151.5,124.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="277" Position="151.5,124.5,0" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="730" Player="7" Position="119.3427,162.658,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="730" Position="119.3427,162.658,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1281" Player="5" Position="149.6887,159.0241,0" Rotation="2.4704" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="1281" Position="149.6887,159.0241,0" Rotation="2.4704" Scale="1,1,1" UnitType="Raven" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="268" Player="6" Position="96.5842,66.378,0" Rotation="6.0598" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="268" Position="96.5842,66.378,0" Rotation="6.0598" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="646" Player="5" Position="147.5,149.5,0" Rotation="5.8103" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="646" Position="147.5,149.5,0" Rotation="5.8103" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="749" Player="5" Position="147.955,154.7607,0" Rotation="3.3706" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="749" Position="147.955,154.7607,0" Rotation="3.3706" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="680" Player="5" Position="152.5,185.5,0" Rotation="5.6623" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="680" Position="152.5,185.5,0" Rotation="5.6623" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="707" Player="7" Position="128.8823,146.338,0" Rotation="0.563" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="707" Position="128.8823,146.338,0" Rotation="0.563" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="329" Player="3" Position="134.5,136.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="329" Position="134.5,136.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="290" Player="7" Position="124.475,100.0021,0" Rotation="0.1953" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="290" Position="124.475,100.0021,0" Rotation="0.1953" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1284" Player="3" Position="141.7192,79.2585,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed">
+    <ObjectUnit Id="1284" Position="141.7192,79.2585,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="265" Player="6" Position="96.0935,68.6281,0" Rotation="6.152" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="265" Position="96.0935,68.6281,0" Rotation="6.152" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="354" Player="4" Position="115.008,231.3203,0" Rotation="1.817" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="744" Player="5" Position="146.2822,157.7922,0" Rotation="3.5158" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="354" Position="115.008,231.3203,0" Rotation="1.817" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="744" Position="146.2822,157.7922,0" Rotation="3.5158" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="643" Player="6" Position="104.2097,53.022,0" Rotation="6.2248" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="643" Position="104.2097,53.022,0" Rotation="6.2248" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="710" Player="7" Position="124.7915,143.7216,0" Rotation="0.805" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="710" Position="124.7915,143.7216,0" Rotation="0.805" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="685" Player="7" Position="130.615,211.09,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix">
+    <ObjectUnit Id="685" Position="130.615,211.09,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="295" Player="7" Position="144.0566,113.2172,0" Rotation="5.1262" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="295" Position="144.0566,113.2172,0" Rotation="5.1262" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="753" Player="5" Position="149.3664,153.6748,0" Rotation="3.4482" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="753" Position="149.3664,153.6748,0" Rotation="3.4482" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="666" Player="6" Position="64.1567,217.1386,0" Rotation="0.6413" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="666" Position="64.1567,217.1386,0" Rotation="0.6413" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="272" Player="5" Position="113.9814,91.8757,0" Rotation="5.3706" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="272" Position="113.9814,91.8757,0" Rotation="5.3706" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="341" Player="4" Position="21.8098,75.3098,0" Rotation="1.294" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="735" Player="7" Position="117.7861,163.028,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="341" Position="21.8098,75.3098,0" Rotation="1.294" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="735" Position="117.7861,163.028,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="692" Player="7" Position="122.3095,216.7756,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="692" Position="122.3095,216.7756,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="738" Player="7" Position="115.2937,161.0012,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="738" Position="115.2937,161.0012,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="649" Player="3" Position="121,164,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="649" Position="121,164,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="259" Player="3" Position="127.5,101.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="259" Position="127.5,101.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="301" Player="7" Position="138.384,114.297,0" Rotation="5.4042" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="301" Position="138.384,114.297,0" Rotation="5.4042" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="716" Player="7" Position="129.3354,144.6218,0" Rotation="0.5925" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="716" Position="129.3354,144.6218,0" Rotation="0.5925" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="679" Player="5" Position="95.5,219.5,0" Rotation="0.486" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="679" Position="95.5,219.5,0" Rotation="0.486" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="282" Player="7" Position="131.548,99.949,0" Rotation="5.818" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="282" Position="131.548,99.949,0" Rotation="5.818" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="763" Player="7" Position="126.48,215.0598,0" Rotation="5.5634" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="763" Position="126.48,215.0598,0" Rotation="5.5634" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="725" Player="7" Position="109.3037,162.2045,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="725" Position="109.3037,162.2045,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="702" Player="7" Position="142.151,121.2155,0" Rotation="5.555" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="702" Position="142.151,121.2155,0" Rotation="5.555" Scale="1,1,1" UnitType="SiegeTankSieged" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="351" Player="4" Position="88.3305,226.7631,0" Rotation="4.429" Scale="1,1,1" UnitType="ShadowCloudEpilogue01">
+    <ObjectUnit Id="351" Position="88.3305,226.7631,0" Rotation="4.429" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="287" Player="2" Position="95.5078,74.8103,0" Rotation="2.7834" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="287" Position="95.5078,74.8103,0" Rotation="2.7834" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7724,126 +7642,126 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="661" Player="3" Position="123.9106,39.5732,0" Rotation="3.2026" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="661" Position="123.9106,39.5732,0" Rotation="3.2026" Scale="1,1,1" UnitType="InfestedAbomination" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="766" Player="7" Position="118.6372,219.8552,0" Rotation="5.9372" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="766" Position="118.6372,219.8552,0" Rotation="5.9372" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="720" Player="7" Position="128.3203,147.155,0" Rotation="0.6511" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="720" Position="128.3203,147.155,0" Rotation="0.6511" Scale="1,1,1" UnitType="Banshee" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="305" Player="7" Position="136.9423,115.853,0" Rotation="5.5817" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="305" Position="136.9423,115.853,0" Rotation="5.5817" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="743" Player="5" Position="144.7446,159.4816,0" Rotation="3.4428" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="743" Position="144.7446,159.4816,0" Rotation="3.4428" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="262" Player="3" Position="132.5,105.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="262" Position="132.5,105.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="323" Player="5" Position="28.8032,148.5722,0" Rotation="0.9333" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="323" Position="28.8032,148.5722,0" Rotation="0.9333" Scale="1,1,1" UnitType="Stalker" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="296" Player="7" Position="144.5632,115.8845,0" Rotation="5.2517" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="296" Position="144.5632,115.8845,0" Rotation="5.2517" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="674" Player="7" Position="116.9384,221.195,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="674" Position="116.9384,221.195,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="713" Player="7" Position="125.8327,141.1284,0" Rotation="0.8696" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="713" Position="125.8327,141.1284,0" Rotation="0.8696" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="632" Position="118,81.5,0" Resources="2650" Scale="1,1,1" UnitType="MineralField" Variation="4">
+    <ObjectUnit Id="632" Variation="4" Position="118,81.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2650">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="409" Player="3" Position="124,93,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="409" Position="124,93,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="498" Player="7" Position="113.576,166.7658,0" Rotation="0.581" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="498" Position="113.576,166.7658,0" Rotation="0.581" Scale="1,1,1" UnitType="Overseer" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="476" Player="5" Position="29.94,149.3398,0" Rotation="0.7751" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="476" Position="29.94,149.3398,0" Rotation="0.7751" Scale="1,1,1" UnitType="Raven" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="598" Player="6" Position="54,175,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="598" Position="54,175,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="573" Player="7" Position="138.5131,77.5898,0" Rotation="5.7441" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="573" Position="138.5131,77.5898,0" Rotation="5.7441" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="384" Player="6" Position="58.5,217.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="384" Position="58.5,217.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="491" Player="5" Position="163.0241,97.898,0" Rotation="5.39" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="491" Position="163.0241,97.898,0" Rotation="5.39" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="609" Player="6" Position="48.5,168.5,0" Rotation="0.4587" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="609" Position="48.5,168.5,0" Rotation="0.4587" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="591" Player="2" Position="55.864,177.0954,0" Rotation="2.5334" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="591" Position="55.864,177.0954,0" Rotation="2.5334" Scale="1,1,1" UnitType="Goliath" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7851,37 +7769,37 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="430" Player="5" Position="21.1281,42.6457,0" Rotation="5.9172" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="430" Position="21.1281,42.6457,0" Rotation="5.9172" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="453" Player="3" Position="120.5,161.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="453" Position="120.5,161.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="494" Player="6" Position="50.3937,209.6948,0" Rotation="0.554" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="494" Position="50.3937,209.6948,0" Rotation="0.554" Scale="1,1,1" UnitType="Raven" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="389" Player="7" Position="127.5,226.5,0" Rotation="5.7487" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="389" Position="127.5,226.5,0" Rotation="5.7487" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1064242121" Position="172,103.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="3"/>
-    <ObjectUnit Id="545" Player="4" Position="142.918,247.4003,0" Rotation="3.5976" Scale="1,1,1" UnitType="ShadowCloudEpilogue01">
+    <ObjectUnit Id="1064242121" Variation="3" Position="172,103.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="545" Position="142.918,247.4003,0" Rotation="3.5976" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="586" Player="2" Position="54.034,177.7751,0" Rotation="2.4235" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="586" Position="54.034,177.7751,0" Rotation="2.4235" Scale="1,1,1" UnitType="SCV" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7889,72 +7807,72 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="448" Player="5" Position="65.5825,99.6252,0" Rotation="5.6196" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="448" Position="65.5825,99.6252,0" Rotation="5.6196" Scale="1,1,1" UnitType="Overseer" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="637" Player="6" Position="94.664,54.5957,0" Rotation="6.2248" Scale="1,1,1" UnitType="Stalker">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="503" Player="5" Position="160.5178,100.3806,0" Rotation="5.6835" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="637" Position="94.664,54.5957,0" Rotation="6.2248" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="473" Player="3" Position="135,107,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="503" Position="160.5178,100.3806,0" Rotation="5.6835" Scale="1,1,1" UnitType="Zergling" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="473" Position="135,107,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="954391783" Position="148,30.5,0" Scale="1,1,1" UnitType="RichMineralField" Variation="4"/>
-    <ObjectUnit Id="434" Player="5" Position="29.8298,41.3098,0" Rotation="5.8557" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="954391783" Variation="4" Position="148,30.5,0" Scale="1,1,1" UnitType="RichMineralField"/>
+    <ObjectUnit Id="434" Position="29.8298,41.3098,0" Rotation="5.8557" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="568" Player="7" Position="150.5942,78.167,0" Rotation="5.3012" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="568" Position="150.5942,78.167,0" Rotation="5.3012" Scale="1,1,1" UnitType="SiegeTankSieged" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="595" Player="5" Position="52,137,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="595" Position="52,137,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="517" Player="5" Position="92.7868,210.7136,0" Rotation="0.425" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="517" Position="92.7868,210.7136,0" Rotation="0.425" Scale="1,1,1" UnitType="Overseer" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="622" Player="7" Position="118.9606,223.2878,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix">
+    <ObjectUnit Id="622" Position="118.9606,223.2878,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="484" Player="5" Position="118.0385,94.4084,0" Rotation="0.554" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="484" Position="118.0385,94.4084,0" Rotation="0.554" Scale="1,1,1" UnitType="Overseer" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="399" Player="2" Position="92.7436,72.8955,0" Rotation="2.7675" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="399" Position="92.7436,72.8955,0" Rotation="2.7675" Scale="1,1,1" UnitType="SCV" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7962,132 +7880,132 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="458" Player="1" Position="22.0656,16.0036,0" Rotation="2.3176" Scale="1,1,1" UnitType="AP_ZealotPurifier"/>
-    <ObjectUnit Id="189616888" Position="169,107.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="4"/>
-    <ObjectUnit Id="1305281627" Position="19,103.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="1"/>
-    <ObjectUnit Id="555" Player="3" Position="109.0927,174.9936,0" Rotation="3.4047" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="458" Position="22.0656,16.0036,0" Rotation="2.3176" Scale="1,1,1" UnitType="AP_ZealotPurifier" Player="1"/>
+    <ObjectUnit Id="189616888" Variation="4" Position="169,107.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="555" Position="109.0927,174.9936,0" Rotation="3.4047" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="576" Player="7" Position="150.1428,69.5683,0" Rotation="4.8845" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="1305281627" Variation="1" Position="19,103.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="576" Position="150.1428,69.5683,0" Rotation="4.8845" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="509" Player="5" Position="159.6474,99.059,0" Rotation="5.6811" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="509" Position="159.6474,99.059,0" Rotation="5.6811" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="406" Player="4" Position="177.4916,149.673,0" Rotation="0.1147" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="540" Player="3" Position="121,52,0" Rotation="2.965" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="406" Position="177.4916,149.673,0" Rotation="0.1147" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="540" Position="121,52,0" Rotation="2.965" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="360413363" Position="19,101.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="3"/>
-    <ObjectUnit Id="631" Position="111,82.5,0" Resources="2450" Scale="1,1,1" UnitType="MineralField">
+    <ObjectUnit Id="360413363" Variation="3" Position="19,101.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="631" Position="111,82.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2450">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="562" Player="3" Position="107.7062,170.815,0" Rotation="2.9472" Scale="1,1,1" UnitType="RoachVile">
+    <ObjectUnit Id="562" Position="107.7062,170.815,0" Rotation="2.9472" Scale="1,1,1" UnitType="RoachVile" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="467" Player="2" Position="182.5,245.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="FusionCore">
+    <ObjectUnit Id="467" Position="182.5,245.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="FusionCore" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="403" Player="4" Position="152.0085,211.8527,0" Rotation="3.8237" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="1769109367" Position="19,105.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="8"/>
-    <ObjectUnit Id="968032485" Position="148,27.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="7"/>
-    <ObjectUnit Id="626" Position="116,82.5,0" Resources="2450" Scale="1,1,1" UnitType="MineralField" Variation="1">
+    <ObjectUnit Id="403" Position="152.0085,211.8527,0" Rotation="3.8237" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="1769109367" Variation="8" Position="19,105.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="626" Variation="1" Position="116,82.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2450">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="537" Player="5" Position="168.306,94.818,0" Rotation="5.487" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="968032485" Variation="7" Position="148,27.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="537" Position="168.306,94.818,0" Rotation="5.487" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="604" Player="3" Position="119.5,167.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="604" Position="119.5,167.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="567" Player="7" Position="112,167,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="567" Position="112,167,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="619" Player="7" Position="133.257,216.294,0" Rotation="5.4543" Scale="1,1,1" UnitType="BroodLord">
+    <ObjectUnit Id="619" Position="133.257,216.294,0" Rotation="5.4543" Scale="1,1,1" UnitType="BroodLord" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="512" Player="5" Position="168.0761,95.8957,0" Rotation="5.5644" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="512" Position="168.0761,95.8957,0" Rotation="5.5644" Scale="1,1,1" UnitType="Banshee" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="394" Player="3" Position="127.5,140.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="394" Position="127.5,140.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="481" Player="5" Position="148.99,184.65,0" Rotation="5.5515" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="481" Position="148.99,184.65,0" Rotation="5.5515" Scale="1,1,1" UnitType="Raven" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="420" Player="1" Position="20.0947,17.9455,0" Rotation="2.1901" Scale="1,1,1" UnitType="AP_ZealotPurifier"/>
-    <ObjectUnit Id="463" Player="3" Position="179.5,248.5,0" Rotation="5.7595" Scale="1,1,1" UnitType="InfestationPit">
+    <ObjectUnit Id="420" Position="20.0947,17.9455,0" Rotation="2.1901" Scale="1,1,1" UnitType="AP_ZealotPurifier" Player="1"/>
+    <ObjectUnit Id="463" Position="179.5,248.5,0" Rotation="5.7595" Scale="1,1,1" UnitType="InfestationPit" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="581" Player="5" Position="142,152,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="581" Position="142,152,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="558" Player="3" Position="108.3576,175.2866,0" Rotation="3.358" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="558" Position="108.3576,175.2866,0" Rotation="3.358" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="478" Player="5" Position="161.5861,99.4196,0" Rotation="5.5644" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="478" Position="161.5861,99.4196,0" Rotation="5.5644" Scale="1,1,1" UnitType="Banshee" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="575" Player="7" Position="141.0146,78.1638,0" Rotation="5.3303" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="575" Position="141.0146,78.1638,0" Rotation="5.3303" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="596" Player="2" Position="57.1513,178.1064,0" Rotation="2.5822" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="596" Position="57.1513,178.1064,0" Rotation="2.5822" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8095,86 +8013,86 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="634" Player="6" Position="50.5,180.5,0" Rotation="5.7482" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="634" Position="50.5,180.5,0" Rotation="5.7482" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="496" Player="7" Position="121.16,221.69,0" Rotation="5.808" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="496" Position="121.16,221.69,0" Rotation="5.808" Scale="1,1,1" UnitType="Raven" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="589" Player="5" Position="114,98,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="589" Position="114,98,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="455" Player="4" Position="172.315,130.6496,0" Rotation="4.8952" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="489" Player="6" Position="86.1711,103.6313,0" Rotation="0.554" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="455" Position="172.315,130.6496,0" Rotation="4.8952" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="489" Position="86.1711,103.6313,0" Rotation="0.554" Scale="1,1,1" UnitType="Overseer" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="386" Player="6" Position="61.5,223.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="386" Position="61.5,223.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="875665599" Position="172,105.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="4"/>
-    <ObjectUnit Id="611" Player="7" Position="128.5373,221.2272,0" Rotation="5.6037" Scale="1,1,1" UnitType="Battlecruiser">
+    <ObjectUnit Id="611" Position="128.5373,221.2272,0" Rotation="5.6037" Scale="1,1,1" UnitType="Battlecruiser" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="584" Player="6" Position="91,70,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="875665599" Variation="4" Position="172,105.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="584" Position="91,70,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="450" Player="5" Position="30.5163,36.4047,0" Rotation="6.2321" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="450" Position="30.5163,36.4047,0" Rotation="6.2321" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="391" Player="7" Position="132.5,222.5,0" Rotation="0.6914" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="391" Position="132.5,222.5,0" Rotation="0.6914" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="492" Player="5" Position="159.0566,100.5341,0" Rotation="5.7966" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="492" Position="159.0566,100.5341,0" Rotation="5.7966" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="614" Player="7" Position="124.5,222.5,0" Rotation="0.531" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="614" Position="124.5,222.5,0" Rotation="0.531" Scale="1,1,1" UnitType="SiegeTankSieged" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="432" Player="5" Position="31.7941,28.558,0" Rotation="5.6074" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="432" Position="31.7941,28.558,0" Rotation="5.6074" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="133051673" Position="166,107.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="2"/>
-    <ObjectUnit Id="475" Player="2" Position="89.0451,40.2365,0" Rotation="2.9758" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="475" Position="89.0451,40.2365,0" Rotation="2.9758" Scale="1,1,1" UnitType="Marine" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="593" Player="2" Position="58.3381,176.825,0" Rotation="2.7446" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="133051673" Variation="2" Position="166,107.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="593" Position="58.3381,176.825,0" Rotation="2.7446" Scale="1,1,1" UnitType="Goliath" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8182,145 +8100,145 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="570" Player="7" Position="142.3242,73.8693,0" Rotation="5.7023" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="570" Position="142.3242,73.8693,0" Rotation="5.7023" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="639" Player="6" Position="107.5715,51.5166,0" Rotation="5.4416" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="639" Position="107.5715,51.5166,0" Rotation="5.4416" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="501" Player="4" Position="69.3103,185.2065,0" Rotation="3.9506" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="419" Player="1" Position="18.9626,18.9572,0" Rotation="2.188" Scale="1,1,1" UnitType="AP_ZealotPurifier"/>
-    <ObjectUnit Id="456" Player="4" Position="113.6684,132.4948,0" Rotation="4.6811" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="578" Player="7" Position="145.6528,71.7978,0" Rotation="5.2033" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="501" Position="69.3103,185.2065,0" Rotation="3.9506" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="419" Position="18.9626,18.9572,0" Rotation="2.188" Scale="1,1,1" UnitType="AP_ZealotPurifier" Player="1"/>
+    <ObjectUnit Id="456" Position="113.6684,132.4948,0" Rotation="4.6811" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="578" Position="145.6528,71.7978,0" Rotation="5.2033" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="553" Player="3" Position="109.7746,175.641,0" Rotation="3.4663" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="553" Position="109.7746,175.641,0" Rotation="3.4663" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="620" Player="7" Position="128.025,214.6884,0" Rotation="5.454" Scale="1,1,1" UnitType="Battlecruiser">
+    <ObjectUnit Id="620" Position="128.025,214.6884,0" Rotation="5.454" Scale="1,1,1" UnitType="Battlecruiser" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="519" Player="5" Position="166.906,93.5095,0" Rotation="5.492" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="519" Position="166.906,93.5095,0" Rotation="5.492" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="486" Player="1" Position="23.0202,14.957,0" Rotation="2.3215" Scale="1,1,1" UnitType="AP_ZealotPurifier"/>
-    <ObjectUnit Id="603" Player="3" Position="112.5,163.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="486" Position="23.0202,14.957,0" Rotation="2.3215" Scale="1,1,1" UnitType="AP_ZealotPurifier" Player="1"/>
+    <ObjectUnit Id="603" Position="112.5,163.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="560" Player="3" Position="114.1601,173.665,0" Rotation="3.6442" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="560" Position="114.1601,173.665,0" Rotation="3.6442" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1861596670" Position="144,190.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="5"/>
-    <ObjectUnit Id="442" Player="5" Position="21.7822,38.8356,0" Rotation="6.196" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="1861596670" Variation="5" Position="144,190.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="442" Position="21.7822,38.8356,0" Rotation="6.196" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="465" Player="3" Position="185.5,248.5,0" Rotation="5.8117" Scale="1,1,1" UnitType="HydraliskDen">
+    <ObjectUnit Id="465" Position="185.5,248.5,0" Rotation="5.8117" Scale="1,1,1" UnitType="HydraliskDen" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="404" Player="4" Position="178.016,188.9057,0" Rotation="5.8608" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="511" Player="5" Position="81.6914,212.0268,0" Rotation="6.0644" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="404" Position="178.016,188.9057,0" Rotation="5.8608" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="511" Position="81.6914,212.0268,0" Rotation="6.0644" Scale="1,1,1" UnitType="Overseer" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="629" Position="113,82.5,0" Resources="2600" Scale="1,1,1" UnitType="MineralField" Variation="2">
+    <ObjectUnit Id="629" Variation="2" Position="113,82.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2600">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="542" Player="3" Position="140,63,0" Rotation="2.965" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="542" Position="140,63,0" Rotation="2.965" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="565" Player="3" Position="106,175,0" Rotation="3.3178" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="565" Position="106,175,0" Rotation="3.3178" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="468" Player="2" Position="185.5,245.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="EngineeringBay">
+    <ObjectUnit Id="468" Position="185.5,245.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="EngineeringBay" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="447" Player="2" Position="177,241,0" Rotation="5.4975" Scale="1,1,1" UnitType="SupplyDepot">
+    <ObjectUnit Id="447" Position="177,241,0" Rotation="5.4975" Scale="1,1,1" UnitType="SupplyDepot" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="506" Player="3" Position="127.5,46.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="506" Position="127.5,46.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="539" Player="3" Position="128.6198,31.0498,0" Rotation="3.3562" Scale="1,1,1" UnitType="HotSNoxious">
+    <ObjectUnit Id="539" Position="128.6198,31.0498,0" Rotation="3.3562" Scale="1,1,1" UnitType="HotSNoxious" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="2100325080" Position="143,186.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="5"/>
-    <ObjectUnit Id="624" Player="8" Position="28.5,148.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Factory">
+    <ObjectUnit Id="624" Position="28.5,148.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Factory" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="461" Player="3" Position="182.5,251.5,0" Rotation="5.707" Scale="1,1,1" UnitType="RoachWarren">
+    <ObjectUnit Id="2100325080" Variation="5" Position="143,186.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="461" Position="182.5,251.5,0" Rotation="5.707" Scale="1,1,1" UnitType="RoachWarren" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="422" Player="1" Position="20.019,13.204,0" Rotation="2.2856" Scale="1,1,1" UnitType="AP_ImmortalShakuras"/>
-    <ObjectUnit Id="556" Player="3" Position="109.853,174.8891,0" Rotation="3.4545" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="422" Position="20.019,13.204,0" Rotation="2.2856" Scale="1,1,1" UnitType="AP_ImmortalShakuras" Player="1"/>
+    <ObjectUnit Id="556" Position="109.853,174.8891,0" Rotation="3.4545" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="583" Player="2" Position="56.05,178.9614,0" Rotation="2.44" Scale="1,1,1" UnitType="Marauder">
+    <ObjectUnit Id="583" Position="56.05,178.9614,0" Rotation="2.44" Scale="1,1,1" UnitType="Marauder" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8328,85 +8246,82 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="514" Player="5" Position="169.5141,94.374,0" Rotation="5.39" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="514" Position="169.5141,94.374,0" Rotation="5.39" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1636" Player="7" Position="128.98,104.71,0" Rotation="6.0441" Scale="1,1,1" UnitType="Medivac">
+    <ObjectUnit Id="1636" Position="128.98,104.71,0" Rotation="6.0441" Scale="1,1,1" UnitType="Medivac" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="617" Player="6" Position="47.5788,208.8093,0" Rotation="0.744" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="617" Position="47.5788,208.8093,0" Rotation="0.744" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="483" Player="5" Position="164.0097,95.2697,0" Rotation="5.7595" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="483" Position="164.0097,95.2697,0" Rotation="5.7595" Scale="1,1,1" UnitType="Raven" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="392" Player="5" Position="29.8425,154.0764,0" Rotation="0.9333" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="392" Position="29.8425,154.0764,0" Rotation="0.9333" Scale="1,1,1" UnitType="Stalker" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="627" Position="119,82.5,0" Resources="2500" Scale="1,1,1" UnitType="MineralField" Variation="2">
+    <ObjectUnit Id="627" Variation="2" Position="119,82.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2500">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="536" Player="5" Position="166.1374,95.5351,0" Rotation="5.6811" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="536" Position="166.1374,95.5351,0" Rotation="5.6811" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="402" Player="4" Position="176.8122,209.1965,0" Rotation="2.311" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="505" Player="3" Position="135.5,126.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="402" Position="176.8122,209.1965,0" Rotation="2.311" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="505" Position="135.5,126.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="974743767" Position="18,155.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField"/>
+    <ObjectUnit Id="974743767" Position="18,155.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
     <ObjectUnit Id="566" Position="112,167,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="395" Player="3" Position="129.5,148.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="395" Position="129.5,148.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="480" Player="5" Position="87.7768,166.4387,0" Rotation="5.4113" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="480" Position="87.7768,166.4387,0" Rotation="5.4113" Scale="1,1,1" UnitType="Overseer" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1106407594" Position="19,107.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField"/>
-    <ObjectUnit Id="618" Player="6" Position="57.0363,224.986,0" Rotation="0.744" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="1106407594" Position="19,107.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="618" Position="57.0363,224.986,0" Rotation="0.744" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="513" Player="5" Position="169.3662,96.4892,0" Rotation="5.521" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="513" Position="169.3662,96.4892,0" Rotation="5.521" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -8414,133 +8329,133 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="580" Position="142,152,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="559" Player="3" Position="115.3557,174.2687,0" Rotation="3.7192" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="559" Position="115.3557,174.2687,0" Rotation="3.7192" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="421" Player="1" Position="21.0886,16.9936,0" Rotation="2.1218" Scale="1,1,1" UnitType="AP_ZealotPurifier"/>
-    <ObjectUnit Id="462" Player="3" Position="185.5,251.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="BanelingNest">
+    <ObjectUnit Id="421" Position="21.0886,16.9936,0" Rotation="2.1218" Scale="1,1,1" UnitType="AP_ZealotPurifier" Player="1"/>
+    <ObjectUnit Id="462" Position="185.5,251.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="BanelingNest" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="485" Player="1" Position="23.9807,13.9648,0" Rotation="2.4621" Scale="1,1,1" UnitType="AP_ZealotPurifier"/>
-    <ObjectUnit Id="516" Player="5" Position="167.0078,96.8566,0" Rotation="5.6835" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="485" Position="23.9807,13.9648,0" Rotation="2.4621" Scale="1,1,1" UnitType="AP_ZealotPurifier" Player="1"/>
+    <ObjectUnit Id="516" Position="167.0078,96.8566,0" Rotation="5.6835" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="623" Player="7" Position="130.598,226.0742,0" Rotation="5.454" Scale="1,1,1" UnitType="BroodLord">
+    <ObjectUnit Id="623" Position="130.598,226.0742,0" Rotation="5.454" Scale="1,1,1" UnitType="BroodLord" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="554" Player="3" Position="108.5483,174.4584,0" Rotation="3.3583" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="554" Position="108.5483,174.4584,0" Rotation="3.3583" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="577" Player="7" Position="147.136,69.6984,0" Rotation="4.931" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="577" Position="147.136,69.6984,0" Rotation="4.931" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="541" Player="3" Position="128,60,0" Rotation="2.965" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="541" Position="128,60,0" Rotation="2.965" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="630" Position="110,83.5,0" Resources="2650" Scale="1,1,1" UnitType="MineralField" Variation="9">
+    <ObjectUnit Id="630" Variation="9" Position="110,83.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2650">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="508" Player="5" Position="160.416,97.0334,0" Rotation="5.492" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="508" Position="160.416,97.0334,0" Rotation="5.492" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="407" Player="3" Position="124.5,56.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="407" Position="124.5,56.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="259442763" Position="137,19.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="3"/>
-    <ObjectUnit Id="466" Player="2" Position="179.5,245.5,0" Scale="1,1,1" UnitType="Armory">
+    <ObjectUnit Id="466" Position="179.5,245.5,0" Scale="1,1,1" UnitType="Armory" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="563" Player="3" Position="105.9023,171.3605,0" Rotation="3.2617" Scale="1,1,1" UnitType="RoachVile">
+    <ObjectUnit Id="259442763" Variation="3" Position="137,19.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="563" Position="105.9023,171.3605,0" Rotation="3.2617" Scale="1,1,1" UnitType="RoachVile" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="600" Player="5" Position="85,173,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="600" Position="85,173,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="612133318" Position="171,106.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="9"/>
-    <ObjectUnit Id="613" Player="9" Position="167,94,0" Rotation="5.4975" Scale="1,1,1" UnitType="Spire">
+    <ObjectUnit Id="612133318" Variation="9" Position="171,106.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="613" Position="167,94,0" Rotation="5.4975" Scale="1,1,1" UnitType="Spire" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="495" Player="6" Position="61.172,216.0395,0" Rotation="0.554" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="495" Position="61.172,216.0395,0" Rotation="0.554" Scale="1,1,1" UnitType="Raven" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="388" Player="6" Position="53.5,211.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="388" Position="53.5,211.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="351458102" Position="20,159.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="8"/>
-    <ObjectUnit Id="587" Player="6" Position="88.5,134.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="351458102" Variation="8" Position="20,159.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="587" Position="88.5,134.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="502" Player="3" Position="128,114,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="502" Position="128,114,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="636" Player="6" Position="67.5,150.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="636" Position="67.5,150.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="569" Player="7" Position="142.43,75.9765,0" Rotation="5.778" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="569" Position="142.43,75.9765,0" Rotation="5.778" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="594" Player="2" Position="54.9633,180.2675,0" Rotation="2.2656" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="594" Position="54.9633,180.2675,0" Rotation="2.2656" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8548,77 +8463,75 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="435" Player="5" Position="30.7597,101.69,0" Rotation="0.554" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="435" Position="30.7597,101.69,0" Rotation="0.554" Scale="1,1,1" UnitType="Raven" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="408" Player="2" Position="175.5,244.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="CommandCenter">
+    <ObjectUnit Id="408" Position="175.5,244.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="CommandCenter" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="499" Player="7" Position="123.769,144.3112,0" Rotation="0.9094" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="499" Position="123.769,144.3112,0" Rotation="0.9094" Scale="1,1,1" UnitType="Overseer" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="633" Player="7" Position="119.0241,220.0952,0" Rotation="5.454" Scale="1,1,1" UnitType="Battlecruiser">
+    <ObjectUnit Id="633" Position="119.0241,220.0952,0" Rotation="5.454" Scale="1,1,1" UnitType="Battlecruiser" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
     <ObjectUnit Id="599" Position="85,173,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="572" Player="7" Position="140.1887,75.7412,0" Rotation="5.4611" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="572" Position="140.1887,75.7412,0" Rotation="5.4611" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="477" Player="2" Position="88.8793,41.3857,0" Rotation="2.9758" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="477" Position="88.8793,41.3857,0" Rotation="2.9758" Scale="1,1,1" UnitType="Marine" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="608" Player="6" Position="88,205,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="608" Position="88,205,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="1120444913" Position="18.5,152.5,0" Resources="5000" Scale="1,1,1" UnitType="RichVespeneGeyser"/>
-    <ObjectUnit Id="385" Player="7" Position="133.5,214.5,0" Rotation="5.8515" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1120444913" Position="18.5,152.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="5000"/>
+    <ObjectUnit Id="385" Position="133.5,214.5,0" Rotation="5.8515" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="490" Player="6" Position="92.335,129.5817,0" Rotation="5.931" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="490" Position="92.335,129.5817,0" Rotation="5.931" Scale="1,1,1" UnitType="Overseer" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="431" Player="5" Position="24.9521,41.086,0" Rotation="5.6074" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="431" Position="24.9521,41.086,0" Rotation="5.6074" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="452" Player="3" Position="121.5,152.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="452" Position="121.5,152.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="590" Player="2" Position="51.7087,178.7434,0" Rotation="2.196" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="590" Position="51.7087,178.7434,0" Rotation="2.196" Scale="1,1,1" UnitType="SiegeTankSieged" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8626,18 +8539,18 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="549" Player="3" Position="109.5,172.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="549" Position="109.5,172.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="469" Player="2" Position="179.5,242.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="GhostAcademy">
+    <ObjectUnit Id="469" Position="179.5,242.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="GhostAcademy" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="564" Player="3" Position="113,176,0" Rotation="2.9658" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="564" Position="113,176,0" Rotation="2.9658" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8645,92 +8558,87 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="607" Position="88,205,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="625" Player="8" Position="31,148,0" Rotation="5.4975" Scale="1,1,1" UnitType="FactoryTechReactor">
+    <ObjectUnit Id="625" Position="31,148,0" Rotation="5.4975" Scale="1,1,1" UnitType="FactoryTechReactor" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="507" Player="5" Position="160.5793,98.7177,0" Rotation="5.592" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="507" Position="160.5793,98.7177,0" Rotation="5.592" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="400" Player="4" Position="170.204,233.044,0" Rotation="6.0747" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="557" Player="3" Position="109.27,174.2282,0" Rotation="3.403" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="400" Position="170.204,233.044,0" Rotation="6.0747" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="557" Position="109.27,174.2282,0" Rotation="3.403" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="582" Player="2" Position="57.5,180.5,0" Rotation="2.455" Scale="1,1,1" UnitType="Bunker">
+    <ObjectUnit Id="582" Position="57.5,180.5,0" Rotation="2.455" Scale="1,1,1" UnitType="Bunker" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="460" Player="3" Position="179.5,251.5,0" Rotation="0.5234" Scale="1,1,1" UnitType="UltraliskCavern">
+    <ObjectUnit Id="460" Position="179.5,251.5,0" Rotation="0.5234" Scale="1,1,1" UnitType="UltraliskCavern" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="423" Player="5" Position="24.0043,33.7236,0" Rotation="5.6074" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="423" Position="24.0043,33.7236,0" Rotation="5.6074" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="482" Player="5" Position="150.876,153.9565,0" Rotation="5.465" Scale="1,1,1" UnitType="Overseer">
+    <ObjectUnit Id="482" Position="150.876,153.9565,0" Rotation="5.465" Scale="1,1,1" UnitType="Overseer" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="393" Player="5" Position="149.5,192.5,0" Rotation="5.856" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="393" Position="149.5,192.5,0" Rotation="5.856" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="515" Player="5" Position="165.5466,97.0102,0" Rotation="5.7966" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="515" Position="165.5466,97.0102,0" Rotation="5.7966" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="616" Player="6" Position="47.4995,215.686,0" Rotation="0.744" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="616" Position="47.4995,215.686,0" Rotation="0.744" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1637" Player="5" Position="71.6235,92.888,0" Rotation="5.909" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="1637" Position="71.6235,92.888,0" Rotation="5.909" Scale="1,1,1" UnitType="Stalker" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="579" Player="7" Position="145.436,75.3676,0" Rotation="5.5324" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="579" Position="145.436,75.3676,0" Rotation="5.5324" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="552" Player="3" Position="111.0798,169.996,0" Rotation="3.689" Scale="1,1,1" UnitType="Queen">
+    <ObjectUnit Id="552" Position="111.0798,169.996,0" Rotation="3.689" Scale="1,1,1" UnitType="Queen" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8738,44 +8646,44 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="457" Player="4" Position="111.7717,187.8078,0" Rotation="4.9794" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="621" Player="7" Position="123.9152,221.9274,0" Rotation="5.454" Scale="1,1,1" UnitType="BroodLord">
+    <ObjectUnit Id="457" Position="111.7717,187.8078,0" Rotation="4.9794" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="621" Position="123.9152,221.9274,0" Rotation="5.454" Scale="1,1,1" UnitType="BroodLord" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="518" Player="5" Position="167.0693,95.1938,0" Rotation="5.592" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="518" Position="167.0693,95.1938,0" Rotation="5.592" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="464" Player="3" Position="182,249,0" Rotation="5.9338" Scale="1,1,1" UnitType="GreaterSpire">
+    <ObjectUnit Id="464" Position="182,249,0" Rotation="5.9338" Scale="1,1,1" UnitType="GreaterSpire" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="561" Player="3" Position="115.3132,173.0107,0" Rotation="3.681" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="561" Position="115.3132,173.0107,0" Rotation="3.681" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1425914034" Position="19,156.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField"/>
-    <ObjectUnit Id="628" Position="114,81.5,0" Resources="2600" Scale="1,1,1" UnitType="MineralField" Variation="8">
+    <ObjectUnit Id="1425914034" Position="19,156.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="628" Variation="8" Position="114,81.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2600">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="543" Player="3" Position="142,72,0" Rotation="2.965" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="543" Position="142,72,0" Rotation="2.965" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="405" Player="4" Position="167.9685,169.9106,0" Rotation="6.0214" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="510" Player="5" Position="161.7778,98.388,0" Rotation="5.487" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="405" Position="167.9685,169.9106,0" Rotation="6.0214" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="510" Position="161.7778,98.388,0" Rotation="5.487" Scale="1,1,1" UnitType="Zergling" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -8783,56 +8691,56 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="424" Player="5" Position="24.855,44.0341,0" Rotation="6.2145" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="424" Position="24.855,44.0341,0" Rotation="6.2145" Scale="1,1,1" UnitType="Hydralisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="451" Player="1" Position="22.1093,13.589,0" Rotation="2.3881" Scale="1,1,1" UnitType="AP_StalkerShakuras"/>
-    <ObjectUnit Id="585" Player="5" Position="43,79,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="451" Position="22.1093,13.589,0" Rotation="2.3881" Scale="1,1,1" UnitType="AP_StalkerShakuras" Player="1"/>
+    <ObjectUnit Id="585" Position="43,79,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="546" Player="4" Position="180.538,248.7014,0" Rotation="6.0744" Scale="1,1,1" UnitType="ShadowCloudEpilogue01">
+    <ObjectUnit Id="546" Position="180.538,248.7014,0" Rotation="6.0744" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="615" Player="6" Position="52.8205,218.4831,0" Rotation="0.531" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="615" Position="52.8205,218.4831,0" Rotation="0.531" Scale="1,1,1" UnitType="SiegeTankSieged" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="390" Player="7" Position="125.5,218.5,0" Rotation="5.836" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="390" Position="125.5,218.5,0" Rotation="5.836" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="592" Player="7" Position="144,118,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="592" Position="144,118,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="571" Player="7" Position="144.2604,73.222,0" Rotation="5.5712" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="571" Position="144.2604,73.222,0" Rotation="5.5712" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="433" Player="5" Position="27.2785,38.7268,0" Rotation="5.812" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="433" Position="27.2785,38.7268,0" Rotation="5.812" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="638" Player="5" Position="86.5,163.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="638" Position="86.5,163.5,0" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="574" Player="7" Position="138.5961,79.9326,0" Rotation="5.8466" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="574" Position="138.5961,79.9326,0" Rotation="5.8466" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -8840,158 +8748,123 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="597" Position="54,175,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="479" Player="5" Position="162.8762,100.0131,0" Rotation="5.521" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="479" Position="162.8762,100.0131,0" Rotation="5.521" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="497" Player="7" Position="130.311,216.3737,0" Rotation="5.808" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="497" Position="130.311,216.3737,0" Rotation="5.808" Scale="1,1,1" UnitType="Raven" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="410" Player="3" Position="124,103,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="410" Position="124,103,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="635" Player="6" Position="61.5,173.5,0" Rotation="5.9118" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="635" Position="61.5,173.5,0" Rotation="5.9118" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="454" Player="8" Position="28.5,96.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Barracks">
+    <ObjectUnit Id="454" Position="28.5,96.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Barracks" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="551" Player="3" Position="108.5,177.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="551" Position="108.5,177.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="588" Player="7" Position="147,79,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="588" Position="147,79,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="1410077979" Position="144,189.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="9"/>
-    <ObjectUnit Id="610" Player="6" Position="49.6013,217.5922,0" Rotation="0.5937" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="1410077979" Variation="9" Position="144,189.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="610" Position="49.6013,217.5922,0" Rotation="0.5937" Scale="1,1,1" UnitType="Carrier" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1942279797" Position="18,157.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="1"/>
-    <ObjectUnit Id="387" Player="6" Position="48.5,214.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1942279797" Variation="1" Position="18,157.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="387" Position="48.5,214.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="306" Player="7" Position="129.5,91.5,0" Rotation="0.4775" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="306" Position="129.5,91.5,0" Rotation="0.4775" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="345" Player="4" Position="45.493,194.6044,0" Rotation="2.1997" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="723" Player="7" Position="111.1945,161.6635,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="345" Position="45.493,194.6044,0" Rotation="2.1997" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="723" Position="111.1945,161.6635,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="696" Player="7" Position="132.5705,218.753,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="696" Position="132.5705,218.753,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="765" Player="7" Position="126.59,212.4785,0" Rotation="5.5307" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="765" Position="126.59,212.4785,0" Rotation="5.5307" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="284" Player="7" Position="129.746,98.8471,0" Rotation="6.0173" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="284" Position="129.746,98.8471,0" Rotation="6.0173" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="714" Player="7" Position="126.8151,142.3828,0" Rotation="0.7805" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="714" Position="126.8151,142.3828,0" Rotation="0.7805" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="673" Player="7" Position="120.2736,218.012,0" Rotation="5.721" Scale="1,1,1" UnitType="Archon">
+    <ObjectUnit Id="673" Position="120.2736,218.012,0" Rotation="5.721" Scale="1,1,1" UnitType="Archon" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="299" Player="5" Position="58.5,137.5,0" Rotation="0.343" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="299" Position="58.5,137.5,0" Rotation="0.343" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1288" Player="3" Position="115.0734,171.3271,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed">
+    <ObjectUnit Id="1288" Position="115.0734,171.3271,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="261" Player="2" Position="86.9985,131.953,0" Rotation="3.882" Scale="1,1,1" UnitType="Marine">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="951245526" Position="19,158.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="2"/>
-    <ObjectUnit Id="740" Player="5" Position="146.1513,160.2055,0" Rotation="3.5852" Scale="1,1,1" UnitType="Zergling">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="676" Player="6" Position="52.5,222.5,0" Scale="1,1,1" UnitType="VoidRift">
-        <AIRebuild Index="1" Value="0"/>
-        <AIRebuild Index="2" Value="0"/>
-        <AIRebuild Index="3" Value="0"/>
-        <AIRebuild Index="4" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="719" Player="7" Position="128.1833,143.2197,0" Rotation="0.6914" Scale="1,1,1" UnitType="Zealot">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="302" Player="5" Position="51.5,129.5,0" Rotation="0.2731" Scale="1,1,1" UnitType="VoidRift">
-        <AIRebuild Index="1" Value="0"/>
-        <AIRebuild Index="2" Value="0"/>
-        <AIRebuild Index="3" Value="0"/>
-        <AIRebuild Index="4" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="256" Player="2" Position="91.4343,135.582,0" Rotation="4.1284" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="261" Position="86.9985,131.953,0" Rotation="3.882" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8999,92 +8872,127 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="650" Player="8" Position="33.6381,150.1347,0" Rotation="1.6628" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="951245526" Variation="2" Position="19,158.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="740" Position="146.1513,160.2055,0" Rotation="3.5852" Scale="1,1,1" UnitType="Zergling" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="676" Position="52.5,222.5,0" Scale="1,1,1" UnitType="VoidRift" Player="6">
+        <AIRebuild Index="1" Value="0"/>
+        <AIRebuild Index="2" Value="0"/>
+        <AIRebuild Index="3" Value="0"/>
+        <AIRebuild Index="4" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="719" Position="128.1833,143.2197,0" Rotation="0.6914" Scale="1,1,1" UnitType="Zealot" Player="7">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="302" Position="51.5,129.5,0" Rotation="0.2731" Scale="1,1,1" UnitType="VoidRift" Player="5">
+        <AIRebuild Index="1" Value="0"/>
+        <AIRebuild Index="2" Value="0"/>
+        <AIRebuild Index="3" Value="0"/>
+        <AIRebuild Index="4" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="256" Position="91.4343,135.582,0" Rotation="4.1284" Scale="1,1,1" UnitType="SiegeTankSieged" Player="2">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="650" Position="33.6381,150.1347,0" Rotation="1.6628" Scale="1,1,1" UnitType="Goliath" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="737" Player="7" Position="116.8288,160.0832,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="737" Position="116.8288,160.0832,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="348" Player="4" Position="42.1472,232.1491,0" Rotation="0.4821" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="311" Player="7" Position="135.5,65.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="348" Position="42.1472,232.1491,0" Rotation="0.4821" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="311" Position="135.5,65.5,0" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="701" Player="3" Position="128.6403,25.5595,0" Rotation="2.9602" Scale="1,1,1" UnitType="Queen">
+    <ObjectUnit Id="701" Position="128.6403,25.5595,0" Rotation="2.9602" Scale="1,1,1" UnitType="Queen" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="726" Player="7" Position="116.5344,166.3691,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="726" Position="116.5344,166.3691,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="659" Position="109,84.5,0" Resources="2500" Scale="1,1,1" UnitType="MineralField" Variation="3">
+    <ObjectUnit Id="659" Variation="3" Position="109,84.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2500">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="760" Player="6" Position="57.7163,220.9055,0" Rotation="0.2216" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="760" Position="57.7163,220.9055,0" Rotation="0.2216" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="281" Player="7" Position="126.4514,100.5021,0" Rotation="0.003" Scale="1,1,1" UnitType="Immortal">
+    <ObjectUnit Id="281" Position="126.4514,100.5021,0" Rotation="0.003" Scale="1,1,1" UnitType="Immortal" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="292" Player="7" Position="145.457,114.244,0" Rotation="5.1472" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="292" Position="145.457,114.244,0" Rotation="5.1472" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="686" Player="7" Position="123.5747,226.085,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix">
+    <ObjectUnit Id="686" Position="123.5747,226.085,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="709" Player="7" Position="124.003,145.223,0" Rotation="0.7802" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="709" Position="124.003,145.223,0" Rotation="0.7802" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="640" Player="7" Position="106.5,166.5,0" Rotation="5.6503" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="640" Position="106.5,166.5,0" Rotation="5.6503" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="747" Player="5" Position="149.686,157.6271,0" Rotation="3.5852" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="747" Position="149.686,157.6271,0" Rotation="3.5852" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="353" Player="4" Position="133.8015,210.4941,0" Rotation="1.3713" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="1287" Player="3" Position="107.7185,169.5322,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed">
+    <ObjectUnit Id="353" Position="133.8015,210.4941,0" Rotation="1.3713" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="1287" Position="107.7185,169.5322,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9092,49 +9000,49 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="266" Position="60,47,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="732" Player="7" Position="113.173,160.7456,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="732" Position="113.173,160.7456,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="342" Player="4" Position="21.1247,179.3654,0" Rotation="2.2121" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="275" Player="2" Position="93.5,76.5,0" Rotation="1.7575" Scale="1,1,1" UnitType="Bunker">
+    <ObjectUnit Id="342" Position="21.1247,179.3654,0" Rotation="2.2121" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="275" Position="93.5,76.5,0" Rotation="1.7575" Scale="1,1,1" UnitType="Bunker" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="665" Player="6" Position="50.9553,207.1516,0" Rotation="0.8388" Scale="1,1,1" UnitType="Thor">
+    <ObjectUnit Id="665" Position="50.9553,207.1516,0" Rotation="0.8388" Scale="1,1,1" UnitType="Thor" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="754" Player="5" Position="148.026,158.728,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="754" Position="148.026,158.728,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="729" Player="7" Position="119.181,164.163,0" Rotation="0.4934" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="729" Position="119.181,164.163,0" Rotation="0.4934" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="690" Player="7" Position="115.4675,226.391,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="690" Position="115.4675,226.391,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="339" Player="4" Position="27.259,47.7893,0" Rotation="4.488" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="278" Player="2" Position="93.6635,73.8354,0" Rotation="2.937" Scale="1,1,1" UnitType="Marauder">
+    <ObjectUnit Id="339" Position="27.259,47.7893,0" Rotation="4.488" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="278" Position="93.6635,73.8354,0" Rotation="2.937" Scale="1,1,1" UnitType="Marauder" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9142,89 +9050,87 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="381" Player="5" Position="79.5,218.5,0" Rotation="5.9462" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="381" Position="79.5,218.5,0" Rotation="5.9462" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="759" Player="7" Position="122.1237,226.3027,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="759" Position="122.1237,226.3027,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="668" Player="6" Position="61.002,219.9807,0" Rotation="0.6413" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="668" Position="61.002,219.9807,0" Rotation="0.6413" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="289" Player="7" Position="127.9133,102.7363,0" Rotation="6.1726" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="289" Position="127.9133,102.7363,0" Rotation="6.1726" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="704" Player="7" Position="126.127,145.4982,0" Rotation="0.6977" Scale="1,1,1" UnitType="Ultralisk">
+    <ObjectUnit Id="704" Position="126.127,145.4982,0" Rotation="0.6977" Scale="1,1,1" UnitType="Ultralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="683" Player="1" Position="55.5,43.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_RoboticsFacility"/>
-    <ObjectUnit Id="750" Player="5" Position="148.2792,156.9033,0" Rotation="3.4426" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="683" Position="55.5,43.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_RoboticsFacility" Player="1"/>
+    <ObjectUnit Id="750" Position="148.2792,156.9033,0" Rotation="3.4426" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="645" Player="6" Position="81.5,36.5,0" Rotation="0.4687" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="645" Position="81.5,36.5,0" Rotation="0.4687" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1282" Player="5" Position="148.0981,160.5932,0" Rotation="5.844" Scale="1,1,1" UnitType="Immortal">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="271" Player="6" Position="91.4265,62.9201,0" Rotation="0.1738" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1282" Position="148.0981,160.5932,0" Rotation="5.844" Scale="1,1,1" UnitType="Immortal" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="356" Player="8" Position="19.5,97.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Barracks">
+    <ObjectUnit Id="271" Position="91.4265,62.9201,0" Rotation="0.1738" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="356" Position="19.5,97.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Barracks" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="660" Player="8" Position="30.4213,155.8862,0" Rotation="1.848" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="660" Position="30.4213,155.8862,0" Rotation="1.848" Scale="1,1,1" UnitType="Goliath" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="767" Player="7" Position="129.0302,209.7038,0" Rotation="5.2832" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="767" Position="129.0302,209.7038,0" Rotation="5.2832" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="286" Player="2" Position="94.8298,74.1748,0" Rotation="2.676" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="286" Position="94.8298,74.1748,0" Rotation="2.676" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9232,64 +9138,64 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1276251355" Position="149.5,183.5,0" Resources="5000" Scale="1,1,1" UnitType="RichVespeneGeyser"/>
-    <ObjectUnit Id="347" Player="4" Position="66.9028,207.0031,0" Rotation="2.8054" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="304" Player="7" Position="147.1806,115.4914,0" Rotation="5.1674" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="347" Position="66.9028,207.0031,0" Rotation="2.8054" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="1276251355" Position="149.5,183.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="5000"/>
+    <ObjectUnit Id="304" Position="147.1806,115.4914,0" Rotation="5.1674" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="721" Player="7" Position="113.0861,164.354,0" Rotation="0.651" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="721" Position="113.0861,164.354,0" Rotation="0.651" Scale="1,1,1" UnitType="Banshee" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="263" Player="5" Position="69.5,89.5,0" Rotation="0.7138" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="263" Position="69.5,89.5,0" Rotation="0.7138" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="742" Player="5" Position="144.4204,157.339,0" Rotation="3.3708" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="742" Position="144.4204,157.339,0" Rotation="3.3708" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1386953199" Position="143,21.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="4"/>
-    <ObjectUnit Id="675" Player="7" Position="123.9338,215.1582,0" Rotation="5.721" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="1386953199" Variation="4" Position="143,21.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="675" Position="123.9338,215.1582,0" Rotation="5.721" Scale="1,1,1" UnitType="InfestedAbomination" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="712" Player="7" Position="123.6821,142.6184,0" Rotation="0.8818" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="712" Position="123.6821,142.6184,0" Rotation="0.8818" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="322" Player="5" Position="32.0666,150.1125,0" Rotation="0.9333" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="322" Position="32.0666,150.1125,0" Rotation="0.9333" Scale="1,1,1" UnitType="Stalker" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="297" Player="7" Position="141.8222,117.0312,0" Rotation="5.3986" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="297" Position="141.8222,117.0312,0" Rotation="5.3986" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="258" Player="2" Position="87.9133,130.665,0" Rotation="3.8671" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="258" Position="87.9133,130.665,0" Rotation="3.8671" Scale="1,1,1" UnitType="Goliath" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9297,287 +9203,232 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="739" Player="7" Position="118.8613,160.2106,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="739" Position="118.8613,160.2106,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="648" Player="3" Position="118,152,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="648" Position="118,152,0" Rotation="2.9648" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="717" Player="7" Position="130.8117,145.3078,0" Rotation="0.5021" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="717" Position="130.8117,145.3078,0" Rotation="0.5021" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="300" Player="7" Position="133.5,146.5,0" Rotation="5.9316" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="300" Position="133.5,146.5,0" Rotation="5.9316" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="327" Player="3" Position="102.5,171.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="327" Position="102.5,171.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1783" Player="5" Position="67.8967,101.2507,0" Rotation="5.3874" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="1783" Position="67.8967,101.2507,0" Rotation="5.3874" Scale="1,1,1" UnitType="Ghost" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="762" Player="7" Position="128.51,212.1953,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="762" Position="128.51,212.1953,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="564443661" Position="149,28.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="3"/>
-    <ObjectUnit Id="283" Player="7" Position="129.2553,100.827,0" Rotation="6.0356" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="564443661" Variation="3" Position="149,28.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="283" Position="129.2553,100.827,0" Rotation="6.0356" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="398895581" Position="145,184.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="5"/>
-    <ObjectUnit Id="309" Player="5" Position="101.3732,211.1823,0" Rotation="0.841" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="309" Position="101.3732,211.1823,0" Rotation="0.841" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="350" Player="4" Position="42.9814,214.593,0" Rotation="1.7988" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="724" Player="7" Position="110.975,163.47,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="398895581" Variation="5" Position="145,184.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="350" Position="42.9814,214.593,0" Rotation="1.7988" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="724" Position="110.975,163.47,0" Rotation="0.8217" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="703" Player="7" Position="116.2314,163.8354,0" Rotation="0.3666" Scale="1,1,1" UnitType="Archon">
+    <ObjectUnit Id="703" Position="116.2314,163.8354,0" Rotation="0.3666" Scale="1,1,1" UnitType="Archon" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="745" Player="5" Position="143.7993,156.1257,0" Rotation="3.3085" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="745" Position="143.7993,156.1257,0" Rotation="3.3085" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="642" Player="7" Position="120.5,169.5,0" Rotation="0.641" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="642" Position="120.5,169.5,0" Rotation="0.641" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="264" Player="7" Position="141.5,85.5,0" Rotation="5.9445" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="264" Position="141.5,85.5,0" Rotation="5.9445" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1285" Player="3" Position="134.9631,117.7705,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed">
+    <ObjectUnit Id="1285" Position="134.9631,117.7705,0" Rotation="0.7851" Scale="1,1,1" UnitType="SwarmHostSplitBBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="355" Player="4" Position="142.3745,231.2431,0" Rotation="3.598" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="294" Player="7" Position="142.9335,113.482,0" Rotation="5.1716" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="355" Position="142.3745,231.2431,0" Rotation="3.598" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="294" Position="142.9335,113.482,0" Rotation="5.1716" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="711" Player="7" Position="123.7575,144.462,0" Rotation="0.8134" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="711" Position="123.7575,144.462,0" Rotation="0.8134" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="684" Player="7" Position="123.1132,216.855,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix">
+    <ObjectUnit Id="684" Position="123.1132,216.855,0" Rotation="5.454" Scale="1,1,1" UnitType="Phoenix" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="273" Player="7" Position="143.5,109.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="273" Position="143.5,109.5,0" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="752" Player="5" Position="147.334,153.5473,0" Rotation="3.3085" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="752" Position="147.334,153.5473,0" Rotation="3.3085" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="667" Player="6" Position="64.1665,219.223,0" Rotation="0.6413" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="667" Position="64.1665,219.223,0" Rotation="0.6413" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="734" Player="7" Position="117.45,161.2966,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="734" Position="117.45,161.2966,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="693" Player="7" Position="130.8054,211.9816,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="693" Position="130.8054,211.9816,0" Rotation="5.4145" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1720" Player="5" Position="63.792,101.019,0" Rotation="5.4604" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="1720" Position="63.792,101.019,0" Rotation="5.4604" Scale="1,1,1" UnitType="Hydralisk" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="340" Player="4" Position="44.6284,32.2492,0" Rotation="1.5146" Scale="1,1,1" UnitType="ShadowCloudEpilogue01"/>
-    <ObjectUnit Id="383" Player="7" Position="118.5,227.5,0" Rotation="0.248" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="340" Position="44.6284,32.2492,0" Rotation="1.5146" Scale="1,1,1" UnitType="ShadowCloudEpilogue01" Player="4"/>
+    <ObjectUnit Id="383" Position="118.5,227.5,0" Rotation="0.248" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="276" Player="7" Position="136.5,123.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="276" Position="136.5,123.5,0" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="670" Player="6" Position="46.622,220.05,0" Rotation="0.7436" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="670" Position="46.622,220.05,0" Rotation="0.7436" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="757" Player="7" Position="127.9892,213.9003,0" Rotation="5.4262" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="757" Position="127.9892,213.9003,0" Rotation="5.4262" Scale="1,1,1" UnitType="Hydralisk" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="688" Player="7" Position="114.4956,221.69,0" Rotation="5.721" Scale="1,1,1" UnitType="Archon">
+    <ObjectUnit Id="688" Position="114.4956,221.69,0" Rotation="5.721" Scale="1,1,1" UnitType="Archon" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="731" Player="7" Position="116.3498,162.442,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="731" Position="116.3498,162.442,0" Rotation="0.679" Scale="1,1,1" UnitType="Zergling" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="647" Player="3" Position="130,135,0" Rotation="3.7775" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="647" Position="130,135,0" Rotation="3.7775" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="748" Player="5" Position="148.9238,156.1481,0" Rotation="3.475" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="748" Position="148.9238,156.1481,0" Rotation="3.475" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="269" Player="6" Position="98.5063,67.1855,0" Rotation="5.8864" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="269" Position="98.5063,67.1855,0" Rotation="5.8864" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1280" Player="3" Position="114.8793,176.8288,0" Rotation="4.1103" Scale="1,1,1" UnitType="HotSHunter">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="328" Player="3" Position="130.7983,34.4692,0" Rotation="2.9604" Scale="1,1,1" UnitType="Queen">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="291" Player="7" Position="140.7565,114.7265,0" Rotation="5.3403" Scale="1,1,1" UnitType="Archon">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="681" Player="5" Position="141.5,188.5,0" Rotation="0.2656" Scale="1,1,1" UnitType="VoidRift">
-        <AIRebuild Index="1" Value="0"/>
-        <AIRebuild Index="2" Value="0"/>
-        <AIRebuild Index="3" Value="0"/>
-        <AIRebuild Index="4" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="706" Player="7" Position="129.9787,147.3122,0" Rotation="0.4904" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1178" Player="5" Position="83.5,169.5898,0" Rotation="5.8417" Scale="1,1,1" UnitType="Carrier">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="151" Player="2" Position="91,34,0" Rotation="3.2106" Scale="1,1,1" UnitType="MissileTurret">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1265" Player="2" Position="57.4272,175.2448,0" Rotation="2.824" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="1280" Position="114.8793,176.8288,0" Rotation="4.1103" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9585,29 +9436,83 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="252" Player="6" Position="104.418,48.9765,0" Rotation="5.6081" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="328" Position="130.7983,34.4692,0" Rotation="2.9604" Scale="1,1,1" UnitType="Queen" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="291" Position="140.7565,114.7265,0" Rotation="5.3403" Scale="1,1,1" UnitType="Archon" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="886" Player="6" Position="69.3576,155.055,0" Rotation="0.8623" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="681" Position="141.5,188.5,0" Rotation="0.2656" Scale="1,1,1" UnitType="VoidRift" Player="5">
+        <AIRebuild Index="1" Value="0"/>
+        <AIRebuild Index="2" Value="0"/>
+        <AIRebuild Index="3" Value="0"/>
+        <AIRebuild Index="4" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="706" Position="129.9787,147.3122,0" Rotation="0.4904" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="797" Player="5" Position="142.825,157.758,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1178" Position="83.5,169.5898,0" Rotation="5.8417" Scale="1,1,1" UnitType="Carrier" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="856" Player="6" Position="94.0698,125.7,0" Rotation="5.8361" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="151" Position="91,34,0" Rotation="3.2106" Scale="1,1,1" UnitType="MissileTurret" Player="2">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1265" Position="57.4272,175.2448,0" Rotation="2.824" Scale="1,1,1" UnitType="Goliath" Player="2">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="252" Position="104.418,48.9765,0" Rotation="5.6081" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="886" Position="69.3576,155.055,0" Rotation="0.8623" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="797" Position="142.825,157.758,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="856" Position="94.0698,125.7,0" Rotation="5.8361" Scale="1,1,1" UnitType="Stalker" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="819" Position="115.8632,91.5451,0" Rotation="5.765" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -9615,22 +9520,15 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2165" Position="67.6481,136.6018,0" Rotation="3.9653" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="819" Player="5" Position="115.8632,91.5451,0" Rotation="5.765" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
     <ObjectUnit Id="185" Position="147,79,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="1204" Player="9" Position="146.75,183.75,0" Rotation="5.7404" Scale="1,1,1" UnitType="HotSNoxious">
+    <ObjectUnit Id="1204" Position="146.75,183.75,0" Rotation="5.7404" Scale="1,1,1" UnitType="HotSNoxious" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="210" Player="3" Position="136.3996,123.0837,0" Rotation="3.4033" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="210" Position="136.3996,123.0837,0" Rotation="3.4033" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9638,34 +9536,34 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1247" Position="59.229,71.5322,0" Rotation="1.4047" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="879" Player="6" Position="54.0632,168.4077,0" Rotation="0.2985" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="879" Position="54.0632,168.4077,0" Rotation="0.2985" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="772" Player="7" Position="127.6003,218.7792,0" Rotation="5.613" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="772" Position="127.6003,218.7792,0" Rotation="5.613" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="142" Player="6" Position="82.8513,97.6511,0" Rotation="0.999" Scale="1,1,1" UnitType="Immortal">
+    <ObjectUnit Id="142" Position="82.8513,97.6511,0" Rotation="0.999" Scale="1,1,1" UnitType="Immortal" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1155" Player="9" Position="161,97,0" Rotation="2.885" Scale="1,1,1" UnitType="SporeCrawler">
+    <ObjectUnit Id="1155" Position="161,97,0" Rotation="2.885" Scale="1,1,1" UnitType="SporeCrawler" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="229" Player="3" Position="135.5,86.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="229" Position="135.5,86.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9673,13 +9571,13 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1256" Position="38.6455,129.3791,0" Rotation="2.6437" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="160" Player="5" Position="38.5,104.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="160" Position="38.5,104.5,0" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="203" Player="3" Position="137.5065,119.1037,0" Rotation="3.689" Scale="1,1,1" UnitType="Queen">
+    <ObjectUnit Id="203" Position="137.5065,119.1037,0" Rotation="3.689" Scale="1,1,1" UnitType="Queen" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9687,28 +9585,28 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="833" Player="3" Position="137.1203,39.576,0" Rotation="3.6191" Scale="1,1,1" UnitType="MutaliskBroodlord">
+    <ObjectUnit Id="833" Position="137.1203,39.576,0" Rotation="3.6191" Scale="1,1,1" UnitType="MutaliskBroodlord" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="810" Player="5" Position="76.3891,210.5041,0" Rotation="5.8728" Scale="1,1,1" UnitType="Ultralisk">
-        <AIRebuild Index="1" Value="0"/>
-        <AIRebuild Index="2" Value="0"/>
-        <AIRebuild Index="3" Value="0"/>
-        <AIRebuild Index="4" Value="0"/>
-        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2156" Position="142.5983,146.808,0" Rotation="2.5324" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="769" Player="7" Position="120.2116,223.8093,0" Rotation="6.0212" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="810" Position="76.3891,210.5041,0" Rotation="5.8728" Scale="1,1,1" UnitType="Ultralisk" Player="5">
+        <AIRebuild Index="1" Value="0"/>
+        <AIRebuild Index="2" Value="0"/>
+        <AIRebuild Index="3" Value="0"/>
+        <AIRebuild Index="4" Value="0"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="769" Position="120.2116,223.8093,0" Rotation="6.0212" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="874" Player="6" Position="91.6027,125.6108,0" Rotation="6.0253" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="874" Position="91.6027,125.6108,0" Rotation="6.0253" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -9716,14 +9614,14 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="224" Player="5" Position="112.425,94.4143,0" Rotation="5.8256" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="224" Position="112.425,94.4143,0" Rotation="5.8256" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1261" Player="2" Position="58.2092,178.5781,0" Rotation="2.655" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1261" Position="58.2092,178.5781,0" Rotation="2.655" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9731,83 +9629,86 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="139" Player="6" Position="100.3117,85.2988,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="139" Position="100.3117,85.2988,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1158" Player="9" Position="161.4296,98.3125,0" Rotation="5.1894" Scale="1,1,1" UnitType="MutaliskBroodlord">
+    <ObjectUnit Id="1158" Position="161.4296,98.3125,0" Rotation="5.1894" Scale="1,1,1" UnitType="MutaliskBroodlord" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1219" Player="8" Position="177,227,0" Rotation="5.4975" Scale="1,1,1" UnitType="SupplyDepot">
+    <ObjectUnit Id="1219" Position="177,227,0" Rotation="5.4975" Scale="1,1,1" UnitType="SupplyDepot" Player="8">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="206" Player="3" Position="136.9042,124.4965,0" Rotation="3.4665" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="206" Position="136.9042,124.4965,0" Rotation="3.4665" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1192" Player="9" Position="144,186,0" Rotation="2.8847" Scale="1,1,1" UnitType="SporeCrawler">
+    <ObjectUnit Id="1192" Position="144,186,0" Rotation="2.8847" Scale="1,1,1" UnitType="SporeCrawler" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="165" Player="5" Position="78.0402,208.8427,0" Rotation="5.3627" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="165" Position="78.0402,208.8427,0" Rotation="5.3627" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1268" Player="5" Position="150.5798,179.8298,0" Rotation="5.565" Scale="1,1,1" UnitType="Battlecruiser">
+    <ObjectUnit Id="1268" Position="150.5798,179.8298,0" Rotation="5.565" Scale="1,1,1" UnitType="Battlecruiser" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="249" Player="6" Position="96.3078,67.2077,0" Rotation="6.109" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="249" Position="96.3078,67.2077,0" Rotation="6.109" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1183" Player="6" Position="62.4553,170.2321,0" Rotation="0.6132" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="1183" Position="62.4553,170.2321,0" Rotation="0.6132" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="146" Player="6" Position="51.8276,208.9072,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="146" Position="51.8276,208.9072,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="792" Player="6" Position="57.1062,213.3464,0" Rotation="0.875" Scale="1,1,1" UnitType="Thor">
+    <ObjectUnit Id="792" Position="57.1062,213.3464,0" Rotation="0.875" Scale="1,1,1" UnitType="Thor" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="883" Player="6" Position="70.616,154.574,0" Rotation="0.7834" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="883" Position="70.616,154.574,0" Rotation="0.7834" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="822" Position="99.0065,86.5114,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -9815,14 +9716,7 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2160" Position="74.495,185.148,0" Rotation="4.0822" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="822" Player="6" Position="99.0065,86.5114,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="861" Player="6" Position="89.7888,127.1667,0" Rotation="6.1936" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="861" Position="89.7888,127.1667,0" Rotation="6.1936" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -9830,75 +9724,73 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="215" Player="3" Position="141.433,125.2805,0" Rotation="3.7194" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="215" Position="141.433,125.2805,0" Rotation="3.7194" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="188" Player="6" Position="59.1672,173.5905,0" Rotation="0.2832" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="188" Position="59.1672,173.5905,0" Rotation="0.2832" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1201" Player="9" Position="148.5253,181.2321,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="1201" Position="148.5253,181.2321,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="234" Player="6" Position="95.8298,54.5966,0" Rotation="6.2011" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="234" Position="95.8298,54.5966,0" Rotation="6.2011" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1255" Player="7" Position="111.8247,171.8527,0" Rotation="0.6503" Scale="1,1,1" UnitType="BroodLord">
+    <ObjectUnit Id="1255" Position="111.8247,171.8527,0" Rotation="0.6503" Scale="1,1,1" UnitType="BroodLord" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="129" Player="2" Position="84.5,15.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Factory">
+    <ObjectUnit Id="129" Position="84.5,15.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Factory" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1164" Player="9" Position="160.91,99.1147,0" Rotation="5.2626" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="1164" Position="160.91,99.1147,0" Rotation="5.2626" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="66494882" Position="148,29.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="1"/>
-    <ObjectUnit Id="779" Player="6" Position="55.3327,216.253,0" Rotation="0.622" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="779" Position="55.3327,216.253,0" Rotation="0.622" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
+    <ObjectUnit Id="66494882" Variation="1" Position="148,29.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
     <ObjectUnit Id="864" Position="134,38,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
     <ObjectUnit Id="805" Position="122.5,82.5,0" Scale="1,1,1" UnitType="VespeneGeyser">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="846" Player="6" Position="99.0383,87.693,0" Rotation="6.2307" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="846" Position="99.0383,87.693,0" Rotation="6.2307" Scale="1,1,1" UnitType="Ghost" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1225" Player="2" Position="91.3271,75.4545,0" Rotation="2.269" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1225" Position="91.3271,75.4545,0" Rotation="2.269" Scale="1,1,1" UnitType="Marine" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9906,27 +9798,27 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="196" Player="6" Position="55.5876,172.3781,0" Rotation="0.398" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="196" Position="55.5876,172.3781,0" Rotation="0.398" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="786" Player="6" Position="58.2172,210.5163,0" Rotation="0.954" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="786" Position="58.2172,210.5163,0" Rotation="0.954" Scale="1,1,1" UnitType="Zealot" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="889" Player="6" Position="70.3698,157.9594,0" Rotation="0.5234" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="889" Position="70.3698,157.9594,0" Rotation="0.5234" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1278" Player="3" Position="115.8383,176.6076,0" Rotation="4.1572" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="1278" Position="115.8383,176.6076,0" Rotation="4.1572" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9934,48 +9826,45 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="243" Player="6" Position="88.455,64.5087,0" Rotation="0.3415" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="243" Position="88.455,64.5087,0" Rotation="0.3415" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="152" Player="2" Position="83,23.0156,0" Rotation="2.356" Scale="1,1,1" UnitType="HyperionKorhal">
+    <ObjectUnit Id="152" Position="83,23.0156,0" Rotation="2.356" Scale="1,1,1" UnitType="HyperionKorhal" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="221" Player="3" Position="133,123,0" Rotation="3.318" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="221" Position="133,123,0" Rotation="3.318" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="182" Player="6" Position="82.5883,106.3464,0" Rotation="0.489" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="182" Position="82.5883,106.3464,0" Rotation="0.489" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1211" Player="8" Position="175.5,233.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="CommandCenter">
+    <ObjectUnit Id="1211" Position="175.5,233.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="CommandCenter" Player="8">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="828" Player="5" Position="95.76,214.4367,0" Rotation="0.6718" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="828" Position="95.76,214.4367,0" Rotation="0.6718" Scale="1,1,1" UnitType="Carrier" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="855" Player="6" Position="93.2607,127.532,0" Rotation="5.9455" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="855" Position="93.2607,127.532,0" Rotation="5.9455" Scale="1,1,1" UnitType="Stalker" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -9983,37 +9872,34 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="892" Player="6" Position="72.2541,145.0251,0" Rotation="0.7851" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="892" Position="72.2541,145.0251,0" Rotation="0.7851" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="791" Player="6" Position="52.7246,216.1813,0" Rotation="0.7656" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="791" Position="52.7246,216.1813,0" Rotation="0.7656" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1168" Player="5" Position="81.2697,166.5798,0" Rotation="5.7592" Scale="1,1,1" UnitType="InfestedAbomination">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="157" Player="6" Position="84.168,104.9084,0" Rotation="0.5922" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="1168" Position="81.2697,166.5798,0" Rotation="5.7592" Scale="1,1,1" UnitType="InfestedAbomination" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1628311699" Position="141,20.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="7"/>
-    <ObjectUnit Id="1275" Player="3" Position="139.3645,126.0021,0" Rotation="4.1574" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="157" Position="84.168,104.9084,0" Rotation="0.5922" Scale="1,1,1" UnitType="Hydralisk" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1275" Position="139.3645,126.0021,0" Rotation="4.1574" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -10021,40 +9907,40 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="246" Player="6" Position="98.2126,65.6772,0" Rotation="5.849" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1628311699" Variation="7" Position="141,20.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="246" Position="98.2126,65.6772,0" Rotation="5.849" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="179" Player="6" Position="80.9675,103.4187,0" Rotation="0.7651" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="179" Position="80.9675,103.4187,0" Rotation="0.7651" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1214" Player="8" Position="179.5,228.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="GhostAcademy">
+    <ObjectUnit Id="1214" Position="179.5,228.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="GhostAcademy" Player="8">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="216" Player="3" Position="140.2375,124.6767,0" Rotation="3.6445" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="216" Position="140.2375,124.6767,0" Rotation="3.6445" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="850" Player="6" Position="84.8637,101.6506,0" Rotation="0.5756" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="850" Position="84.8637,101.6506,0" Rotation="0.5756" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1080271144" Position="19,108.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="8"/>
-    <ObjectUnit Id="825" Player="3" Position="112.74,172.41,0" Rotation="3.6447" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="825" Position="112.74,172.41,0" Rotation="3.6447" Scale="1,1,1" UnitType="InfestedAbomination" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -10062,28 +9948,29 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="132" Player="6" Position="95.5485,88.8908,0" Rotation="5.9226" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1080271144" Variation="8" Position="19,108.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="132" Position="95.5485,88.8908,0" Rotation="5.9226" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1161" Player="9" Position="161.589,95.075,0" Rotation="5.2885" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="1161" Position="161.589,95.075,0" Rotation="5.2885" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="239" Player="3" Position="142.323,24.2033,0" Rotation="1.222" Scale="1,1,1" UnitType="Drone">
+    <ObjectUnit Id="239" Position="146,28.5,0" Rotation="1.222" Scale="1,1,1" UnitType="Drone" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1250" Position="104.998,153.1115,0" Rotation="0.8974" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="869" Player="6" Position="84.6882,124.7673,0" Rotation="0.0541" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="869" Position="84.6882,124.7673,0" Rotation="0.0541" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -10091,48 +9978,48 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="782" Player="6" Position="46.7375,207.3574,0" Rotation="1.237" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="782" Position="46.7375,207.3574,0" Rotation="1.237" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="843" Player="6" Position="97.9104,92.4877,0" Rotation="5.9255" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="843" Position="97.9104,92.4877,0" Rotation="5.9255" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="800" Player="5" Position="151.4577,153.8925,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="800" Position="151.4577,153.8925,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1191" Player="9" Position="150.5,189.5,0" Scale="1,1,1" UnitType="Lair">
+    <ObjectUnit Id="1191" Position="150.5,189.5,0" Scale="1,1,1" UnitType="Lair" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1920279935" Position="90.5,24.5,0" Resources="5000" Scale="1,1,1" UnitType="RichVespeneGeyser"/>
-    <ObjectUnit Id="193" Player="6" Position="53.5876,165.9836,0" Rotation="0.9377" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="1920279935" Position="90.5,24.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="5000"/>
+    <ObjectUnit Id="193" Position="53.5876,165.9836,0" Rotation="0.9377" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="817" Player="2" Position="92.6628,36.3581,0" Rotation="2.7507" Scale="1,1,1" UnitType="Goliath">
+    <ObjectUnit Id="817" Position="92.6628,36.3581,0" Rotation="2.7507" Scale="1,1,1" UnitType="Goliath" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="858" Player="6" Position="83.5722,126.2526,0" Rotation="0.1342" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="858" Position="83.5722,126.2526,0" Rotation="0.1342" Scale="1,1,1" UnitType="Stalker" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -10141,22 +10028,22 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1245" Position="74.1096,78.0537,0" Rotation="3.6562" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="2027852850" Position="161,108.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="7"/>
-    <ObjectUnit Id="208" Player="3" Position="136.2224,123.849,0" Rotation="3.405" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="208" Position="136.2224,123.849,0" Rotation="3.405" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="187" Player="6" Position="53.3923,171.3706,0" Rotation="0.5476" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="2027852850" Variation="7" Position="161,108.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="187" Position="53.3923,171.3706,0" Rotation="0.5476" Scale="1,1,1" UnitType="Carrier" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="254" Player="2" Position="87.9348,132.8166,0" Rotation="3.9924" Scale="1,1,1" UnitType="Marauder">
+    <ObjectUnit Id="254" Position="87.9348,132.8166,0" Rotation="3.9924" Scale="1,1,1" UnitType="Marauder" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -10164,80 +10051,78 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1267" Player="3" Position="131.023,41.3957,0" Rotation="3.7277" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="1267" Position="131.023,41.3957,0" Rotation="3.7277" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="149" Player="2" Position="87.6672,31.9345,0" Rotation="2.6123" Scale="1,1,1" UnitType="Medivac">
+    <ObjectUnit Id="149" Position="87.6672,31.9345,0" Rotation="2.6123" Scale="1,1,1" UnitType="Medivac" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="799" Player="5" Position="144.3452,161.1755,0" Rotation="3.585" Scale="1,1,1" UnitType="SiegeTankSieged">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="884" Player="6" Position="70.5214,156.784,0" Rotation="0.584" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="799" Position="144.3452,161.1755,0" Rotation="3.585" Scale="1,1,1" UnitType="SiegeTankSieged" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="201" Player="7" Position="149.5,73.5,0" Rotation="5.8076" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="884" Position="70.5214,156.784,0" Rotation="0.584" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="201" Position="149.5,73.5,0" Rotation="5.8076" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1220" Player="9" Position="179.5,237.5,0" Rotation="0.5234" Scale="1,1,1" UnitType="UltraliskCavern">
+    <ObjectUnit Id="1220" Position="179.5,237.5,0" Rotation="0.5234" Scale="1,1,1" UnitType="UltraliskCavern" Player="9">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="162" Player="5" Position="100.4658,215.9035,0" Rotation="0.531" Scale="1,1,1" UnitType="SiegeTankSieged">
+    <ObjectUnit Id="162" Position="100.4658,215.9035,0" Rotation="0.531" Scale="1,1,1" UnitType="SiegeTankSieged" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1199" Player="9" Position="148.733,184.9455,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="1199" Position="148.733,184.9455,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="808" Position="54.6933,218.3002,0" Rotation="0.464" Scale="1,1,1" UnitType="Mutalisk" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
     <ObjectUnit Id="2158" Position="135.5144,184.356,0" Rotation="4.2192" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="808" Player="6" Position="54.6933,218.3002,0" Rotation="0.464" Scale="1,1,1" UnitType="Mutalisk">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="4"/>
-    </ObjectUnit>
-    <ObjectUnit Id="835" Player="3" Position="137.2675,40.622,0" Rotation="3.6535" Scale="1,1,1" UnitType="MutaliskBroodlord">
+    <ObjectUnit Id="835" Position="137.2675,40.622,0" Rotation="3.6535" Scale="1,1,1" UnitType="MutaliskBroodlord" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="774" Player="7" Position="122.4846,224.3078,0" Rotation="5.9335" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="774" Position="122.4846,224.3078,0" Rotation="5.9335" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="877" Player="6" Position="53.3662,165.3737,0" Rotation="0.4785" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="877" Position="53.3662,165.3737,0" Rotation="0.4785" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -10245,53 +10130,51 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1258" Position="103.2443,154.5002,0" Rotation="4.0104" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="231" Player="3" Position="133.5,93.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="231" Position="133.5,93.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1153" Player="9" Position="165.5,101.5,0" Scale="1,1,1" UnitType="Lair">
+    <ObjectUnit Id="1153" Position="165.5,101.5,0" Scale="1,1,1" UnitType="Lair" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="140" Player="6" Position="87.8305,106.1997,0" Rotation="0.477" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="140" Position="87.8305,106.1997,0" Rotation="0.477" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="167" Player="2" Position="78.9497,20.8264,0" Rotation="2.4345" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="167" Position="78.9497,20.8264,0" Rotation="2.4345" Scale="1,1,1" UnitType="SCV" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1194" Player="7" Position="124.91,146.7897,0" Rotation="0.651" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="1194" Position="124.91,146.7897,0" Rotation="0.651" Scale="1,1,1" UnitType="Banshee" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="204" Player="7" Position="123.5,57.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="204" Position="123.5,57.5,0" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1217" Player="9" Position="179.5,234.5,0" Rotation="5.7595" Scale="1,1,1" UnitType="InfestationPit">
+    <ObjectUnit Id="1217" Position="179.5,234.5,0" Rotation="5.7595" Scale="1,1,1" UnitType="InfestationPit" Player="9">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="838" Player="5" Position="80.5397,208.9501,0" Rotation="5.363" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="838" Position="80.5397,208.9501,0" Rotation="5.363" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
@@ -10299,7 +10182,7 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2155" Position="149.243,63.2023,0" Rotation="5.9973" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="872" Player="6" Position="88.9978,128.6806,0" Rotation="6.258" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="872" Position="88.9978,128.6806,0" Rotation="6.258" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -10307,25 +10190,25 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="771" Player="7" Position="128.5954,217.2687,0" Rotation="5.5302" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="771" Position="128.5954,217.2687,0" Rotation="5.5302" Scale="1,1,1" UnitType="Marine" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1156" Player="5" Position="168.5,99.5,0" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1156" Position="168.5,99.5,0" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="137" Player="3" Position="134.7893,41.9841,0" Rotation="3.4011" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="137" Position="134.7893,41.9841,0" Rotation="3.4011" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1263" Player="3" Position="135.9372,121.2705,0" Rotation="3.6445" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="1263" Position="135.9372,121.2705,0" Rotation="3.6445" Scale="1,1,1" UnitType="InfestedAbomination" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -10333,7 +10216,7 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="226" Player="5" Position="114.279,93.1564,0" Rotation="5.8288" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="226" Position="114.279,93.1564,0" Rotation="5.8288" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -10341,148 +10224,91 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="863" Position="88,29,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="1599287487" Position="19,106.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="8"/>
-    <ObjectUnit Id="820" Player="6" Position="101.7915,84.3522,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
+    <ObjectUnit Id="1599287487" Variation="8" Position="19,106.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
     <ObjectUnit Id="2162" Position="110.6647,207.0253,0" Rotation="4.2192" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="1203" Player="9" Position="142.9304,183.647,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="820" Position="101.7915,84.3522,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1203" Position="142.9304,183.647,0" Rotation="5.2883" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="190" Player="6" Position="59.1013,169.9372,0" Rotation="0.373" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="190" Position="59.1013,169.9372,0" Rotation="0.373" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="213" Player="6" Position="96.827,52.891,0" Rotation="6.0725" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="213" Position="96.827,52.891,0" Rotation="6.0725" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="144" Player="1" Position="48.5,40.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_CyberneticsCore"/>
-    <ObjectUnit Id="1181" Player="6" Position="57.7736,166.1301,0" Rotation="0.6132" Scale="1,1,1" UnitType="Hydralisk">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="251" Player="6" Position="106.303,48.9118,0" Rotation="5.4257" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="144" Position="48.5,40.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_CyberneticsCore" Player="1"/>
+    <ObjectUnit Id="1181" Position="57.7736,166.1301,0" Rotation="0.6132" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1270" Player="3" Position="126.1232,39.6218,0" Rotation="3.1501" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="251" Position="106.303,48.9118,0" Rotation="5.4257" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1270" Position="126.1232,39.6218,0" Rotation="3.1501" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="881" Player="6" Position="57.2568,167.5708,0" Rotation="0.6137" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="881" Position="57.2568,167.5708,0" Rotation="0.6137" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="794" Player="5" Position="143.1215,159.461,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="794" Position="143.1215,159.461,0" Rotation="3.1682" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="844" Player="6" Position="97.792,87.4824,0" Rotation="5.6696" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="844" Position="97.792,87.4824,0" Rotation="5.6696" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="807" Player="6" Position="52.136,214.3342,0" Rotation="0.4003" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="807" Position="52.136,214.3342,0" Rotation="0.4003" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="173" Player="2" Position="93,21,0" Rotation="5.4975" Scale="1,1,1" UnitType="StarportTechReactor">
+    <ObjectUnit Id="173" Position="93,21,0" Rotation="5.4975" Scale="1,1,1" UnitType="StarportTechReactor" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1184" Player="7" Position="122.92,143.97,0" Rotation="0.9091" Scale="1,1,1" UnitType="Raven">
-        <Flag Index="ForcePlacement" Value="1"/>
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="198" Player="6" Position="55.433,167.2285,0" Rotation="0.758" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1227" Player="2" Position="88.1594,135.5322,0" Rotation="4.2097" Scale="1,1,1" UnitType="Marine">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1166" Player="9" Position="158.2055,99.526,0" Rotation="5.1752" Scale="1,1,1" UnitType="HotSRaptor">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="131" Player="6" Position="97.888,90.0563,0" Rotation="5.8305" Scale="1,1,1" UnitType="Zergling">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1253" Player="7" Position="108.9255,160.5876,0" Rotation="0.6506" Scale="1,1,1" UnitType="BroodLord">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="232" Player="6" Position="94.4768,53.2507,0" Rotation="0.0563" Scale="1,1,1" UnitType="Zergling">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="866" Player="6" Position="91.3186,125.053,0" Rotation="6.0375" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1184" Position="122.92,143.97,0" Rotation="0.9091" Scale="1,1,1" UnitType="Raven" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -10490,66 +10316,117 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="777" Player="6" Position="46.7585,210.649,0" Rotation="1.063" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="198" Position="55.433,167.2285,0" Rotation="0.758" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1227" Position="88.1594,135.5322,0" Rotation="4.2097" Scale="1,1,1" UnitType="Marine" Player="2">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1166" Position="158.2055,99.526,0" Rotation="5.1752" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="131" Position="97.888,90.0563,0" Rotation="5.8305" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1253" Position="108.9255,160.5876,0" Rotation="0.6506" Scale="1,1,1" UnitType="BroodLord" Player="7">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="232" Position="94.4768,53.2507,0" Rotation="0.0563" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="866" Position="91.3186,125.053,0" Rotation="6.0375" Scale="1,1,1" UnitType="Marine" Player="6">
+        <Flag Index="ForcePlacement" Value="1"/>
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="777" Position="46.7585,210.649,0" Rotation="1.063" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1209" Player="8" Position="179.5,231.5,0" Scale="1,1,1" UnitType="Armory">
+    <ObjectUnit Id="1209" Position="179.5,231.5,0" Scale="1,1,1" UnitType="Armory" Player="8">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="180" Player="2" Position="92.8413,38.2836,0" Rotation="3.0856" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="180" Position="92.8413,38.2836,0" Rotation="3.0856" Scale="1,1,1" UnitType="Marine" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="223" Player="5" Position="115.5537,94.8371,0" Rotation="5.7922" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="223" Position="115.5537,94.8371,0" Rotation="5.7922" Scale="1,1,1" UnitType="Hydralisk" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="853" Player="6" Position="88.6025,103.6997,0" Rotation="0.3166" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="853" Position="88.6025,103.6997,0" Rotation="0.3166" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="891" Player="6" Position="70.463,146.3872,0" Rotation="0.8225" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="891" Position="70.463,146.3872,0" Rotation="0.8225" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="784" Player="6" Position="60.061,212.378,0" Rotation="0.3945" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="784" Position="60.061,212.378,0" Rotation="0.3945" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="154" Player="2" Position="81.902,18.0097,0" Rotation="2.1262" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="154" Position="81.902,18.0097,0" Rotation="2.1262" Scale="1,1,1" UnitType="SCV" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1175" Player="5" Position="31,107,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="1175" Position="31,107,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="241" Player="6" Position="90.517,62.9226,0" Rotation="0.3" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="241" Position="90.517,62.9226,0" Rotation="0.3" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1276" Player="3" Position="138.5412,125.2553,0" Rotation="4.0134" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="1276" Position="138.5412,125.2553,0" Rotation="4.0134" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -10557,24 +10434,24 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="218" Player="3" Position="134.836,119.6704,0" Rotation="2.9475" Scale="1,1,1" UnitType="RoachVile">
+    <ObjectUnit Id="218" Position="134.836,119.6704,0" Rotation="2.9475" Scale="1,1,1" UnitType="RoachVile" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1212" Player="8" Position="185.5,231.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="EngineeringBay">
+    <ObjectUnit Id="1212" Position="185.5,231.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="EngineeringBay" Player="8">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="177" Player="2" Position="90.901,38.1638,0" Rotation="2.976" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="177" Position="90.901,38.1638,0" Rotation="2.976" Scale="1,1,1" UnitType="Marine" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="827" Player="3" Position="139.1962,80.8818,0" Rotation="3.6447" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="827" Position="139.1962,80.8818,0" Rotation="3.6447" Scale="1,1,1" UnitType="InfestedAbomination" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -10582,34 +10459,34 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="848" Player="6" Position="84.904,102.943,0" Rotation="0.454" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="848" Position="84.904,102.943,0" Rotation="0.454" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="789" Player="6" Position="49.8425,204.4306,0" Rotation="1.3364" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="789" Position="49.8425,204.4306,0" Rotation="1.3364" Scale="1,1,1" UnitType="Zealot" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="894" Player="6" Position="70.9907,143.64,0" Rotation="1.1037" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="894" Position="70.9907,143.64,0" Rotation="1.1037" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="244" Player="6" Position="89.0078,63.019,0" Rotation="0.6345" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="244" Position="89.0078,63.019,0" Rotation="0.6345" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1273" Player="3" Position="134.8742,81.6743,0" Rotation="3.3974" Scale="1,1,1" UnitType="HotSHunter">
+    <ObjectUnit Id="1273" Position="134.8742,81.6743,0" Rotation="3.3974" Scale="1,1,1" UnitType="HotSHunter" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -10617,7 +10494,7 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="159" Player="5" Position="31.1928,97.0754,0" Rotation="1.1523" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="159" Position="31.1928,97.0754,0" Rotation="1.1523" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
@@ -10625,62 +10502,62 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1170" Position="172,96,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="802" Player="5" Position="144.6098,157.67,0" Rotation="3.398" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="802" Position="144.6098,157.67,0" Rotation="3.398" Scale="1,1,1" UnitType="Raven" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="841" Player="6" Position="98.7927,90.966,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="841" Position="98.7927,90.966,0" Rotation="6.0595" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="195" Player="6" Position="54.6093,170.8681,0" Rotation="0.6313" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="195" Position="54.6093,170.8681,0" Rotation="0.6313" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="168" Player="2" Position="87.6271,23.6674,0" Rotation="2.1132" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="168" Position="87.6271,23.6674,0" Rotation="2.1132" Scale="1,1,1" UnitType="SCV" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1248" Position="91.0312,108.226,0" Rotation="1.6813" Scale="1,1,1" UnitType="NaturalGas"/>
-    <ObjectUnit Id="237" Player="3" Position="133.4606,22.0441,0" Rotation="1.222" Scale="1,1,1" UnitType="Drone">
+    <ObjectUnit Id="237" Position="143.5,23.5,0" Rotation="1.222" Scale="1,1,1" UnitType="Drone" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1163" Player="9" Position="163.5524,97.4055,0" Rotation="5.2163" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="1163" Position="163.5524,97.4055,0" Rotation="5.2163" Scale="1,1,1" UnitType="HotSRaptor" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="134" Player="6" Position="96.3991,87.9946,0" Rotation="5.9003" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="134" Position="96.3991,87.9946,0" Rotation="5.9003" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="191031087" Position="27.5,110.5,0" Resources="5000" Scale="1,1,1" UnitType="RichVespeneGeyser"/>
-    <ObjectUnit Id="780" Player="6" Position="63.0935,214.6408,0" Rotation="0.2712" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="191031087" Position="27.5,110.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="5000"/>
+    <ObjectUnit Id="780" Position="63.0935,214.6408,0" Rotation="0.2712" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="871" Player="6" Position="85.1135,123.7011,0" Rotation="0.0185" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="871" Position="85.1135,123.7011,0" Rotation="0.0185" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -10688,96 +10565,85 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="957" Player="6" Position="93.5168,65.2416,0" Rotation="0.4875" Scale="1,1,1" UnitType="InfestedAbomination">
+    <ObjectUnit Id="957" Position="93.5168,65.2416,0" Rotation="0.4875" Scale="1,1,1" UnitType="InfestedAbomination" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="55" Player="3" Position="132,45,0" Rotation="2.9658" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="55" Position="132,45,0" Rotation="2.9658" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="92" Position="51,28.5,0" Resources="1650" Scale="1,1,1" UnitType="MineralField" Variation="5">
+    <ObjectUnit Id="92" Variation="5" Position="51,28.5,0" Scale="1,1,1" UnitType="MineralField" Resources="1650">
         <Resources Index="1" Value="3200"/>
         <Resources Index="2" Value="3200"/>
     </ObjectUnit>
-    <ObjectUnit Id="25" Player="7" Position="121.1757,60.433,0" Rotation="5.876" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="25" Position="121.1757,60.433,0" Rotation="5.876" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1151" Player="5" Position="25.5,157.5,0" Rotation="0.5114" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1151" Position="25.5,157.5,0" Rotation="0.5114" Scale="1,1,1" UnitType="VoidRift" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="114" Player="3" Position="141.721,84.6013,0" Rotation="3.9611" Scale="1,1,1" UnitType="HydraliskImpaler">
+    <ObjectUnit Id="114" Position="141.721,84.6013,0" Rotation="3.9611" Scale="1,1,1" UnitType="HydraliskImpaler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1016" Position="71.381,151.5065,0" Rotation="0.6152" Scale="1,1,1" UnitType="Battlecruiser" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2238" Position="173.235,50.2746,0" Rotation="5.6115" Scale="1,1,1" UnitType="TreasureGoblin"/>
-    <ObjectUnit Id="1016" Player="6" Position="71.381,151.5065,0" Rotation="0.6152" Scale="1,1,1" UnitType="Battlecruiser">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1373721895" Position="160,107.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="6"/>
-    <ObjectUnit Id="915" Player="5" Position="83.2658,166.329,0" Rotation="1.5986" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="2261" Player="8" Position="36.5,96.5,0" Rotation="5.1906" Scale="1,1,1" UnitType="Bunker">
+    <ObjectUnit Id="2261" Position="36.5,96.5,0" Rotation="5.1906" Scale="1,1,1" UnitType="Bunker" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1059" Player="5" Position="146.1647,182.0334,0" Rotation="5.565" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="915" Position="83.2658,166.329,0" Rotation="1.5986" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1373721895" Variation="6" Position="160,107.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="1059" Position="146.1647,182.0334,0" Rotation="5.565" Scale="1,1,1" UnitType="Banshee" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="46" Player="6" Position="93,131,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption">
+    <ObjectUnit Id="46" Position="93,131,0" Rotation="5.4975" Scale="1,1,1" UnitType="VoidCorruption" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="69" Player="6" Position="45.1198,212.7697,0" Rotation="0.7431" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="69" Position="45.1198,212.7697,0" Rotation="0.7431" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="932" Player="5" Position="46.9812,131.5551,0" Rotation="1.0607" Scale="1,1,1" UnitType="Zergling">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="2274" Player="8" Position="29,101.5,0" Rotation="3.288" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="2274" Position="29,101.5,0" Rotation="3.288" Scale="1,1,1" UnitType="SCV" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -10785,42 +10651,49 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2252" Player="7" Position="143.2736,233.6872,0" Rotation="0.8864" Scale="1,1,1" UnitType="Raven">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="4"/>
-    </ObjectUnit>
-    <ObjectUnit Id="906" Player="5" Position="79.9675,170.911,0" Rotation="4.9338" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="932" Position="46.9812,131.5551,0" Rotation="1.0607" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1601914077" Position="126.5,21.5,0" Resources="5000" Scale="1,1,1" UnitType="RichVespeneGeyser"/>
-    <ObjectUnit Id="1126" Player="8" Position="33.1843,94.9665,0" Rotation="0.7922" Scale="1,1,1" UnitType="Medivac">
+    <ObjectUnit Id="906" Position="79.9675,170.911,0" Rotation="4.9338" Scale="1,1,1" UnitType="Mutalisk" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2252" Position="143.2736,233.6872,0" Rotation="0.8864" Scale="1,1,1" UnitType="Raven" Player="7">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="4"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1601914077" Position="126.5,21.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="5000"/>
+    <ObjectUnit Id="1126" Position="33.1843,94.9665,0" Rotation="0.7922" Scale="1,1,1" UnitType="Medivac" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="64" Player="6" Position="96.6882,50.958,0" Rotation="6.0336" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="64" Position="96.6882,50.958,0" Rotation="6.0336" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1062" Player="5" Position="147.5917,180.6013,0" Rotation="5.3901" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1062" Position="147.5917,180.6013,0" Rotation="5.3901" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="43" Player="3" Position="176.5,251.5,0" Scale="1,1,1" UnitType="SpawningPool">
+    <ObjectUnit Id="43" Position="176.5,251.5,0" Scale="1,1,1" UnitType="SpawningPool" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -10828,47 +10701,45 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="929" Player="5" Position="49.5087,130.6477,0" Rotation="1.0283" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="929" Position="49.5087,130.6477,0" Rotation="1.0283" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="970" Position="102,143.5,0" Resources="2600" Scale="1,1,1" UnitType="MineralField" Variation="8">
+    <ObjectUnit Id="970" Variation="8" Position="102,143.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2600">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="2249" Player="6" Position="32.5573,225.7626,0" Rotation="5.6687" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="911" Position="79.9025,169.223,0" Rotation="4.509" Scale="1,1,1" UnitType="Banshee" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2249" Position="32.5573,225.7626,0" Rotation="5.6687" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="911" Player="5" Position="79.9025,169.223,0" Rotation="4.509" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="996" Position="131.0151,102.9501,0" Rotation="5.6386" Scale="1,1,1" UnitType="Medivac" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="996" Player="7" Position="131.0151,102.9501,0" Rotation="5.6386" Scale="1,1,1" UnitType="Medivac">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="110" Player="3" Position="136.511,83.4631,0" Rotation="3.6315" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="110" Position="136.511,83.4631,0" Rotation="3.6315" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="5" Player="5" Position="32.338,99.8535,0" Rotation="1.1523" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="5" Position="32.338,99.8535,0" Rotation="1.1523" Scale="1,1,1" UnitType="Marine" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -10876,119 +10747,117 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1032" Player="5" Position="28.164,154.4931,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="1032" Position="28.164,154.4931,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="952" Player="8" Position="22,97,0" Rotation="5.4975" Scale="1,1,1" UnitType="BarracksTechReactor">
+    <ObjectUnit Id="952" Position="22,97,0" Rotation="5.4975" Scale="1,1,1" UnitType="BarracksTechReactor" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="575803713" Position="140,19.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="9"/>
-    <ObjectUnit Id="568456047" Position="164,108.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField"/>
-    <ObjectUnit Id="89" Player="5" Position="28.7895,97.6447,0" Rotation="0.3737" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="575803713" Variation="9" Position="140,19.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="568456047" Position="164,108.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="89" Position="28.7895,97.6447,0" Rotation="0.3737" Scale="1,1,1" UnitType="Stalker" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="50" Player="6" Position="57.1711,221.1174,0" Rotation="0.2705" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="50" Position="57.1711,221.1174,0" Rotation="0.2705" Scale="1,1,1" UnitType="Carrier" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1087" Player="7" Position="121.5,36.5,0" Rotation="0.8874" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1087" Position="121.5,36.5,0" Rotation="0.8874" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1146" Player="8" Position="36.9858,148.9445,0" Rotation="1.4472" Scale="1,1,1" UnitType="ThorAP">
+    <ObjectUnit Id="1146" Position="36.9858,148.9445,0" Rotation="1.4472" Scale="1,1,1" UnitType="ThorAP" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="119" Player="3" Position="128.4484,42.5593,0" Rotation="3.4052" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="119" Position="128.4484,42.5593,0" Rotation="3.4052" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="416041591" Position="144,191.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="4"/>
-    <ObjectUnit Id="28" Player="2" Position="78,24,0" Rotation="5.4975" Scale="1,1,1" UnitType="BarracksTechReactor">
+    <ObjectUnit Id="28" Position="78,24,0" Rotation="5.4975" Scale="1,1,1" UnitType="BarracksTechReactor" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="2256" Player="7" Position="151.4204,231.2915,0" Rotation="0.6911" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="416041591" Variation="4" Position="144,191.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="918" Position="85.973,167.1943,0" Rotation="0.8232" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2256" Position="151.4204,231.2915,0" Rotation="0.6911" Scale="1,1,1" UnitType="Mutalisk" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="918" Player="5" Position="85.973,167.1943,0" Rotation="0.8232" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1021" Player="8" Position="33.5,102.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Starport">
+    <ObjectUnit Id="1021" Position="33.5,102.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Starport" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="939" Player="5" Position="80.2595,207.1472,0" Rotation="5.363" Scale="1,1,1" UnitType="Mutalisk">
-        <AIRebuild Index="1" Value="0"/>
-        <AIRebuild Index="2" Value="0"/>
-        <AIRebuild Index="3" Value="0"/>
-        <AIRebuild Index="4" Value="0"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="960" Player="5" Position="33.0322,97.7656,0" Rotation="1.3427" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="74" Player="2" Position="91.5,40.5,0" Rotation="2.9873" Scale="1,1,1" UnitType="Bunker">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1068" Player="5" Position="142.1862,184.7595,0" Rotation="5.9584" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="939" Position="80.2595,207.1472,0" Rotation="5.363" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="33" Player="6" Position="107.1904,50.1665,0" Rotation="5.4631" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="960" Position="33.0322,97.7656,0" Rotation="1.3427" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="100" Player="5" Position="65.04,95.5332,0" Rotation="5.3876" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="74" Position="91.5,40.5,0" Rotation="2.9873" Scale="1,1,1" UnitType="Bunker" Player="2">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1068" Position="142.1862,184.7595,0" Rotation="5.9584" Scale="1,1,1" UnitType="Banshee" Player="5">
+        <AIRebuild Index="1" Value="0"/>
+        <AIRebuild Index="2" Value="0"/>
+        <AIRebuild Index="3" Value="0"/>
+        <AIRebuild Index="4" Value="0"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="33" Position="107.1904,50.1665,0" Rotation="5.4631" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="100" Position="65.04,95.5332,0" Rotation="5.3876" Scale="1,1,1" UnitType="Ghost" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -10996,7 +10865,7 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1129" Player="8" Position="38.7185,99.4423,0" Rotation="0.8461" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1129" Position="38.7185,99.4423,0" Rotation="0.8461" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -11004,44 +10873,42 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="15" Player="1" Position="66,40,0" Scale="1,1,1" UnitType="AP_Pylon"/>
-    <ObjectUnit Id="1026" Player="2" Position="88.6635,35.7604,0" Rotation="2.6064" Scale="1,1,1" UnitType="Banshee">
+    <ObjectUnit Id="15" Position="66,40,0" Scale="1,1,1" UnitType="AP_Pylon" Player="1"/>
+    <ObjectUnit Id="1026" Position="88.6635,35.7604,0" Rotation="2.6064" Scale="1,1,1" UnitType="Banshee" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="901" Player="6" Position="69.794,148.7604,0" Rotation="1.0693" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="2243" Player="6" Position="32.3173,232.7382,0" Rotation="5.4995" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="2243" Position="32.3173,232.7382,0" Rotation="5.4995" Scale="1,1,1" UnitType="Carrier" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1006" Player="6" Position="85.8398,125.3098,0" Rotation="0.6684" Scale="1,1,1" UnitType="Phoenix">
+    <ObjectUnit Id="901" Position="69.794,148.7604,0" Rotation="1.0693" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1006" Position="85.8398,125.3098,0" Rotation="0.6684" Scale="1,1,1" UnitType="Phoenix" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="83" Player="5" Position="46.6135,74.2185,0" Rotation="0.5993" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="83" Position="46.6135,74.2185,0" Rotation="0.5993" Scale="1,1,1" UnitType="Zealot" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1118" Player="6" Position="83.6313,22.77,0" Rotation="5.5876" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1118" Position="83.6313,22.77,0" Rotation="5.5876" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
@@ -11049,38 +10916,27 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="56" Player="3" Position="125,42,0" Rotation="3.318" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="56" Position="125,42,0" Rotation="3.318" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="946" Player="7" Position="145.2998,83.41,0" Rotation="5.301" Scale="1,1,1" UnitType="SiegeTankSieged">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="985" Player="5" Position="47.0185,82.701,0" Rotation="0.3923" Scale="1,1,1" UnitType="SiegeTankSieged">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="924" Player="5" Position="56.6555,132.8776,0" Rotation="0.4497" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="946" Position="145.2998,83.41,0" Rotation="5.301" Scale="1,1,1" UnitType="SiegeTankSieged" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2266" Player="8" Position="35.1604,98.8874,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="985" Position="47.0185,82.701,0" Rotation="0.3923" Scale="1,1,1" UnitType="SiegeTankSieged" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2266" Position="35.1604,98.8874,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -11088,41 +10944,46 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1015" Player="6" Position="71.5498,147.5698,0" Rotation="1.0092" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="924" Position="56.6555,132.8776,0" Rotation="0.4497" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="125" Player="3" Position="133,84,0" Rotation="3.3874" Scale="1,1,1" UnitType="SpineCrawler">
+    <ObjectUnit Id="1015" Position="71.5498,147.5698,0" Rotation="1.0092" Scale="1,1,1" UnitType="Ghost" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="125" Position="133,84,0" Rotation="3.3874" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="61" Player="3" Position="131.5,38.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed">
+    <ObjectUnit Id="61" Position="131.5,38.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1058484825" Position="90.5,18.5,0" Resources="5000" Scale="1,1,1" UnitType="RichVespeneGeyser"/>
-    <ObjectUnit Id="1072" Player="5" Position="138.8286,185.602,0" Rotation="5.0993" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1072" Position="138.8286,185.602,0" Rotation="5.0993" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="86" Position="49,29.5,0" Resources="1650" Scale="1,1,1" UnitType="MineralField" Variation="4">
+    <ObjectUnit Id="1058484825" Position="90.5,18.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="5000"/>
+    <ObjectUnit Id="86" Variation="4" Position="49,29.5,0" Scale="1,1,1" UnitType="MineralField" Resources="1650">
         <Resources Index="1" Value="3200"/>
         <Resources Index="2" Value="3200"/>
     </ObjectUnit>
-    <ObjectUnit Id="1115" Player="6" Position="83.2614,24.286,0" Rotation="6.0114" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="1115" Position="83.2614,24.286,0" Rotation="6.0114" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
@@ -11130,129 +10991,121 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="988" Player="5" Position="62.811,99.6247,0" Rotation="5.1982" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="988" Position="62.811,99.6247,0" Rotation="5.1982" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="951" Player="6" Position="94.5,25.5,0" Rotation="5.9104" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="951" Position="94.5,25.5,0" Rotation="5.9104" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1010" Position="45.6464,137.2812,0" Rotation="1.0988" Scale="1,1,1" UnitType="Liberator" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2228" Position="23.8337,14.9724,0" Rotation="6.1037" Scale="1,1,1" UnitType="WarpPrismPhasing"/>
-    <ObjectUnit Id="1010" Player="5" Position="45.6464,137.2812,0" Rotation="1.0988" Scale="1,1,1" UnitType="Liberator">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="921" Player="5" Position="54.659,135.1645,0" Rotation="0.5104" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="921" Position="54.659,135.1645,0" Rotation="0.5104" Scale="1,1,1" UnitType="Stalker" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="19" Player="3" Position="133.5,25.5,0" Scale="1,1,1" UnitType="Hive">
+    <ObjectUnit Id="19" Position="133.5,25.5,0" Scale="1,1,1" UnitType="Hive" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1141" Player="8" Position="23.5,143.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Factory">
+    <ObjectUnit Id="1141" Position="23.5,143.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Factory" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="120" Player="3" Position="129.2087,42.4548,0" Rotation="3.455" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="120" Position="129.2087,42.4548,0" Rotation="3.455" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="965" Position="97,144.5,0" Resources="2450" Scale="1,1,1" UnitType="MineralField" Variation="7">
+    <ObjectUnit Id="965" Variation="7" Position="97,144.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2450">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="942" Player="5" Position="102.1044,213.1254,0" Rotation="0.401" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="942" Position="102.1044,213.1254,0" Rotation="0.401" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1065" Player="5" Position="144.9836,179.7368,0" Rotation="5.4921" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1065" Position="144.9836,179.7368,0" Rotation="5.4921" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1090" Player="6" Position="98.5,39.5,0" Rotation="5.815" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1090" Position="98.5,39.5,0" Rotation="5.815" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="79" Player="1" Position="53.2016,30.9873,0" Rotation="3.6276" Scale="1,1,1" UnitType="AP_Probe"/>
-    <ObjectUnit Id="10" Player="2" Position="75.5,24.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Barracks">
+    <ObjectUnit Id="79" Position="53.2016,30.9873,0" Rotation="3.6276" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
+    <ObjectUnit Id="10" Position="75.5,24.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Barracks" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1031" Player="5" Position="27.6232,149.8093,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="1031" Position="27.6232,149.8093,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="97" Player="1" Position="61.5,34.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Stargate"/>
-    <ObjectUnit Id="1132" Player="8" Position="34.0573,94.0178,0" Rotation="0.8461" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="97" Position="61.5,34.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Stargate" Player="1"/>
+    <ObjectUnit Id="1132" Position="34.0573,94.0178,0" Rotation="0.8461" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1003" Player="7" Position="140.0334,119.3527,0" Rotation="5.568" Scale="1,1,1" UnitType="Viper">
+    <ObjectUnit Id="1003" Position="140.0334,119.3527,0" Rotation="5.568" Scale="1,1,1" UnitType="Viper" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2246" Player="6" Position="32.9526,230.424,0" Rotation="5.598" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="896" Position="68.8315,146.4248,0" Rotation="0.9392" Scale="1,1,1" UnitType="Marine" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2246" Position="32.9526,230.424,0" Rotation="5.598" Scale="1,1,1" UnitType="Mutalisk" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="896" Player="6" Position="68.8315,146.4248,0" Rotation="0.9392" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="112" Player="3" Position="135.5986,84.5214,0" Rotation="3.6064" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="112" Position="135.5986,84.5214,0" Rotation="3.6064" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -11260,94 +11113,90 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1149" Position="23,148,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="27" Player="2" Position="84,30,0" Rotation="5.4975" Scale="1,1,1" UnitType="BarracksTechReactor">
+    <ObjectUnit Id="27" Position="84,30,0" Rotation="5.4975" Scale="1,1,1" UnitType="BarracksTechReactor" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="2263" Player="8" Position="33.9912,96.4826,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="913" Position="80.8151,169.4323,0" Rotation="4.5895" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2263" Position="33.9912,96.4826,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="913" Player="5" Position="80.8151,169.4323,0" Rotation="4.5895" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1018" Position="144,193,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue"/>
-    <ObjectUnit Id="959" Player="6" Position="102.542,49.625,0" Rotation="6.2243" Scale="1,1,1" UnitType="Hydralisk">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="94" Player="5" Position="35.4648,100.8591,0" Rotation="0.5051" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="959" Position="102.542,49.625,0" Rotation="6.2243" Scale="1,1,1" UnitType="Hydralisk" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="53" Player="3" Position="134.5,32.5,0" Scale="1,1,1" UnitType="SpawningPool">
+    <ObjectUnit Id="94" Position="35.4648,100.8591,0" Rotation="0.5051" Scale="1,1,1" UnitType="Zealot" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="53" Position="134.5,32.5,0" Scale="1,1,1" UnitType="SpawningPool" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1809945316" Position="19,104.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="5"/>
-    <ObjectUnit Id="904" Player="6" Position="67.7836,158.4272,0" Rotation="0.631" Scale="1,1,1" UnitType="Stalker">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="2254" Player="7" Position="149.0881,229.517,0" Rotation="0.6303" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="1809945316" Variation="5" Position="19,104.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="2254" Position="149.0881,229.517,0" Rotation="0.6303" Scale="1,1,1" UnitType="Carrier" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="995" Player="7" Position="126.0585,104.372,0" Rotation="0.0754" Scale="1,1,1" UnitType="Medivac">
+    <ObjectUnit Id="904" Position="67.7836,158.4272,0" Rotation="0.631" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="105" Player="3" Position="137.0156,84.876,0" Rotation="3.7197" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="995" Position="126.0585,104.372,0" Rotation="0.0754" Scale="1,1,1" UnitType="Medivac" Player="7">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="105" Position="137.0156,84.876,0" Rotation="3.7197" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="2" Player="6" Position="98.1174,91.5744,0" Rotation="5.8752" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="2" Position="98.1174,91.5744,0" Rotation="5.8752" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="71" Player="6" Position="48.5717,205.3652,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="71" Position="48.5717,205.3652,0" Rotation="1.2082" Scale="1,1,1" UnitType="Zergling" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="44" Player="9" Position="176.5,237.5,0" Scale="1,1,1" UnitType="SpawningPool">
+    <ObjectUnit Id="44" Position="176.5,237.5,0" Scale="1,1,1" UnitType="SpawningPool" Player="9">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -11355,73 +11204,73 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="2272" Player="8" Position="29.06,152.351,0" Rotation="3.288" Scale="1,1,1" UnitType="SCV">
+    <ObjectUnit Id="934" Position="49.1157,78.2553,0" Rotation="0.2143" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2272" Position="29.06,152.351,0" Rotation="3.288" Scale="1,1,1" UnitType="SCV" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="934" Player="5" Position="49.1157,78.2553,0" Rotation="0.2143" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="973" Position="90.5,144.5,0" Scale="1,1,1" UnitType="VespeneGeyser">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="2251" Player="7" Position="147.0834,233.6462,0" Rotation="0.6816" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="909" Position="81.5563,175.5627,0" Rotation="1.5058" Scale="1,1,1" UnitType="Mutalisk" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2251" Position="147.0834,233.6462,0" Rotation="0.6816" Scale="1,1,1" UnitType="Raven" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="909" Player="5" Position="81.5563,175.5627,0" Rotation="1.5058" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="1034" Position="25.567,145.442,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1034" Player="5" Position="25.567,145.442,0" Rotation="0.5764" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="7" Position="134.4436,61.0537,0" Rotation="5.9091" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="7" Player="7" Position="134.4436,61.0537,0" Rotation="5.9091" Scale="1,1,1" UnitType="Stalker">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1121" Player="8" Position="25.5,103.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="CommandCenter">
+    <ObjectUnit Id="1121" Position="25.5,103.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="CommandCenter" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="108" Player="3" Position="136.3337,84.2285,0" Rotation="3.6474" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="108" Position="136.3337,84.2285,0" Rotation="3.6474" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1060" Player="5" Position="147.4438,182.7165,0" Rotation="5.5212" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1060" Position="147.4438,182.7165,0" Rotation="5.5212" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="66" Player="5" Position="68.0795,97.9155,0" Rotation="5.4606" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="66" Position="68.0795,97.9155,0" Rotation="5.4606" Scale="1,1,1" UnitType="Hydralisk" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -11429,68 +11278,66 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="968" Position="100,144.5,0" Resources="2450" Scale="1,1,1" UnitType="MineralField" Variation="6">
+    <ObjectUnit Id="968" Variation="6" Position="100,144.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2450">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="931" Player="5" Position="50.323,132.2875,0" Rotation="0.8957" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="931" Position="50.323,132.2875,0" Rotation="0.8957" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="30" Player="7" Position="118.6286,62.4035,0" Rotation="0.0764" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="30" Position="118.6286,62.4035,0" Rotation="0.0764" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="117" Player="3" Position="140.3723,82.8381,0" Rotation="3.445" Scale="1,1,1" UnitType="RoachVile">
+    <ObjectUnit Id="117" Position="140.3723,82.8381,0" Rotation="3.445" Scale="1,1,1" UnitType="RoachVile" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1144" Player="8" Position="36,153,0" Rotation="5.4975" Scale="1,1,1" UnitType="FactoryTechReactor">
+    <ObjectUnit Id="1144" Position="36,153,0" Rotation="5.4975" Scale="1,1,1" UnitType="FactoryTechReactor" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="2258" Player="7" Position="146.7482,225.6916,0" Rotation="1.0236" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="916" Position="79.907,168.1086,0" Rotation="4.2543" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="2258" Position="146.7482,225.6916,0" Rotation="1.0236" Scale="1,1,1" UnitType="Mutalisk" Player="7">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="916" Player="5" Position="79.907,168.1086,0" Rotation="4.2543" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1252668576" Variation="7" Position="19,154.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="954" Position="117.6433,94.2145,0" Rotation="5.6977" Scale="1,1,1" UnitType="Ghost" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1252668576" Position="19,154.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField" Variation="7"/>
-    <ObjectUnit Id="954" Player="5" Position="117.6433,94.2145,0" Rotation="5.6977" Scale="1,1,1" UnitType="Ghost">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1085" Player="6" Position="82.5,100.5,0" Rotation="0.8383" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="1085" Position="82.5,100.5,0" Rotation="0.8383" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="48" Player="3" Position="125.5,35.5,0" Rotation="5.7595" Scale="1,1,1" UnitType="EvolutionChamber">
+    <ObjectUnit Id="48" Position="125.5,35.5,0" Rotation="5.7595" Scale="1,1,1" UnitType="EvolutionChamber" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -11500,90 +11347,79 @@
         <Resources Index="1" Value="3000"/>
         <Resources Index="2" Value="3000"/>
     </ObjectUnit>
-    <ObjectUnit Id="13" Player="7" Position="130.1345,64.0268,0" Rotation="5.7021" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="13" Position="130.1345,64.0268,0" Rotation="5.7021" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1131" Player="8" Position="34,95.5666,0" Rotation="0.8461" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1131" Position="34,95.5666,0" Rotation="0.8461" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="102" Player="5" Position="55.2192,138.7478,0" Rotation="0.3598" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="102" Position="55.2192,138.7478,0" Rotation="0.3598" Scale="1,1,1" UnitType="Ghost" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1004" Player="7" Position="146.3874,112.7792,0" Rotation="5.1052" Scale="1,1,1" UnitType="Viper">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="903" Player="6" Position="71.527,158.18,0" Rotation="0.631" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="1004" Position="146.3874,112.7792,0" Rotation="5.1052" Scale="1,1,1" UnitType="Viper" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2241" Player="6" Position="40.7807,231.1738,0" Rotation="5.5534" Scale="1,1,1" UnitType="Raven">
+    <ObjectUnit Id="2241" Position="40.7807,231.1738,0" Rotation="5.5534" Scale="1,1,1" UnitType="Raven" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="962" Player="5" Position="34.7954,98.786,0" Rotation="1.1523" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="903" Position="71.527,158.18,0" Rotation="0.631" Scale="1,1,1" UnitType="Stalker" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="937" Player="5" Position="81.9384,168.8361,0" Rotation="5.3876" Scale="1,1,1" UnitType="Ghost">
+    <ObjectUnit Id="962" Position="34.7954,98.786,0" Rotation="1.1523" Scale="1,1,1" UnitType="Marine" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1070" Player="5" Position="138.8435,183.5844,0" Rotation="6.2272" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="937" Position="81.9384,168.8361,0" Rotation="5.3876" Scale="1,1,1" UnitType="Ghost" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="72" Player="1" Position="18.861,16.8825,0" Rotation="2.3332" Scale="1,1,1" UnitType="AP_StalkerShakuras"/>
-    <ObjectUnit Id="784518127" Position="163,107.5,0" Resources="5000" Scale="1,1,1" UnitType="RichMineralField"/>
+    <ObjectUnit Id="1070" Position="138.8435,183.5844,0" Rotation="6.2272" Scale="1,1,1" UnitType="Marine" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="72" Position="18.861,16.8825,0" Rotation="2.3332" Scale="1,1,1" UnitType="AP_StalkerShakuras" Player="1"/>
+    <ObjectUnit Id="1013" Position="29.662,139.2944,0" Rotation="0.933" Scale="1,1,1" UnitType="Stalker" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
     <ObjectUnit Id="2227" Position="17.419,17.256,0" Rotation="6.104" Scale="1,1,1" UnitType="WarpPrismPhasing"/>
-    <ObjectUnit Id="1013" Player="5" Position="29.662,139.2944,0" Rotation="0.933" Scale="1,1,1" UnitType="Stalker">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="926" Player="5" Position="54.774,133.3134,0" Rotation="0.5803" Scale="1,1,1" UnitType="Zergling">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="2264" Player="8" Position="33.9265,97.3483,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="784518127" Position="163,107.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="5000"/>
+    <ObjectUnit Id="2264" Position="33.9265,97.3483,0" Rotation="0.846" Scale="1,1,1" UnitType="Marine" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -11591,27 +11427,34 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="20" Player="7" Position="131.4335,63.2944,0" Rotation="5.571" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="926" Position="54.774,133.3134,0" Rotation="0.5803" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="127" Player="6" Position="102.5893,85.8188,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="20" Position="131.4335,63.2944,0" Rotation="5.571" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="58" Player="3" Position="142,35,0" Rotation="0.7504" Scale="1,1,1" UnitType="SporeCrawler">
+    <ObjectUnit Id="127" Position="102.5893,85.8188,0" Rotation="6.0312" Scale="1,1,1" UnitType="Zergling" Player="6">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="58" Position="142,35,0" Rotation="0.7504" Scale="1,1,1" UnitType="SporeCrawler" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1116" Player="6" Position="82.2006,24.0905,0" Rotation="5.5876" Scale="1,1,1" UnitType="Marine">
+    <ObjectUnit Id="1116" Position="82.2006,24.0905,0" Rotation="5.5876" Scale="1,1,1" UnitType="Marine" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
@@ -11619,72 +11462,64 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="81" Player="1" Position="48.6567,33.6103,0" Rotation="4.4655" Scale="1,1,1" UnitType="AP_Probe"/>
-    <ObjectUnit Id="987" Player="5" Position="68.386,95.6806,0" Rotation="5.1982" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="81" Position="48.6567,33.6103,0" Rotation="4.4655" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
+    <ObjectUnit Id="2205" Position="150.5302,159.04,0" Rotation="5.6308" Scale="1,1,1" UnitType="Immortal" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="987" Position="68.386,95.6806,0" Rotation="5.1982" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2205" Player="5" Position="150.5302,159.04,0" Rotation="5.6308" Scale="1,1,1" UnitType="Immortal">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="944" Player="7" Position="135.9287,58.8664,0" Rotation="5.909" Scale="1,1,1" UnitType="Stalker">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-
-
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="923" Player="5" Position="51.3745,134.5314,0" Rotation="0.73" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="944" Position="135.9287,58.8664,0" Rotation="5.909" Scale="1,1,1" UnitType="Stalker" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1008" Player="6" Position="82.49,125.5097,0" Rotation="0.6682" Scale="1,1,1" UnitType="Phoenix">
+    <ObjectUnit Id="923" Position="51.3745,134.5314,0" Rotation="0.73" Scale="1,1,1" UnitType="Zergling" Player="5">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1008" Position="82.49,125.5097,0" Rotation="0.6682" Scale="1,1,1" UnitType="Phoenix" Player="6">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="122" Player="3" Position="127.7133,42.8522,0" Rotation="3.3581" Scale="1,1,1" UnitType="HotSRaptor">
+    <ObjectUnit Id="122" Position="127.7133,42.8522,0" Rotation="3.3581" Scale="1,1,1" UnitType="HotSRaptor" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1143" Player="8" Position="33.5,153.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Factory">
+    <ObjectUnit Id="1143" Position="33.5,153.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Factory" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="17" Player="3" Position="141.5,27.5,0" Scale="1,1,1" UnitType="Hatchery">
+    <ObjectUnit Id="17" Position="141.5,27.5,0" Scale="1,1,1" UnitType="Hatchery" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="84" Player="5" Position="32.445,101.778,0" Rotation="0.7507" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="84" Position="32.445,101.778,0" Rotation="0.7507" Scale="1,1,1" UnitType="Hydralisk" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -11692,29 +11527,27 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1074" Player="5" Position="141.016,182.373,0" Rotation="5.9943" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1074" Position="141.016,182.373,0" Rotation="5.9943" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="63" Player="6" Position="101.5,53.5,0" Rotation="6.1271" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="63" Position="101.5,53.5,0" Rotation="6.1271" Scale="1,1,1" UnitType="VoidRift" Player="6">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="949" Player="5" Position="168.121,91.5986,0" Rotation="5.6762" Scale="1,1,1" UnitType="Archon">
+    <ObjectUnit Id="949" Position="168.121,91.5986,0" Rotation="5.6762" Scale="1,1,1" UnitType="Archon" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="99" Player="5" Position="66.315,99.062,0" Rotation="5.9091" Scale="1,1,1" UnitType="Stalker">
+    <ObjectUnit Id="99" Position="66.315,99.062,0" Rotation="5.9091" Scale="1,1,1" UnitType="Stalker" Player="5">
         <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
@@ -11722,49 +11555,45 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="8" Player="7" Position="130.1943,66.0327,0" Rotation="5.7778" Scale="1,1,1" UnitType="Zealot">
+    <ObjectUnit Id="8" Position="130.1943,66.0327,0" Rotation="5.7778" Scale="1,1,1" UnitType="Zealot" Player="7">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="898" Player="6" Position="68.8686,145.2712,0" Rotation="1.045" Scale="1,1,1" UnitType="Marine">
-        <AIRebuild Index="1" Value="1"/>
-        <AIRebuild Index="2" Value="2"/>
-        <AIRebuild Index="3" Value="3"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="2244" Player="6" Position="39.9548,226.8212,0" Rotation="5.4995" Scale="1,1,1" UnitType="Carrier">
+    <ObjectUnit Id="2244" Position="39.9548,226.8212,0" Rotation="5.4995" Scale="1,1,1" UnitType="Carrier" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="4"/>
     </ObjectUnit>
-    <ObjectUnit Id="1001" Player="7" Position="125.8598,102.4,0" Rotation="0.195" Scale="1,1,1" UnitType="Hydralisk">
+    <ObjectUnit Id="898" Position="68.8686,145.2712,0" Rotation="1.045" Scale="1,1,1" UnitType="Marine" Player="6">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="940" Player="5" Position="72.4665,212.6247,0" Rotation="5.363" Scale="1,1,1" UnitType="Mutalisk">
+    <ObjectUnit Id="1001" Position="125.8598,102.4,0" Rotation="0.195" Scale="1,1,1" UnitType="Hydralisk" Player="7">
+        <AIRebuild Index="1" Value="1"/>
+        <AIRebuild Index="2" Value="2"/>
+        <AIRebuild Index="3" Value="3"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="940" Position="72.4665,212.6247,0" Rotation="5.363" Scale="1,1,1" UnitType="Mutalisk" Player="5">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-
-
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="967" Position="99,145.5,0" Resources="2600" Scale="1,1,1" UnitType="MineralField" Variation="4">
+    <ObjectUnit Id="967" Variation="4" Position="99,145.5,0" Scale="1,1,1" UnitType="MineralField" Resources="2600">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="77" Player="1" Position="50.5134,30.7687,0" Rotation="0.6093" Scale="1,1,1" UnitType="AP_Probe"/>
-    <ObjectUnit Id="1088" Player="7" Position="138.5,32.5,0" Rotation="5.7395" Scale="1,1,1" UnitType="VoidRift">
+    <ObjectUnit Id="77" Position="50.5134,30.7687,0" Rotation="0.6093" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
+    <ObjectUnit Id="1088" Position="138.5,32.5,0" Rotation="5.7395" Scale="1,1,1" UnitType="VoidRift" Player="7">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
@@ -11773,14 +11602,14 @@
     <ObjectUnit Id="38" Position="93,131,0" Rotation="5.4975" Scale="1,1,1" UnitType="XelNagaTowerEpilogue">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="1067" Player="5" Position="146.3835,181.0454,0" Rotation="5.4873" Scale="1,1,1" UnitType="Zergling">
+    <ObjectUnit Id="1067" Position="146.3835,181.0454,0" Rotation="5.4873" Scale="1,1,1" UnitType="Zergling" Player="5">
         <AIRebuild Index="1" Value="1"/>
         <AIRebuild Index="2" Value="2"/>
         <AIRebuild Index="3" Value="3"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <Group Id="1" Name="Kerrigan Bonus Obj 1 Units" Type="ObjectUnit">
+    <Group Type="ObjectUnit" Name="Kerrigan Bonus Obj 1 Units" Id="1">
         <GroupObject Id="613"/>
         <GroupObject Id="1153"/>
         <GroupObject Id="1155"/>
@@ -11794,7 +11623,7 @@
         <GroupObject Id="1165"/>
         <GroupObject Id="1166"/>
     </Group>
-    <Group Id="2" Name="Kerrigan Bonus Obj 2 Units" Type="ObjectUnit">
+    <Group Type="ObjectUnit" Name="Kerrigan Bonus Obj 2 Units" Id="2">
         <GroupObject Id="1190"/>
         <GroupObject Id="1191"/>
         <GroupObject Id="1192"/>
@@ -11807,7 +11636,7 @@
         <GroupObject Id="1203"/>
         <GroupObject Id="1204"/>
     </Group>
-    <Group Id="3" Name="TakeOverAIResources" Type="ObjectUnit">
+    <Group Type="ObjectUnit" Name="TakeOverAIResources" Id="3">
         <GroupObject Id="1978466315"/>
         <GroupObject Id="1472824811"/>
         <GroupObject Id="425450477"/>
@@ -11863,356 +11692,184 @@
         <GroupObject Id="1252668576"/>
         <GroupObject Id="784518127"/>
     </Group>
-    <Group Id="4" Name="Casual Removal" Type="ObjectUnit">
-        <GroupObject Id="989">
-        </GroupObject>
-        <GroupObject Id="950">
-        </GroupObject>
-        <GroupObject Id="1011">
-        </GroupObject>
-        <GroupObject Id="943">
-        </GroupObject>
-        <GroupObject Id="1002">
-        </GroupObject>
-        <GroupObject Id="1007">
-        </GroupObject>
-        <GroupObject Id="947">
-        </GroupObject>
-        <GroupObject Id="984">
-        </GroupObject>
-        <GroupObject Id="1014">
-        </GroupObject>
-        <GroupObject Id="953">
-        </GroupObject>
-        <GroupObject Id="956">
-        </GroupObject>
-        <GroupObject Id="1017">
-        </GroupObject>
-        <GroupObject Id="1009">
-        </GroupObject>
-        <GroupObject Id="948">
-        </GroupObject>
-        <GroupObject Id="941">
-        </GroupObject>
-        <GroupObject Id="1005">
-        </GroupObject>
-        <GroupObject Id="1012">
-        </GroupObject>
-        <GroupObject Id="986">
-        </GroupObject>
-        <GroupObject Id="945">
-        </GroupObject>
-        <GroupObject Id="955">
-        </GroupObject>
-        <GroupObject Id="958">
-        </GroupObject>
-        <GroupObject Id="994">
-        </GroupObject>
-        <GroupObject Id="1169">
-        </GroupObject>
-        <GroupObject Id="1254">
-        </GroupObject>
-        <GroupObject Id="1187">
-        </GroupObject>
-        <GroupObject Id="1182">
-        </GroupObject>
-        <GroupObject Id="1179">
-        </GroupObject>
-        <GroupObject Id="1154">
-        </GroupObject>
-        <GroupObject Id="1196">
-        </GroupObject>
-        <GroupObject Id="1188">
-        </GroupObject>
-        <GroupObject Id="781">
-        </GroupObject>
-        <GroupObject Id="806">
-        </GroupObject>
-        <GroupObject Id="1252">
-        </GroupObject>
-        <GroupObject Id="1195">
-        </GroupObject>
-        <GroupObject Id="1180">
-        </GroupObject>
-        <GroupObject Id="1271">
-        </GroupObject>
-        <GroupObject Id="1177">
-        </GroupObject>
-        <GroupObject Id="1221">
-        </GroupObject>
-        <GroupObject Id="764">
-        </GroupObject>
-        <GroupObject Id="741">
-        </GroupObject>
-        <GroupObject Id="1636">
-        </GroupObject>
-        <GroupObject Id="1637">
-        </GroupObject>
-        <GroupObject Id="1282">
-        </GroupObject>
-        <GroupObject Id="1783">
-        </GroupObject>
-        <GroupObject Id="1720">
-        </GroupObject>
-        <GroupObject Id="1178">
-        </GroupObject>
-        <GroupObject Id="1268">
-        </GroupObject>
-        <GroupObject Id="1183">
-        </GroupObject>
-        <GroupObject Id="1255">
-        </GroupObject>
-        <GroupObject Id="828">
-        </GroupObject>
-        <GroupObject Id="1168">
-        </GroupObject>
-        <GroupObject Id="799">
-        </GroupObject>
-        <GroupObject Id="1194">
-        </GroupObject>
-        <GroupObject Id="1181">
-        </GroupObject>
-        <GroupObject Id="1184">
-        </GroupObject>
-        <GroupObject Id="1253">
-        </GroupObject>
-        <GroupObject Id="957">
-        </GroupObject>
-        <GroupObject Id="1016">
-        </GroupObject>
-        <GroupObject Id="996">
-        </GroupObject>
-        <GroupObject Id="939">
-        </GroupObject>
-        <GroupObject Id="1006">
-        </GroupObject>
-        <GroupObject Id="946">
-        </GroupObject>
-        <GroupObject Id="985">
-        </GroupObject>
-        <GroupObject Id="1015">
-        </GroupObject>
-        <GroupObject Id="988">
-        </GroupObject>
-        <GroupObject Id="1010">
-        </GroupObject>
-        <GroupObject Id="942">
-        </GroupObject>
-        <GroupObject Id="1003">
-        </GroupObject>
-        <GroupObject Id="959">
-        </GroupObject>
-        <GroupObject Id="995">
-        </GroupObject>
-        <GroupObject Id="954">
-        </GroupObject>
-        <GroupObject Id="1004">
-        </GroupObject>
-        <GroupObject Id="1013">
-        </GroupObject>
-        <GroupObject Id="987">
-        </GroupObject>
-        <GroupObject Id="2205">
-        </GroupObject>
-        <GroupObject Id="944">
-        </GroupObject>
-        <GroupObject Id="1008">
-        </GroupObject>
-        <GroupObject Id="949">
-        </GroupObject>
-        <GroupObject Id="1001">
-        </GroupObject>
-        <GroupObject Id="940">
-        </GroupObject>
+    <Group Type="ObjectUnit" Name="Casual Removal" Id="4">
+        <GroupObject Id="989"/>
+        <GroupObject Id="950"/>
+        <GroupObject Id="1011"/>
+        <GroupObject Id="943"/>
+        <GroupObject Id="1002"/>
+        <GroupObject Id="1007"/>
+        <GroupObject Id="947"/>
+        <GroupObject Id="984"/>
+        <GroupObject Id="1014"/>
+        <GroupObject Id="953"/>
+        <GroupObject Id="956"/>
+        <GroupObject Id="1017"/>
+        <GroupObject Id="1009"/>
+        <GroupObject Id="948"/>
+        <GroupObject Id="941"/>
+        <GroupObject Id="1005"/>
+        <GroupObject Id="1012"/>
+        <GroupObject Id="986"/>
+        <GroupObject Id="945"/>
+        <GroupObject Id="955"/>
+        <GroupObject Id="958"/>
+        <GroupObject Id="994"/>
+        <GroupObject Id="1169"/>
+        <GroupObject Id="1254"/>
+        <GroupObject Id="1187"/>
+        <GroupObject Id="1182"/>
+        <GroupObject Id="1179"/>
+        <GroupObject Id="1154"/>
+        <GroupObject Id="1196"/>
+        <GroupObject Id="1188"/>
+        <GroupObject Id="781"/>
+        <GroupObject Id="806"/>
+        <GroupObject Id="1252"/>
+        <GroupObject Id="1195"/>
+        <GroupObject Id="1180"/>
+        <GroupObject Id="1271"/>
+        <GroupObject Id="1177"/>
+        <GroupObject Id="1221"/>
+        <GroupObject Id="764"/>
+        <GroupObject Id="741"/>
+        <GroupObject Id="1636"/>
+        <GroupObject Id="1637"/>
+        <GroupObject Id="1282"/>
+        <GroupObject Id="1783"/>
+        <GroupObject Id="1720"/>
+        <GroupObject Id="1178"/>
+        <GroupObject Id="1268"/>
+        <GroupObject Id="1183"/>
+        <GroupObject Id="1255"/>
+        <GroupObject Id="828"/>
+        <GroupObject Id="1168"/>
+        <GroupObject Id="799"/>
+        <GroupObject Id="1194"/>
+        <GroupObject Id="1181"/>
+        <GroupObject Id="1184"/>
+        <GroupObject Id="1253"/>
+        <GroupObject Id="957"/>
+        <GroupObject Id="1016"/>
+        <GroupObject Id="996"/>
+        <GroupObject Id="939"/>
+        <GroupObject Id="1006"/>
+        <GroupObject Id="946"/>
+        <GroupObject Id="985"/>
+        <GroupObject Id="1015"/>
+        <GroupObject Id="988"/>
+        <GroupObject Id="1010"/>
+        <GroupObject Id="942"/>
+        <GroupObject Id="1003"/>
+        <GroupObject Id="959"/>
+        <GroupObject Id="995"/>
+        <GroupObject Id="954"/>
+        <GroupObject Id="1004"/>
+        <GroupObject Id="1013"/>
+        <GroupObject Id="987"/>
+        <GroupObject Id="2205"/>
+        <GroupObject Id="944"/>
+        <GroupObject Id="1008"/>
+        <GroupObject Id="949"/>
+        <GroupObject Id="1001"/>
+        <GroupObject Id="940"/>
     </Group>
-    <Group Id="5" Name="Normal Removal" Type="ObjectUnit">
-        <GroupObject Id="989">
-        </GroupObject>
-        <GroupObject Id="950">
-        </GroupObject>
-        <GroupObject Id="1011">
-        </GroupObject>
-        <GroupObject Id="943">
-        </GroupObject>
-        <GroupObject Id="1002">
-        </GroupObject>
-        <GroupObject Id="1007">
-        </GroupObject>
-        <GroupObject Id="947">
-        </GroupObject>
-        <GroupObject Id="984">
-        </GroupObject>
-        <GroupObject Id="1014">
-        </GroupObject>
-        <GroupObject Id="953">
-        </GroupObject>
-        <GroupObject Id="956">
-        </GroupObject>
-        <GroupObject Id="1017">
-        </GroupObject>
-        <GroupObject Id="1009">
-        </GroupObject>
-        <GroupObject Id="948">
-        </GroupObject>
-        <GroupObject Id="941">
-        </GroupObject>
-        <GroupObject Id="1005">
-        </GroupObject>
-        <GroupObject Id="1012">
-        </GroupObject>
-        <GroupObject Id="986">
-        </GroupObject>
-        <GroupObject Id="945">
-        </GroupObject>
-        <GroupObject Id="955">
-        </GroupObject>
-        <GroupObject Id="958">
-        </GroupObject>
-        <GroupObject Id="994">
-        </GroupObject>
-        <GroupObject Id="1169">
-        </GroupObject>
-        <GroupObject Id="1254">
-        </GroupObject>
-        <GroupObject Id="1187">
-        </GroupObject>
-        <GroupObject Id="1182">
-        </GroupObject>
-        <GroupObject Id="1179">
-        </GroupObject>
-        <GroupObject Id="1154">
-        </GroupObject>
-        <GroupObject Id="1196">
-        </GroupObject>
-        <GroupObject Id="1188">
-        </GroupObject>
-        <GroupObject Id="781">
-        </GroupObject>
-        <GroupObject Id="806">
-        </GroupObject>
-        <GroupObject Id="1252">
-        </GroupObject>
-        <GroupObject Id="1195">
-        </GroupObject>
-        <GroupObject Id="1180">
-        </GroupObject>
-        <GroupObject Id="1271">
-        </GroupObject>
-        <GroupObject Id="1177">
-        </GroupObject>
-        <GroupObject Id="1221">
-        </GroupObject>
-        <GroupObject Id="764">
-        </GroupObject>
-        <GroupObject Id="741">
-        </GroupObject>
-        <GroupObject Id="1636">
-        </GroupObject>
-        <GroupObject Id="1637">
-        </GroupObject>
-        <GroupObject Id="1282">
-        </GroupObject>
-        <GroupObject Id="1783">
-        </GroupObject>
-        <GroupObject Id="1720">
-        </GroupObject>
-        <GroupObject Id="1178">
-        </GroupObject>
-        <GroupObject Id="1268">
-        </GroupObject>
-        <GroupObject Id="1183">
-        </GroupObject>
-        <GroupObject Id="1255">
-        </GroupObject>
-        <GroupObject Id="828">
-        </GroupObject>
-        <GroupObject Id="1168">
-        </GroupObject>
-        <GroupObject Id="799">
-        </GroupObject>
-        <GroupObject Id="1194">
-        </GroupObject>
-        <GroupObject Id="1181">
-        </GroupObject>
-        <GroupObject Id="1184">
-        </GroupObject>
-        <GroupObject Id="1253">
-        </GroupObject>
-        <GroupObject Id="957">
-        </GroupObject>
-        <GroupObject Id="1016">
-        </GroupObject>
-        <GroupObject Id="996">
-        </GroupObject>
-        <GroupObject Id="939">
-        </GroupObject>
-        <GroupObject Id="1006">
-        </GroupObject>
-        <GroupObject Id="946">
-        </GroupObject>
-        <GroupObject Id="985">
-        </GroupObject>
-        <GroupObject Id="1015">
-        </GroupObject>
-        <GroupObject Id="988">
-        </GroupObject>
-        <GroupObject Id="1010">
-        </GroupObject>
-        <GroupObject Id="942">
-        </GroupObject>
-        <GroupObject Id="1003">
-        </GroupObject>
-        <GroupObject Id="959">
-        </GroupObject>
-        <GroupObject Id="995">
-        </GroupObject>
-        <GroupObject Id="954">
-        </GroupObject>
-        <GroupObject Id="1004">
-        </GroupObject>
-        <GroupObject Id="1013">
-        </GroupObject>
-        <GroupObject Id="987">
-        </GroupObject>
-        <GroupObject Id="2205">
-        </GroupObject>
-        <GroupObject Id="944">
-        </GroupObject>
-        <GroupObject Id="1008">
-        </GroupObject>
-        <GroupObject Id="949">
-        </GroupObject>
-        <GroupObject Id="1001">
-        </GroupObject>
-        <GroupObject Id="940">
-        </GroupObject>
+    <Group Type="ObjectUnit" Name="Normal Removal" Id="5">
+        <GroupObject Id="989"/>
+        <GroupObject Id="950"/>
+        <GroupObject Id="1011"/>
+        <GroupObject Id="943"/>
+        <GroupObject Id="1002"/>
+        <GroupObject Id="1007"/>
+        <GroupObject Id="947"/>
+        <GroupObject Id="984"/>
+        <GroupObject Id="1014"/>
+        <GroupObject Id="953"/>
+        <GroupObject Id="956"/>
+        <GroupObject Id="1017"/>
+        <GroupObject Id="1009"/>
+        <GroupObject Id="948"/>
+        <GroupObject Id="941"/>
+        <GroupObject Id="1005"/>
+        <GroupObject Id="1012"/>
+        <GroupObject Id="986"/>
+        <GroupObject Id="945"/>
+        <GroupObject Id="955"/>
+        <GroupObject Id="958"/>
+        <GroupObject Id="994"/>
+        <GroupObject Id="1169"/>
+        <GroupObject Id="1254"/>
+        <GroupObject Id="1187"/>
+        <GroupObject Id="1182"/>
+        <GroupObject Id="1179"/>
+        <GroupObject Id="1154"/>
+        <GroupObject Id="1196"/>
+        <GroupObject Id="1188"/>
+        <GroupObject Id="781"/>
+        <GroupObject Id="806"/>
+        <GroupObject Id="1252"/>
+        <GroupObject Id="1195"/>
+        <GroupObject Id="1180"/>
+        <GroupObject Id="1271"/>
+        <GroupObject Id="1177"/>
+        <GroupObject Id="1221"/>
+        <GroupObject Id="764"/>
+        <GroupObject Id="741"/>
+        <GroupObject Id="1636"/>
+        <GroupObject Id="1637"/>
+        <GroupObject Id="1282"/>
+        <GroupObject Id="1783"/>
+        <GroupObject Id="1720"/>
+        <GroupObject Id="1178"/>
+        <GroupObject Id="1268"/>
+        <GroupObject Id="1183"/>
+        <GroupObject Id="1255"/>
+        <GroupObject Id="828"/>
+        <GroupObject Id="1168"/>
+        <GroupObject Id="799"/>
+        <GroupObject Id="1194"/>
+        <GroupObject Id="1181"/>
+        <GroupObject Id="1184"/>
+        <GroupObject Id="1253"/>
+        <GroupObject Id="957"/>
+        <GroupObject Id="1016"/>
+        <GroupObject Id="996"/>
+        <GroupObject Id="939"/>
+        <GroupObject Id="1006"/>
+        <GroupObject Id="946"/>
+        <GroupObject Id="985"/>
+        <GroupObject Id="1015"/>
+        <GroupObject Id="988"/>
+        <GroupObject Id="1010"/>
+        <GroupObject Id="942"/>
+        <GroupObject Id="1003"/>
+        <GroupObject Id="959"/>
+        <GroupObject Id="995"/>
+        <GroupObject Id="954"/>
+        <GroupObject Id="1004"/>
+        <GroupObject Id="1013"/>
+        <GroupObject Id="987"/>
+        <GroupObject Id="2205"/>
+        <GroupObject Id="944"/>
+        <GroupObject Id="1008"/>
+        <GroupObject Id="949"/>
+        <GroupObject Id="1001"/>
+        <GroupObject Id="940"/>
     </Group>
-    <Group Id="6" Name="Hard Removal" Type="ObjectUnit">
-        <GroupObject Id="1187">
-        </GroupObject>
-        <GroupObject Id="1188">
-        </GroupObject>
-        <GroupObject Id="806">
-        </GroupObject>
-        <GroupObject Id="1636">
-        </GroupObject>
-        <GroupObject Id="499">
-        </GroupObject>
-        <GroupObject Id="1637">
-        </GroupObject>
-        <GroupObject Id="579">
-        </GroupObject>
-        <GroupObject Id="1783">
-        </GroupObject>
-        <GroupObject Id="1720">
-        </GroupObject>
-        <GroupObject Id="828">
-        </GroupObject>
+    <Group Type="ObjectUnit" Name="Hard Removal" Id="6">
+        <GroupObject Id="1187"/>
+        <GroupObject Id="1188"/>
+        <GroupObject Id="806"/>
+        <GroupObject Id="1636"/>
+        <GroupObject Id="499"/>
+        <GroupObject Id="1637"/>
+        <GroupObject Id="579"/>
+        <GroupObject Id="1783"/>
+        <GroupObject Id="1720"/>
+        <GroupObject Id="828"/>
     </Group>
-    <Group Id="7" Name="Brutal Removal" Type="ObjectUnit">
-        <GroupObject Id="499">
-        </GroupObject>
-        <GroupObject Id="579">
-        </GroupObject>
+    <Group Type="ObjectUnit" Name="Brutal Removal" Id="7">
+        <GroupObject Id="499"/>
+        <GroupObject Id="579"/>
     </Group>
 </PlacedObjects>

--- a/Maps/ArchipelagoCampaign/LotV/ap_into_the_void.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/LotV/ap_into_the_void.SC2Map/Triggers
@@ -593,6 +593,7 @@
         <Action Type="FunctionCall" Id="4E5079C0"/>
         <Action Type="FunctionCall" Id="0CD6AC22"/>
         <Action Type="FunctionCall" Id="694F5DF2"/>
+        <Action Type="FunctionCall" Id="6F62F7E6"/>
         <Action Type="FunctionCall" Id="0C22DD40"/>
         <Action Type="Comment" Id="BF59A990"/>
         <Action Type="FunctionCall" Id="2BCA1D47"/>
@@ -2071,6 +2072,27 @@
     <Element Type="Param" Id="18415C72">
         <ParameterDef Type="ParamDef" Library="15EF4C78" Id="FD281233"/>
         <Variable Type="Variable" Id="6C26E3D2"/>
+    </Element>
+    <Element Type="FunctionCall" Id="6F62F7E6">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="024DE4CC"/>
+        <Parameter Type="Param" Id="AEC34AEC"/>
+        <Parameter Type="Param" Id="A5CD0F46"/>
+        <Parameter Type="Param" Id="72DDC9F7"/>
+    </Element>
+    <Element Type="Param" Id="AEC34AEC">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="8845BF3B"/>
+        <Variable Type="Variable" Id="34A58E06"/>
+    </Element>
+    <Element Type="Param" Id="A5CD0F46">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="C30A359C"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="F5E3F3AD"/>
+    </Element>
+    <Element Type="Param" Id="72DDC9F7">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="0BE79C23"/>
+        <FunctionCall Type="FunctionCall" Id="97A69192"/>
+    </Element>
+    <Element Type="FunctionCall" Id="97A69192">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000356"/>
     </Element>
     <Element Type="FunctionCall" Id="0C22DD40">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="943DF2F7"/>
@@ -15912,6 +15934,7 @@
         <Action Type="FunctionCall" Id="0BADCE85"/>
         <Action Type="Comment" Id="BB744D13"/>
         <Action Type="FunctionCall" Id="0CBC2E04"/>
+        <Action Type="FunctionCall" Id="2776608C"/>
         <Action Type="Comment" Id="78196C9C"/>
         <Action Type="FunctionCall" Id="B90D02CA"/>
         <Action Type="FunctionCall" Id="82ACE1A1"/>
@@ -15994,16 +16017,24 @@
         </Comment>
     </Element>
     <Element Type="FunctionCall" Id="0CBC2E04">
-        <FunctionDef Type="FunctionDef" Library="VCMI" Id="11A7316F"/>
-        <Parameter Type="Param" Id="F71366FE"/>
-        <Parameter Type="Param" Id="9026125E"/>
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="84565F53"/>
+        <Parameter Type="Param" Id="6223C42E"/>
     </Element>
-    <Element Type="Param" Id="F71366FE">
+    <Element Type="Param" Id="6223C42E">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="CF70F2A6"/>
+        <Variable Type="Variable" Id="34A58E06"/>
+    </Element>
+    <Element Type="FunctionCall" Id="2776608C">
+        <FunctionDef Type="FunctionDef" Library="VCMI" Id="11A7316F"/>
+        <Parameter Type="Param" Id="9B9A30F2"/>
+        <Parameter Type="Param" Id="85889C5B"/>
+    </Element>
+    <Element Type="Param" Id="9B9A30F2">
         <ParameterDef Type="ParamDef" Library="VCMI" Id="E1353A15"/>
         <ValueType Type="region"/>
         <ValueId Id="8"/>
     </Element>
-    <Element Type="Param" Id="9026125E">
+    <Element Type="Param" Id="85889C5B">
         <ParameterDef Type="ParamDef" Library="VCMI" Id="70E22E41"/>
         <ValueType Type="region"/>
         <ValueId Id="7"/>

--- a/Maps/ArchipelagoCampaign/LotV/ap_last_stand.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/LotV/ap_last_stand.SC2Map/MapScript.galaxy
@@ -1368,6 +1368,7 @@ bool gt_StartGameQ_Func (bool testConds, bool runActions) {
     UIAlertPoint("Trigger", gv_pLAYER_01_USER, StringExternal("Param/Value/9919D0AC"), null, PointFromId(1));
     TriggerExecute(gt_ZergCounter, true, false);
     TriggerExecute(gt_TempleAlignmentFX, true, false);
+    lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_pLAYER_01_USER);
     libLbty_gf_OrderWorkerstoGatherNearbyResources(RegionEntireMap(), gv_pLAYER_01_USER);
     Wait(3.0, c_timeReal);
     TriggerQueueEnter();

--- a/Maps/ArchipelagoCampaign/LotV/ap_last_stand.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/LotV/ap_last_stand.SC2Map/Triggers
@@ -3448,6 +3448,7 @@
         <Action Type="FunctionCall" Id="0D2787B2"/>
         <Action Type="FunctionCall" Id="4A2A617E"/>
         <Action Type="Comment" Id="EE75A262"/>
+        <Action Type="FunctionCall" Id="D5E6A27B"/>
         <Action Type="FunctionCall" Id="8B0F9A0C"/>
         <Action Type="Comment" Id="C4690EB0"/>
         <Action Type="FunctionCall" Id="700B0A70"/>
@@ -3531,6 +3532,14 @@
         <Comment>
             Worker start harvesting
         </Comment>
+    </Element>
+    <Element Type="FunctionCall" Id="D5E6A27B">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="84565F53"/>
+        <Parameter Type="Param" Id="9360F6BD"/>
+    </Element>
+    <Element Type="Param" Id="9360F6BD">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="CF70F2A6"/>
+        <Variable Type="Variable" Id="22451263"/>
     </Element>
     <Element Type="FunctionCall" Id="8B0F9A0C">
         <FunctionDef Type="FunctionDef" Library="Lbty" Id="05E197DE"/>

--- a/Maps/ArchipelagoCampaign/LotV/ap_salvation.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/LotV/ap_salvation.SC2Map/MapScript.galaxy
@@ -1254,6 +1254,8 @@ bool gt_TransferAllyControlToPlayer_Func (bool testConds, bool runActions) {
             libNtve_gf_RescueUnit(lv_unit, gv_pLAYER_01_USER, true);
             lib15EF4C78_gf_AP_Player_ReapplyDefaultBehaviorsToUnit(lv_unit);
         }
+        lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_pLAYER_01_USER);
+        lib15EF4C78_gf_StartingWorkersAutoHarvest(gv_pLAYER_01_USER, RegionEntireMap(), null);
         PlayerModifyPropertyInt(gv_pLAYER_01_USER, c_playerPropSuppliesLimit, c_playerPropOperAdd, 600);
         auto9C5FAAB6_g = UnitGroup("MineralField", c_playerAny, RegionEntireMap(), UnitFilter(0, 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0);
         auto9C5FAAB6_u = UnitGroupCount(auto9C5FAAB6_g, c_unitCountAll);
@@ -1864,6 +1866,7 @@ bool gt_StartGameQ_Func (bool testConds, bool runActions) {
     }
 
     libLbty_gf_OrderWorkerstoGatherNearbyResources(RegionFromId(12), gv_pLAYER_01_USER);
+    lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_pLAYER_01_USER);
     TriggerExecute(gt_ObjectiveKeystoneMustSurviveCreate, true, false);
     Wait(3.0, c_timeReal);
     TriggerExecute(gt_KeystoneStatus, true, false);

--- a/Maps/ArchipelagoCampaign/LotV/ap_salvation.SC2Map/Objects
+++ b/Maps/ArchipelagoCampaign/LotV/ap_salvation.SC2Map/Objects
@@ -457,11 +457,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="966" Position="137.7753,97.7746,11.9868" Scale="1.0068,1.0068,1.0068" Type="Aiur_Overgrowth">
+    <ObjectDoodad Id="2176" Variation="1" Position="38.1228,82.424,9.9836" Rotation="0.7873" Scale="1,1,1" Type="Korhal_Platform_GrimeSplats">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2176" Variation="1" Position="38.1228,82.424,9.9836" Rotation="0.7873" Scale="1,1,1" Type="Korhal_Platform_GrimeSplats">
+    <ObjectDoodad Id="966" Position="137.7753,97.7746,11.9868" Scale="1.0068,1.0068,1.0068" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -769,11 +769,11 @@
     <ObjectDoodad Id="1274" Position="13.0908,80.395,9.9892" Scale="0.9755,0.9755,0.9755" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="893" Position="27.7416,40.8027,7.6862" Rotation="4.712" Scale="1.1196,1.1196,1.1196" Type="Aiur_Temple_BrickGroup">
+    <ObjectDoodad Id="2107" Variation="2" Position="30.301,46.9621,7.6794" Rotation="5.5185" Scale="0.877,0.877,0.877" Type="Aiur_Vines_Cliff">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2107" Variation="2" Position="30.301,46.9621,7.6794" Rotation="5.5185" Scale="0.877,0.877,0.877" Type="Aiur_Vines_Cliff">
+    <ObjectDoodad Id="893" Position="27.7416,40.8027,7.6862" Rotation="4.712" Scale="1.1196,1.1196,1.1196" Type="Aiur_Temple_BrickGroup">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
@@ -781,12 +781,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="790" Variation="2" Position="115.2187,112.0957,11.9868" Scale="0.976,0.976,0.976" Type="Aiur_Overgrowth">
+    <ObjectDoodad Id="2128" Variation="1" Position="131.1347,69.7802,8.087" Rotation="6.2106" Scale="1.4665,1.4665,1.4665" Type="Aiur_Vines_Cliff" TeamColor="0" Pitch="5.9404">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2128" Variation="1" Position="131.1347,69.7802,8.087" Rotation="6.2106" Scale="1.4665,1.4665,1.4665" Type="Aiur_Vines_Cliff" TeamColor="0" Pitch="5.9404">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="790" Variation="2" Position="115.2187,112.0957,11.9868" Scale="0.976,0.976,0.976" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -834,11 +834,11 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="783" Variation="4" Position="24.5437,46.0351,7.7863" Rotation="4.712" Scale="1.0798,1.0798,1.0798" Type="Aiur_Temple_BrickGroup">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2121" Variation="4" Position="54.5,118,11.983" Rotation="2.3657" Scale="1.6596,1.6596,0.25" Type="Aiur_Temple_GroundDecal" TintColor="184,187,203 1.200000">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2121" Variation="4" Position="54.5,118,11.983" Rotation="2.3657" Scale="1.6596,1.6596,0.25" Type="Aiur_Temple_GroundDecal" TintColor="184,187,203 1.200000">
+    <ObjectDoodad Id="783" Variation="4" Position="24.5437,46.0351,7.7863" Rotation="4.712" Scale="1.0798,1.0798,1.0798" Type="Aiur_Temple_BrickGroup">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1160" Variation="10" Position="69.3615,43.019,4.2863" Rotation="2.5893" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
@@ -877,14 +877,14 @@
     <ObjectDoodad Id="1229" Variation="3" Position="139.0117,74.3354,11.9865" Rotation="4.4494" Scale="1,1,1" Type="Aiur_Trees_Tall">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="842" Variation="1" Position="41.0395,120.5966,7.888" Rotation="2.356" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="2060" Variation="2" Position="93.5112,101.8413,11.582" Rotation="1.7265" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="842" Variation="1" Position="41.0395,120.5966,7.888" Rotation="2.356" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1863" Position="131.2895,49.6691,4.0036" Rotation="4.9162" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
         <Flag Index="HeightOffset" Value="1"/>
@@ -912,12 +912,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2087" Variation="4" Position="79.2304,106.2912,9.9826" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
+    <ObjectDoodad Id="865" Variation="3" Position="38.8764,122.8273,7.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="865" Variation="3" Position="38.8764,122.8273,7.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2087" Variation="4" Position="79.2304,106.2912,9.9826" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -982,12 +982,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="787" Variation="3" Position="24.3012,48.6948,7.5864" Rotation="3.8818" Scale="0.5498,0.5498,1.0656" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2133" Position="67.4138,47.8195,11.984" Rotation="2.3581" Scale="1,2,1" Type="Korhal_Platform_GrimeSplats">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2133" Position="67.4138,47.8195,11.984" Rotation="2.3581" Scale="1,2,1" Type="Korhal_Platform_GrimeSplats">
+    <ObjectDoodad Id="787" Variation="3" Position="24.3012,48.6948,7.5864" Rotation="3.8818" Scale="0.5498,0.5498,1.0656" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -995,12 +995,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="888" Variation="3" Position="30.2092,131.5344,7.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2110" Variation="3" Position="119.1921,100.5932,11.283" Rotation="2.8757" Scale="0.9753,0.9753,0.9753" Type="Aiur_Vines">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2110" Variation="3" Position="119.1921,100.5932,11.283" Rotation="2.8757" Scale="0.9753,0.9753,0.9753" Type="Aiur_Vines">
+    <ObjectDoodad Id="888" Variation="3" Position="30.2092,131.5344,7.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1058,14 +1058,14 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="875" Variation="1" Position="32.364,129.2954,7.888" Rotation="2.356" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2093" Position="122.5,47.5,5.5827" Rotation="0.7851" Scale="1.25,1.25,1" Type="Aiur_Temple_Pillars">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="875" Variation="1" Position="32.364,129.2954,7.888" Rotation="2.356" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1827" Variation="3" Position="45.3481,134.9094,4.3134" Rotation="1.3662" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
         <Flag Index="HeightOffset" Value="1"/>
@@ -1104,12 +1104,12 @@
     <ObjectDoodad Id="1812" Variation="1" Position="8.593,18.8415,7.984" Scale="0.96,0.96,0.96" Type="Aiur_GroundCover">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="882" Variation="3" Position="15.1562,125.2868,7.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2100" Variation="4" Position="20.5,109.5,0.1816" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="169,146,75 2.000000">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2100" Variation="4" Position="20.5,109.5,0.1816" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="169,146,75 2.000000">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="882" Variation="3" Position="15.1562,125.2868,7.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1149,23 +1149,23 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="2097" Position="131,39.5,5.5822" Rotation="0.7851" Scale="1.25,1.25,1" Type="Aiur_Temple_Pillars">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="887" Variation="3" Position="28.1584,112.2915,3.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2097" Position="131,39.5,5.5822" Rotation="0.7851" Scale="1.25,1.25,1" Type="Aiur_Temple_Pillars">
+    <ObjectDoodad Id="2138" Variation="10" Position="13.3225,67.468,4.3854" Rotation="1.366" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="796" Variation="5" Position="127.0705,121.5122,11.9868" Scale="0.9907,0.9907,0.9907" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2138" Variation="10" Position="13.3225,67.468,4.3854" Rotation="1.366" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1809" Variation="3" Position="56.8271,9.3635,7.984" Scale="0.9826,0.9826,0.9826" Type="Aiur_GroundCover">
         <Flag Index="HeightAbsolute" Value="1"/>
@@ -1225,34 +1225,34 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2088" Variation="5" Position="54.0895,109.3193,11.995" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
+    <ObjectDoodad Id="878" Position="29.5,130,-0.1118" Rotation="5.4975" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="878" Position="29.5,130,-0.1118" Rotation="5.4975" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2088" Variation="5" Position="54.0895,109.3193,11.995" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1800" Position="74.7441,133.9768,11.9831" Rotation="2.9707" Scale="1,1,1" Type="Birds">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2115" Variation="2" Position="73,78.5,12.2893" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_CliffDoodads">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="773" Position="29,35,-0.112" Rotation="5.4963" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2054" Variation="5" Position="95.5498,106.4348,11.6823" Rotation="4.989" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
+    <ObjectDoodad Id="2115" Variation="2" Position="73,78.5,12.2893" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_CliffDoodads">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="832" Variation="4" Position="43.1774,118.447,5.9877" Rotation="2.356" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2054" Variation="5" Position="95.5498,106.4348,11.6823" Rotation="4.989" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1323,20 +1323,20 @@
     <ObjectDoodad Id="1817" Variation="2" Position="10.761,47.4113,7.984" Scale="0.9792,0.9792,0.9792" Type="Aiur_GroundCover">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="2130" Variation="5" Position="49,71,11.9836" Rotation="3.9365" Scale="1.6596,1.6596,0.25" Type="Aiur_Temple_GroundDecal" TintColor="184,187,203 1.200000">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="788" Variation="3" Position="23.6882,42.9333,7.6862" Rotation="2.3928" Scale="0.7998,0.7998,1.0656" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2130" Variation="5" Position="49,71,11.9836" Rotation="3.9365" Scale="1.6596,1.6596,0.25" Type="Aiur_Temple_GroundDecal" TintColor="184,187,203 1.200000">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="895" Variation="4" Position="23.4904,41.3583,7.5178" Rotation="5.539" Scale="0.6098,0.6098,1.3254" Type="Aiur_Temple_Bricks" TintColor="192,192,192" Pitch="5.8957">
+    <ObjectDoodad Id="2105" Variation="2" Position="60.3078,30.9604,12.4123" Rotation="0.6394" Scale="0.877,0.877,0.877" Type="Aiur_Vines_Cliff">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2105" Variation="2" Position="60.3078,30.9604,12.4123" Rotation="0.6394" Scale="0.877,0.877,0.877" Type="Aiur_Vines_Cliff">
+    <ObjectDoodad Id="895" Variation="4" Position="23.4904,41.3583,7.5178" Rotation="5.539" Scale="0.6098,0.6098,1.3254" Type="Aiur_Temple_Bricks" TintColor="192,192,192" Pitch="5.8957">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1366,14 +1366,14 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="840" Variation="9" Position="23.0397,134.75,7.792" Rotation="3.063" Scale="1.0253,1.0253,0.8354" Type="Aiur_Temple_BrickGroup">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2062" Variation="5" Position="95.829,102.299,11.6821" Rotation="1.7001" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="840" Variation="9" Position="23.0397,134.75,7.792" Rotation="3.063" Scale="1.0253,1.0253,0.8354" Type="Aiur_Temple_BrickGroup">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2123" Position="57.0976,120.4125,11.983" Rotation="5.4326" Scale="1,1.5,1" Type="Korhal_Platform_GrimeSplats">
         <Flag Index="HeightAbsolute" Value="1"/>
@@ -1431,14 +1431,14 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="2144" Variation="4" Position="117.889,21.9436,9.1547" Rotation="5.5478" Scale="1.2966,1.2966,1.2966" Type="Aiur_Vines_Cliff">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="806" Variation="1" Position="29.0971,48.9814,7.6862" Rotation="4.712" Scale="1.2497,1.2497,1.2497" Type="Aiur_Temple_BrickGroup">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2144" Variation="4" Position="117.889,21.9436,9.1547" Rotation="5.5478" Scale="1.2966,1.2966,1.2966" Type="Aiur_Vines_Cliff">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2085" Variation="6" Position="78.3374,104.3107,9.9826" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
         <Flag Index="HeightAbsolute" Value="1"/>
@@ -1522,12 +1522,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="890" Variation="3" Position="30.2023,131.5378,3.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2108" Position="24.9138,46.3696,6.782" Rotation="0.9724" Scale="1.1147,1.1147,1.1147" Type="Aiur_Vines">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2108" Position="24.9138,46.3696,6.782" Rotation="0.9724" Scale="1.1147,1.1147,1.1147" Type="Aiur_Vines">
+    <ObjectDoodad Id="890" Variation="3" Position="30.2023,131.5378,3.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1536,14 +1536,14 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="785" Variation="6" Position="25.7724,49.7175,7.6862" Rotation="4.712" Scale="1.1296,1.1296,1.1296" Type="Aiur_Temple_BrickGroup">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2135" Variation="7" Position="20.6557,71.9743,4.2856" Rotation="0.459" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="785" Variation="6" Position="25.7724,49.7175,7.6862" Rotation="4.712" Scale="1.1296,1.1296,1.1296" Type="Aiur_Temple_BrickGroup">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1866" Variation="4" Position="62.2136,49.2763,7.9873" Rotation="0.7841" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
@@ -1582,12 +1582,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="873" Variation="3" Position="38.8696,122.8308,3.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2095" Variation="5" Position="113,21,5.5817" Rotation="3.9267" Scale="1.25,1.25,1" Type="Aiur_Temple_Pillars_Broken">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2095" Variation="5" Position="113,21,5.5817" Rotation="3.9267" Scale="1.25,1.25,1" Type="Aiur_Temple_Pillars_Broken">
+    <ObjectDoodad Id="873" Variation="3" Position="38.8696,122.8308,3.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1596,12 +1596,12 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2116" Variation="8" Position="88.7243,67.4,9.9833" Rotation="0.743" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
+    <ObjectDoodad Id="770" Position="37,27,-0.111" Rotation="5.4963" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="770" Position="37,27,-0.111" Rotation="5.4963" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
+    <ObjectDoodad Id="2116" Variation="8" Position="88.7243,67.4,9.9833" Rotation="0.743" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1639,12 +1639,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="880" Position="45.5,114,-0.1118" Rotation="5.4975" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
+    <ObjectDoodad Id="2102" Variation="4" Position="36,133.5,0.1816" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="169,146,75 2.000000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2102" Variation="4" Position="36,133.5,0.1816" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="169,146,75 2.000000">
+    <ObjectDoodad Id="880" Position="45.5,114,-0.1118" Rotation="5.4975" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1652,12 +1652,12 @@
     <ObjectDoodad Id="1814" Variation="2" Position="12.846,22.8645,7.984" Scale="1.0034,1.0034,1.0034" Type="Aiur_GroundCover">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="795" Position="107.7932,114.22,11.987" Scale="1.0483,1.0483,1.0483" Type="Aiur_Overgrowth">
+    <ObjectDoodad Id="2141" Variation="10" Position="15.0056,73.3547,4.2846" Rotation="5.1135" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2141" Variation="10" Position="15.0056,73.3547,4.2846" Rotation="5.1135" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="795" Position="107.7932,114.22,11.987" Scale="1.0483,1.0483,1.0483" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1703,20 +1703,20 @@
     <ObjectDoodad Id="1811" Position="29.8405,11.2497,7.9487" Scale="1.0297,1.0297,1.0297" Type="Aiur_GroundCover">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="798" Variation="4" Position="126.7897,125.6225,11.9868" Scale="1.0136,1.0136,1.0136" Type="Aiur_Overgrowth">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2136" Variation="6" Position="17.388,73.4807,4.2846" Rotation="2.5888" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="885" Variation="3" Position="28.1042,112.313,7.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="798" Variation="4" Position="126.7897,125.6225,11.9868" Scale="1.0136,1.0136,1.0136" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2099" Variation="4" Position="26.5,106.5,0.1835" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="169,146,75 2.000000">
         <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="885" Variation="3" Position="28.1042,112.313,7.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -1773,12 +1773,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2113" Variation="1" Position="125.815,83.2934,8.8808" Rotation="4.6176" Scale="1.5366,1.5366,1.5366" Type="Aiur_Vines_Cliff" Pitch="5.9404">
+    <ObjectDoodad Id="775" Position="21,43,-0.112" Rotation="5.4963" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="775" Position="21,43,-0.112" Rotation="5.4963" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
+    <ObjectDoodad Id="2113" Variation="1" Position="125.815,83.2934,8.8808" Rotation="4.6176" Scale="1.5366,1.5366,1.5366" Type="Aiur_Vines_Cliff" Pitch="5.9404">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -1787,12 +1787,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="876" Variation="1" Position="30.2207,131.4863,7.8876" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeArch">
+    <ObjectDoodad Id="2090" Variation="6" Position="104,29,-4.418" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="187,167,104 2.000000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2090" Variation="6" Position="104,29,-4.418" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="187,167,104 2.000000">
+    <ObjectDoodad Id="876" Variation="1" Position="30.2207,131.4863,7.8876" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeArch">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4453,12 +4453,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="886" Variation="4" Position="28.16,112.3256,5.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2096" Variation="6" Position="131,39.5,-4.4174" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="187,167,104 2.000000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2096" Variation="6" Position="131,39.5,-4.4174" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="187,167,104 2.000000">
+    <ObjectDoodad Id="886" Variation="4" Position="28.16,112.3256,5.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4466,13 +4466,13 @@
     <ObjectDoodad Id="1808" Variation="1" Position="61.0397,12.4184,7.984" Scale="1.0278,1.0278,1.0278" Type="Aiur_GroundCover">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="797" Variation="4" Position="114.2814,133.0021,11.9868" Scale="0.9638,0.9638,0.9638" Type="Aiur_Overgrowth">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2139" Variation="6" Position="14.8532,69.8125,4.285" Rotation="1.366" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="797" Variation="4" Position="114.2814,133.0021,11.9868" Scale="0.9638,0.9638,0.9638" Type="Aiur_Overgrowth">
+        <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2078" Variation="1" Position="110.5366,87.5078,11.7045" Rotation="3.9226" Scale="0.5998,0.5998,1" Type="Aiur_Temple_Bricks" TintColor="125,125,125">
         <Flag Index="HeightOffset" Value="1"/>
@@ -4503,12 +4503,12 @@
     <ObjectDoodad Id="1247" Variation="3" Position="4.4187,71.4575,10.2416" Rotation="2.0742" Scale="1.1552,1.1552,1.1552" Type="AiurTree_Grouped">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2089" Variation="10" Position="46.8271,118.4736,11.9833" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
+    <ObjectDoodad Id="879" Position="37.5,122,-0.1118" Rotation="5.4975" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="879" Position="37.5,122,-0.1118" Rotation="5.4975" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2089" Variation="10" Position="46.8271,118.4736,11.9833" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4516,12 +4516,12 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="772" Variation="4" Position="19.5007,121.048,5.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2114" Variation="2" Position="78.5,73,12.3205" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_CliffDoodads">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2114" Variation="2" Position="78.5,73,12.3205" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_CliffDoodads">
+    <ObjectDoodad Id="772" Variation="4" Position="19.5007,121.048,5.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4571,12 +4571,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2119" Variation="2" Position="78.303,97.1147,10.005" Scale="0.9921,0.9921,0.3498" Type="Aiur_GroundCover">
+    <ObjectDoodad Id="769" Position="45,19,-0.112" Rotation="5.4963" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="769" Position="45,19,-0.112" Rotation="5.4963" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2119" Variation="2" Position="78.303,97.1147,10.005" Scale="0.9921,0.9921,0.3498" Type="Aiur_GroundCover">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4584,12 +4584,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="874" Variation="3" Position="34.54,127.1865,3.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2092" Variation="6" Position="122.5,47.5,-4.417" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="187,167,104 2.000000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2092" Variation="6" Position="122.5,47.5,-4.417" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="187,167,104 2.000000">
+    <ObjectDoodad Id="874" Variation="3" Position="34.54,127.1865,3.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4638,12 +4638,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2050" Variation="1" Position="90.518,104.3632,11.6823" Rotation="2.9045" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
+    <ObjectDoodad Id="836" Variation="3" Position="43.1787,118.4814,3.9877" Rotation="2.356" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="836" Variation="3" Position="43.1787,118.4814,3.9877" Rotation="2.356" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2050" Variation="1" Position="90.518,104.3632,11.6823" Rotation="2.9045" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4670,12 +4670,12 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="883" Variation="4" Position="15.1726,125.376,5.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2101" Variation="4" Position="17.5,115.5,0.1816" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="169,146,75 2.000000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2101" Variation="4" Position="17.5,115.5,0.1816" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="169,146,75 2.000000">
+    <ObjectDoodad Id="883" Variation="4" Position="15.1726,125.376,5.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4731,12 +4731,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2086" Position="75.8886,105.9987,9.9826" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
+    <ObjectDoodad Id="864" Variation="1" Position="38.888,122.7792,7.8876" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeArch">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="864" Variation="1" Position="38.888,122.7792,7.8876" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeArch">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2086" Position="75.8886,105.9987,9.9826" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4773,20 +4773,20 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="2132" Variation="3" Position="69.5,50,11.9836" Rotation="2.3657" Scale="1.6596,1.6596,0.25" Type="Aiur_Temple_GroundDecal" TintColor="184,187,203 1.200000">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="786" Variation="3" Position="23.5,44.44,7.6862" Rotation="0.7414" Scale="0.5498,0.5498,1.0656" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2132" Variation="3" Position="69.5,50,11.9836" Rotation="2.3657" Scale="1.6596,1.6596,0.25" Type="Aiur_Temple_GroundDecal" TintColor="184,187,203 1.200000">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="889" Variation="4" Position="30.2011,131.5034,5.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2111" Variation="2" Position="103.7543,115.0512,11.483" Rotation="5.6972" Scale="0.9753,0.9753,0.9753" Type="Aiur_Vines">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2111" Variation="2" Position="103.7543,115.0512,11.483" Rotation="5.6972" Scale="0.9753,0.9753,0.9753" Type="Aiur_Vines">
+    <ObjectDoodad Id="889" Variation="4" Position="30.2011,131.5034,5.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -4815,11 +4815,11 @@
     <ObjectDoodad Id="1211" Variation="3" Position="66.2822,12.7263,8.0363" Rotation="6.005" Scale="1.15,1.15,0.97" Type="AiurTree_Grouped">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="828" Variation="3" Position="43.1855,118.478,7.9877" Rotation="2.356" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2170" Variation="1" Position="82.3752,57.875,9.9836" Rotation="5.5" Scale="1,1,1" Type="Korhal_Platform_GrimeSplats">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2170" Variation="1" Position="82.3752,57.875,9.9836" Rotation="5.5" Scale="1,1,1" Type="Korhal_Platform_GrimeSplats">
+    <ObjectDoodad Id="828" Variation="3" Position="43.1855,118.478,7.9877" Rotation="2.356" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4836,12 +4836,12 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2106" Variation="10" Position="57.062,32.421,7.9855" Rotation="5.5466" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
+    <ObjectDoodad Id="892" Position="47,34,6.587" Rotation="5.497" Scale="1,1,0.5998" Type="Aiur_Temple_OldWalls">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="892" Position="47,34,6.587" Rotation="5.497" Scale="1,1,0.5998" Type="Aiur_Temple_OldWalls">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2106" Variation="10" Position="57.062,32.421,7.9855" Rotation="5.5466" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
@@ -4908,13 +4908,13 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2120" Position="65.5498,119.3198,9.983" Scale="0.9738,0.9738,0.25" Type="Aiur_GroundCover">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="782" Variation="9" Position="40.882,29.0043,6.4353" Rotation="4.7392" Scale="1.5,1.5,1.5" Type="Aiur_Temple_BrickGroup" TintColor="128,128,128">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="2120" Position="65.5498,119.3198,9.983" Scale="0.9738,0.9738,0.25" Type="Aiur_GroundCover">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1795" Variation="3" Position="117.3154,104.067,11.737" Rotation="3.141" Scale="1.0698,1.0698,1.0698" Type="Aiur_Temple_BrickGroup">
         <Flag Index="HeightOffset" Value="1"/>
@@ -4926,12 +4926,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2061" Variation="3" Position="95.0373,102.1152,11.582" Rotation="4.9833" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
+    <ObjectDoodad Id="843" Variation="3" Position="34.5468,127.183,7.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="843" Variation="3" Position="34.5468,127.183,7.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2061" Variation="3" Position="95.0373,102.1152,11.582" Rotation="4.9833" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -5001,24 +5001,24 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="799" Variation="2" Position="117.7277,133.8666,11.9868" Scale="0.9533,0.9533,0.9533" Type="Aiur_Overgrowth">
+    <ObjectDoodad Id="2137" Variation="7" Position="15.7575,71.3354,4.2851" Rotation="2.5888" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
+        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2137" Variation="7" Position="15.7575,71.3354,4.2851" Rotation="2.5888" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="799" Variation="2" Position="117.7277,133.8666,11.9868" Scale="0.9533,0.9533,0.9533" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1810" Position="50.1335,5.8586,7.9841" Scale="0.998,0.998,0.998" Type="Aiur_GroundCover">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="884" Variation="3" Position="15.1711,125.3415,3.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2098" Variation="1" Position="36.946,50.8051,8.1896" Rotation="0.2814" Scale="1.0446,1.0446,1.0446" Type="Aiur_Vines_Cliff">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2098" Variation="1" Position="36.946,50.8051,8.1896" Rotation="0.2814" Scale="1.0446,1.0446,1.0446" Type="Aiur_Vines_Cliff">
+    <ObjectDoodad Id="884" Variation="3" Position="15.1711,125.3415,3.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -5063,12 +5063,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="774" Variation="3" Position="19.4992,121.0136,3.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2112" Variation="1" Position="125.8056,80.7705,8.904" Rotation="4.908" Scale="1.5366,1.5366,1.5366" Type="Aiur_Vines_Cliff" Pitch="5.9404">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2112" Variation="1" Position="125.8056,80.7705,8.904" Rotation="4.908" Scale="1.5366,1.5366,1.5366" Type="Aiur_Vines_Cliff" Pitch="5.9404">
+    <ObjectDoodad Id="774" Variation="3" Position="19.4992,121.0136,3.988" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -5077,12 +5077,12 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2091" Position="104,29,5.5817" Rotation="0.7851" Scale="1.25,1.25,1" Type="Aiur_Temple_Pillars">
+    <ObjectDoodad Id="877" Position="21.5,138,-0.1118" Rotation="5.4975" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="877" Position="21.5,138,-0.1118" Rotation="5.4975" Scale="1.4997,1.4997,1.4997" Type="Slayn_BrickFloor">
+    <ObjectDoodad Id="2091" Position="104,29,5.5817" Rotation="0.7851" Scale="1.25,1.25,1" Type="Aiur_Temple_Pillars">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -5139,12 +5139,12 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="872" Variation="4" Position="38.8684,122.7963,5.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2094" Variation="6" Position="113,21,-4.418" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="187,167,104 2.000000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2094" Variation="6" Position="113,21,-4.418" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="187,167,104 2.000000">
+    <ObjectDoodad Id="872" Variation="4" Position="38.8684,122.7963,5.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -5152,12 +5152,12 @@
     <ObjectDoodad Id="1806" Variation="3" Position="52.6323,35.1027,7.9902" Scale="0.9802,0.9802,0.9802" Type="Aiur_GroundCover">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2117" Variation="9" Position="89.7697,61.8417,9.9833" Rotation="5.581" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
+    <ObjectDoodad Id="771" Variation="3" Position="32.4416,107.9604,3.9873" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="771" Variation="3" Position="32.4416,107.9604,3.9873" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2117" Variation="9" Position="89.7697,61.8417,9.9833" Rotation="5.581" Scale="1.25,1.25,1.25" Type="Aiur_City_Weeds" TintColor="181,225,0 1.300000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -5175,12 +5175,12 @@
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2073" Variation="1" Position="104.827,91.6271,11.6823" Rotation="4.393" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
+    <ObjectDoodad Id="863" Variation="4" Position="34.5388,127.152,5.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="863" Variation="4" Position="34.5388,127.152,5.9877" Rotation="2.3557" Scale="1,1,1" Type="Aiur_Temple_BridgeSection">
+    <ObjectDoodad Id="2073" Variation="1" Position="104.827,91.6271,11.6823" Rotation="4.393" Scale="0.39,0.39,1.2343" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -5216,22 +5216,22 @@
     <ObjectDoodad Id="1270" Variation="2" Position="4.6967,110.4716,8.4091" Scale="0.993,0.993,0.993" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="881" Position="15.1577,125.3073,7.888" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeArch">
-        <Flag Index="HeightOffset" Value="1"/>
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2103" Variation="4" Position="42,130.5,0.1816" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="169,146,75 2.000000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="794" Variation="4" Position="24.5476,43.658,7.6862" Rotation="4.009" Scale="0.47,0.47,1.1855" Type="Aiur_Temple_Bricks" TintColor="192,192,192" Pitch="5.8957">
+    <ObjectDoodad Id="881" Position="15.1577,125.3073,7.888" Rotation="5.4975" Scale="1,1,1" Type="Aiur_Temple_BridgeArch">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2140" Variation="7" Position="19.2026,70.3041,4.285" Rotation="1.366" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="794" Variation="4" Position="24.5476,43.658,7.6862" Rotation="4.009" Scale="0.47,0.47,1.1855" Type="Aiur_Temple_Bricks" TintColor="192,192,192" Pitch="5.8957">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -5293,12 +5293,12 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="777" Variation="7" Position="36.0056,26.1384,6.3354" Rotation="4.779" Scale="1.5,1.5,1.5" Type="Aiur_Temple_BrickGroup" TintColor="128,128,128">
+    <ObjectDoodad Id="2127" Variation="1" Position="121.557,92.04,0.387" Rotation="4.908" Scale="1.8764,1.8764,1.8764" Type="Aiur_Vines_Cliff" Pitch="5.9404">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2127" Variation="1" Position="121.557,92.04,0.387" Rotation="4.908" Scale="1.8764,1.8764,1.8764" Type="Aiur_Vines_Cliff" Pitch="5.9404">
+    <ObjectDoodad Id="777" Variation="7" Position="36.0056,26.1384,6.3354" Rotation="4.779" Scale="1.5,1.5,1.5" Type="Aiur_Temple_BrickGroup" TintColor="128,128,128">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -5323,21 +5323,21 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="2109" Variation="4" Position="112.2788,105.5603,10.8828" Rotation="5.51" Scale="1.039,1.039,1.039" Type="Aiur_Vines">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="891" Position="32,119,7.9821" Rotation="2.366" Scale="1.6596,1.6596,0.25" Type="Aiur_Temple_GroundDecal" TintColor="184,187,203 1.200000">
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2109" Variation="4" Position="112.2788,105.5603,10.8828" Rotation="5.51" Scale="1.039,1.039,1.039" Type="Aiur_Vines">
-        <Flag Index="HeightOffset" Value="1"/>
+    <ObjectDoodad Id="2134" Position="71.2102,51.9096,11.9843" Rotation="5.4995" Scale="1,2,1" Type="Korhal_Platform_GrimeSplats">
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="784" Variation="6" Position="22.111,42.359,7.6862" Scale="1.0795,1.0795,1.0795" Type="Aiur_Temple_BrickGroup">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="2134" Position="71.2102,51.9096,11.9843" Rotation="5.4995" Scale="1,2,1" Type="Korhal_Platform_GrimeSplats">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1821" Variation="5" Position="10.2751,45.8374,7.984" Scale="1.002,1.002,1.002" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
@@ -5384,25 +5384,25 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
+    <ObjectDoodad Id="2131" Variation="6" Position="93.5,40.5,11.9836" Rotation="2.3657" Scale="1.6596,1.6596,0.25" Type="Aiur_Temple_GroundDecal" TintColor="184,187,203 1.200000">
+        <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
     <ObjectDoodad Id="789" Variation="4" Position="23.2651,43.675,7.7863" Rotation="4.0092" Scale="0.3498,0.3498,1.0656" Type="Aiur_Temple_Bricks" TintColor="192,192,192">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="2131" Variation="6" Position="93.5,40.5,11.9836" Rotation="2.3657" Scale="1.6596,1.6596,0.25" Type="Aiur_Temple_GroundDecal" TintColor="184,187,203 1.200000">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="1816" Variation="2" Position="9.7724,28.9812,10.2373" Scale="0.9807,0.9807,0.9807" Type="Aiur_GroundCover">
-        <Flag Index="HeightAbsolute" Value="1"/>
-    </ObjectDoodad>
-    <ObjectDoodad Id="894" Variation="6" Position="24.4826,40.0776,7.6862" Rotation="4.712" Scale="1.2097,1.2097,1.2097" Type="Aiur_Temple_BrickGroup">
-        <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="2104" Variation="4" Position="45,124.5,0.1816" Scale="1,1,1" Type="Slayn_Sacrificial_Altar_Big" TintColor="169,146,75 2.000000">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="894" Variation="6" Position="24.4826,40.0776,7.6862" Rotation="4.712" Scale="1.2097,1.2097,1.2097" Type="Aiur_Temple_BrickGroup">
+        <Flag Index="HeightOffset" Value="1"/>
+        <Flag Index="HeightAbsolute" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1273" Variation="5" Position="14.5532,77.462,9.9831" Scale="1.0278,1.0278,1.0278" Type="Aiur_Overgrowth">
         <Flag Index="HeightAbsolute" Value="1"/>
@@ -6218,13 +6218,13 @@
         <Flag Index="HeightAbsolute" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
-    <ObjectDoodad Id="967" Variation="5" Position="133.2543,100.343,11.9868" Scale="0.961,0.961,0.961" Type="Aiur_Overgrowth">
-        <Flag Index="HeightAbsolute" Value="1"/>
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectDoodad>
     <ObjectDoodad Id="2177" Variation="2" Position="46.0717,27.8198,7.4821" Rotation="5.5185" Scale="0.877,0.877,0.877" Type="Aiur_Vines_Cliff">
         <Flag Index="HeightOffset" Value="1"/>
         <Flag Index="HeightAbsolute" Value="1"/>
+    </ObjectDoodad>
+    <ObjectDoodad Id="967" Variation="5" Position="133.2543,100.343,11.9868" Scale="0.961,0.961,0.961" Type="Aiur_Overgrowth">
+        <Flag Index="HeightAbsolute" Value="1"/>
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectDoodad>
     <ObjectDoodad Id="1994" Variation="5" Position="32.315,87.8103,4.2866" Rotation="2.1225" Scale="1.014,1.014,1.014" Type="ZerusWaterPlant">
         <Flag Index="HeightOffset" Value="1"/>
@@ -6241,22 +6241,22 @@
     <ObjectPoint Id="2203" Position="126.0598,83.48,0" Scale="1,1,1" Type="SoundEmitter" Name="Sound Emitter Rock Tumble Fissure E" Color="0,0,0,0" Sound="AmbEmitter_RockTumbleFissure01"/>
     <ObjectPoint Id="2165" Position="43.7402,142.053,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 024" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="279" Position="71.5,71.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P07 - Taldarim" Color="0,0,0,0"/>
-    <ObjectPoint Id="384" Position="70.8234,10.462,0" Rotation="3.0585" Scale="1,1,1" Type="Normal" Name="Armada Gather Bot Mid" Color="0,0,0,0"/>
     <ObjectPoint Id="1740" Position="80.2324,76.3623,0" Rotation="0.7856" Scale="1,1,1" Type="Normal" Name="Intro Stalker 2" Color="0,0,0,0"/>
-    <ObjectPoint Id="395" Position="121.9018,18.6347,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 028" Color="0,0,0,0" PathingRadiusSoft="1" PathingRadiusHard="0.7"/>
+    <ObjectPoint Id="384" Position="70.8234,10.462,0" Rotation="3.0585" Scale="1,1,1" Type="Normal" Name="Armada Gather Bot Mid" Color="0,0,0,0"/>
     <ObjectPoint Id="1735" Position="76.7888,81.3596,0" Rotation="3.8496" Scale="1,1,1" Type="Normal" Name="Intro Zealot 2" Color="0,0,0,0"/>
+    <ObjectPoint Id="395" Position="121.9018,18.6347,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 028" Color="0,0,0,0" PathingRadiusSoft="1" PathingRadiusHard="0.7"/>
     <ObjectPoint Id="513" Position="11.0397,7.67,0" Rotation="2.3981" Scale="1,1,1" Type="Normal" Name="P3 Spawn" Color="255,0,255,0"/>
     <ObjectPoint Id="366" Position="37.3037,95.8867,0" Rotation="1.1333" Scale="1,1,1" Type="Normal" Name="Prism Deploy 6" Color="255,255,255,0"/>
     <ObjectPoint Id="2151" Position="118.879,130.1884,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 007" Color="0,0,0,0" PathingRadiusSoft="3" PathingRadiusHard="2"/>
     <ObjectPoint Id="2156" Position="95.0288,131.2631,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 015" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="778" Position="11.6091,110.3925,0" Rotation="0.8835" Scale="1,1,1" Type="Normal" Name="Armada Spawn Top Mid" Color="0,0,0,0"/>
     <ObjectPoint Id="1737" Position="76.006,77.4033,0" Rotation="3.8496" Scale="1,1,1" Type="Normal" Name="Intro Immortal 1" Color="0,0,0,0"/>
-    <ObjectPoint Id="43" Position="127.7324,8.2687,0" Rotation="4.0524" Scale="1,1,1" Type="Normal" Name="Armada Spawn Bot" Color="0,0,0,0"/>
     <ObjectPoint Id="398" Position="107.5292,54.9992,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 031" Color="0,0,0,0" PathingRadiusSoft="1" PathingRadiusHard="0.7"/>
+    <ObjectPoint Id="43" Position="127.7324,8.2687,0" Rotation="4.0524" Scale="1,1,1" Type="Normal" Name="Armada Spawn Bot" Color="0,0,0,0"/>
     <ObjectPoint Id="293" Position="58,94.5,0" Rotation="0.9536" Scale="1,1,1" Type="Normal" Name="P2 Target" Color="255,255,0,0"/>
     <ObjectPoint Id="2146" Position="131.7387,82.8032,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 002" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
-    <ObjectPoint Id="448" Position="17.5,21.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P03 - Amon" Color="0,0,0,0"/>
     <ObjectPoint Id="2153" Position="73.1984,131.2727,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 012" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
+    <ObjectPoint Id="448" Position="17.5,21.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P03 - Amon" Color="0,0,0,0"/>
     <ObjectPoint Id="348" Position="114.227,55.6564,0" Rotation="3.7456" Scale="1,1,1" Type="Normal" Name="Prism Deploy 3" Color="255,255,255,0"/>
     <ObjectPoint Id="2197" Position="90.4282,10.7495,0" Rotation="3.4577" Scale="1,1,1" Type="SoundEmitter" Name="Sound Emitter Bird S" Color="0,0,0,0" Sound="AmbEmitter_BirdDistant01"/>
     <ObjectPoint Id="2206" Position="76.7185,89.4487,0" Rotation="4.03" Scale="1,1,1" Type="Normal" Name="Victory - Vorazun" Color="0,0,0,0"/>
@@ -6274,19 +6274,19 @@
     <ObjectPoint Id="2161" Position="105.531,136.6035,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 020" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="2202" Position="115.426,117.0395,0" Scale="1,1,1" Type="SoundEmitter" Name="Sound Emitter Bird NE" Color="0,0,0,0" Sound="AmbEmitter_BirdDistant01"/>
     <ObjectPoint Id="246" Position="117.9604,33.6657,0" Rotation="3.8056" Scale="1,1,1" Type="Normal" Name="P4 Gather" Color="255,255,128,0"/>
-    <ObjectPoint Id="278" Position="11.5,6.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P05 - Golden Armada" Color="0,0,0,0"/>
     <ObjectPoint Id="604" Position="127.9721,67.973,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 003" Color="0,0,0,0"/>
+    <ObjectPoint Id="278" Position="11.5,6.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P05 - Golden Armada" Color="0,0,0,0"/>
     <ObjectPoint Id="2164" Position="61.1555,133.0981,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 023" Color="0,0,0,0" PathingRadiusSoft="3" PathingRadiusHard="2"/>
     <ObjectPoint Id="512" Position="9.69,140.0297,0" Rotation="0.7514" Scale="1,1,1" Type="Normal" Name="P2 Spawn" Color="255,255,0,0"/>
-    <ObjectPoint Id="394" Position="24.0195,4.84,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 006" Color="0,0,0,0"/>
     <ObjectPoint Id="1734" Position="76.8078,82.964,0" Rotation="1.4831" Scale="1,1,1" Type="Normal" Name="Intro Zealot 1" Color="0,0,0,0"/>
+    <ObjectPoint Id="394" Position="24.0195,4.84,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 006" Color="0,0,0,0"/>
     <ObjectPoint Id="1741" Position="77.4357,76.154,0" Rotation="0.7856" Scale="1,1,1" Type="Normal" Name="Intro Immortal 2" Color="0,0,0,0"/>
     <ObjectPoint Id="2157" Position="73.6804,138.289,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 016" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="2150" Position="108.489,120.0405,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 006" Color="0,0,0,0" PathingRadiusSoft="3" PathingRadiusHard="2"/>
     <ObjectPoint Id="367" Position="52.4245,117.671,0" Rotation="0.9821" Scale="1,1,1" Type="Normal" Name="Prism Deploy 7" Color="255,255,255,0"/>
     <ObjectPoint Id="356" Position="55.5,56,0" Rotation="2.425" Scale="1,1,1" Type="Normal" Name="Prism Deploy 4" Color="255,255,255,0"/>
-    <ObjectPoint Id="123" Position="20.5,130.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P02 - Amon" Color="0,0,0,0"/>
     <ObjectPoint Id="2167" Position="58.354,138.7697,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 026" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
+    <ObjectPoint Id="123" Position="20.5,130.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P02 - Amon" Color="0,0,0,0"/>
     <ObjectPoint Id="373" Position="123.5,25.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P04 - Amon" Color="0,0,0,0"/>
     <ObjectPoint Id="347" Position="94.0498,39.8388,0" Rotation="3.7458" Scale="1,1,1" Type="Normal" Name="Prism Deploy 2" Color="255,255,255,0"/>
     <ObjectPoint Id="245" Position="37.075,39.2092,0" Rotation="2.4228" Scale="1,1,1" Type="Normal" Name="P3 Gather" Color="255,0,255,0"/>
@@ -6302,8 +6302,8 @@
     <ObjectPoint Id="616" Position="25.8986,7.9421,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 005" Color="0,0,0,0"/>
     <ObjectPoint Id="2208" Position="88.6738,76.5646,0" Rotation="0.9504" Scale="1,1,1" Type="Normal" Name="Victory - Karax" Color="0,0,0,0"/>
     <ObjectPoint Id="2155" Position="87.9348,131.2194,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 014" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
-    <ObjectPoint Id="41" Position="16.264,8.364,0" Rotation="2.4238" Scale="1,1,1" Type="Normal" Name="Armada Spawn Mid" Color="0,0,0,0"/>
     <ObjectPoint Id="396" Position="133.3574,29.5861,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 029" Color="0,0,0,0" PathingRadiusSoft="1" PathingRadiusHard="0.7"/>
+    <ObjectPoint Id="41" Position="16.264,8.364,0" Rotation="2.4238" Scale="1,1,1" Type="Normal" Name="Armada Spawn Mid" Color="0,0,0,0"/>
     <ObjectPoint Id="1739" Position="81.7531,76.6145,0" Rotation="0.7856" Scale="1,1,1" Type="Normal" Name="Intro Zealot 3" Color="0,0,0,0"/>
     <ObjectPoint Id="2162" Position="111.559,139.5224,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 021" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="272" Position="97.5,56,0" Rotation="3.7685" Scale="1,1,1" Type="Normal" Name="P4 Target" Color="255,255,128,0"/>
@@ -6312,22 +6312,22 @@
     <ObjectPoint Id="59" Position="117.1767,119.8195,0" Scale="1,1,1" Type="BlockPathing" Name="Pathing Cliff Fill 001" Color="0,0,0,0"/>
     <ObjectPoint Id="2145" Position="131.7861,75.756,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 001" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="2154" Position="80.7385,131.2185,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 013" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
-    <ObjectPoint Id="264" Position="33.5,57.5,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 011" Color="0,0,0,0" PathingRadiusSoft="2.5" PathingRadiusHard="1.7998"/>
     <ObjectPoint Id="2209" Position="81.9477,70.2055,0" Rotation="0.208" Scale="1,1,1" Type="Normal" Name="Victory - Fenix" Color="0,0,0,0"/>
+    <ObjectPoint Id="264" Position="33.5,57.5,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 011" Color="0,0,0,0" PathingRadiusSoft="2.5" PathingRadiusHard="1.7998"/>
     <ObjectPoint Id="546" Position="10.5,141,0" Rotation="0.742" Scale="1,1,1" Type="Normal" Name="Zerg Rebuild Point 1" Color="0,0,0,0"/>
     <ObjectPoint Id="294" Position="134.2153,6.632,0" Rotation="3.795" Scale="1,1,1" Type="Normal" Name="P4 Spawn" Color="255,255,128,0"/>
     <ObjectPoint Id="1738" Position="83.0551,76.6108,0" Rotation="0.7856" Scale="1,1,1" Type="Normal" Name="Intro Zealot 4" Color="0,0,0,0"/>
-    <ObjectPoint Id="40" Position="15.3288,138.1325,0" Rotation="0.7448" Scale="1,1,1" Type="Normal" Name="Armada Spawn Top" Color="0,0,0,0"/>
     <ObjectPoint Id="397" Position="133.6098,63.46,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 030" Color="0,0,0,0" PathingRadiusSoft="4.5" PathingRadiusHard="3.5"/>
+    <ObjectPoint Id="40" Position="15.3288,138.1325,0" Rotation="0.7448" Scale="1,1,1" Type="Normal" Name="Armada Spawn Top" Color="0,0,0,0"/>
     <ObjectPoint Id="282" Position="111.5,74.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P09 - Purifier" Color="0,0,0,0"/>
     <ObjectPoint Id="2163" Position="101.4443,132.6911,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 022" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="2168" Position="66.4941,136.864,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 027" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="2198" Position="91.9382,10.5095,0" Rotation="3.4697" Scale="1,1,1" Type="SoundEmitter" Name="Sound Emitter Critter S" Color="0,0,0,0" Sound="AmbEmitter_CritterDistant01"/>
     <ObjectPoint Id="2205" Position="78.4543,78.1274,0" Rotation="5.5795" Scale="1,1,1" Type="Normal" Name="Victory - Artanis" Color="0,0,0,0"/>
     <ObjectPoint Id="383" Position="16.9553,104.922,0" Rotation="0.7534" Scale="1,1,1" Type="Normal" Name="Armada Gather Top Mid" Color="0,0,0,0"/>
-    <ObjectPoint Id="122" Position="96.5,95.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P01 - Player" Color="0,0,0,0"/>
-    <ObjectPoint Id="661" Position="81.0263,80.915,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 009" Color="0,0,0,0" PathingRadiusSoft="1" PathingRadiusHard="0.7"/>
     <ObjectPoint Id="2166" Position="50.9345,140.6213,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 025" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
+    <ObjectPoint Id="661" Position="81.0263,80.915,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 009" Color="0,0,0,0" PathingRadiusSoft="1" PathingRadiusHard="0.7"/>
+    <ObjectPoint Id="122" Position="96.5,95.5,0" Scale="1,1,1" Type="StartLoc" Name="Start Location P01 - Player" Color="0,0,0,0"/>
     <ObjectPoint Id="244" Position="26.4206,124.0625,0" Rotation="0.8085" Scale="1,1,1" Type="Normal" Name="P2 Gather" Color="255,255,0,0"/>
     <ObjectPoint Id="346" Position="80.0297,47.97,0" Rotation="2.6647" Scale="1,1,1" Type="Normal" Name="Prism Deploy 1" Color="255,255,255,0"/>
     <ObjectPoint Id="2195" Position="63.0415,136.0231,0" Scale="1,1,1" Type="SoundEmitter" Name="Sound Emitter Critter N" Color="0,0,0,0" Sound="AmbEmitter_CritterDistant01"/>
@@ -6335,19 +6335,6 @@
     <ObjectPoint Id="2148" Position="131.992,96.5661,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 004" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="2159" Position="88.5815,138.0375,0" Scale="1,1,1" Type="NoFlyZone" Name="No Fly Zone 018" Color="0,0,0,0" PathingRadiusSoft="6" PathingRadiusHard="5"/>
     <ObjectPoint Id="358" Position="37.3085,80.0183,0" Rotation="2.1401" Scale="1,1,1" Type="Normal" Name="Prism Deploy 5" Color="255,255,255,0"/>
-    <ObjectCamera Id="209" Position="97.7214,55.0305,0" Rotation="2.9343" Scale="1,1,1" Name="Intro - PurifierForces01" Color="0,0,0,0" CameraTarget="97.7214,55.0305">
-        <CameraValue Index="FieldOfView" Value="27.7998"/>
-        <CameraValue Index="NearClip" Value="0.0998"/>
-        <CameraValue Index="FarClip" Value="600"/>
-        <CameraValue Index="ShadowClip" Value="75"/>
-        <CameraValue Index="Distance" Value="30.909"/>
-        <CameraValue Index="Pitch" Value="39.0654"/>
-        <CameraValue Index="Yaw" Value="168.1245"/>
-        <CameraValue Index="FocalDepth" Value="8"/>
-        <CameraValue Index="FalloffEnd" Value="8"/>
-        <CameraValue Index="BokehFStop" Value="0.0183"/>
-        <CameraValue Index="BokehMaxCoC" Value="1"/>
-    </ObjectCamera>
     <ObjectCamera Id="1748" Position="81.1586,81.779,0" Rotation="3.097" Scale="1,1,1" Name="Intro - StartCamera01" Color="0,0,0,0" CameraTarget="81.1586,81.779">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
@@ -6361,17 +6348,17 @@
         <CameraValue Index="BokehFStop" Value="0.0178"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera Id="157" Position="60.391,62.5261,0" Rotation="3.149" Scale="1,1,1" Name="Intro - TaldarimForces01" Color="0,0,0,0" CameraTarget="60.391,62.5261">
+    <ObjectCamera Id="209" Position="97.7214,55.0305,0" Rotation="2.9343" Scale="1,1,1" Name="Intro - PurifierForces01" Color="0,0,0,0" CameraTarget="97.7214,55.0305">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
         <CameraValue Index="FarClip" Value="600"/>
         <CameraValue Index="ShadowClip" Value="75"/>
-        <CameraValue Index="Distance" Value="28.099"/>
-        <CameraValue Index="Pitch" Value="40.0112"/>
-        <CameraValue Index="Yaw" Value="180.4201"/>
+        <CameraValue Index="Distance" Value="30.909"/>
+        <CameraValue Index="Pitch" Value="39.0654"/>
+        <CameraValue Index="Yaw" Value="168.1245"/>
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
-        <CameraValue Index="BokehFStop" Value="0.0097"/>
+        <CameraValue Index="BokehFStop" Value="0.0183"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
     <ObjectCamera Id="312" Position="101.2551,51.4152,0" Rotation="2.9343" Scale="1,1,1" Name="Intro - PurifierForces02" Color="0,0,0,0" CameraTarget="101.2551,51.4152">
@@ -6387,6 +6374,19 @@
         <CameraValue Index="BokehFStop" Value="0.0183"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
+    <ObjectCamera Id="157" Position="60.391,62.5261,0" Rotation="3.149" Scale="1,1,1" Name="Intro - TaldarimForces01" Color="0,0,0,0" CameraTarget="60.391,62.5261">
+        <CameraValue Index="FieldOfView" Value="27.7998"/>
+        <CameraValue Index="NearClip" Value="0.0998"/>
+        <CameraValue Index="FarClip" Value="600"/>
+        <CameraValue Index="ShadowClip" Value="75"/>
+        <CameraValue Index="Distance" Value="28.099"/>
+        <CameraValue Index="Pitch" Value="40.0112"/>
+        <CameraValue Index="Yaw" Value="180.4201"/>
+        <CameraValue Index="FocalDepth" Value="8"/>
+        <CameraValue Index="FalloffEnd" Value="8"/>
+        <CameraValue Index="BokehFStop" Value="0.0097"/>
+        <CameraValue Index="BokehMaxCoC" Value="1"/>
+    </ObjectCamera>
     <ObjectCamera Id="1731" Position="81.1604,81.816,0" Rotation="3.0944" Scale="1,1,1" Name="Intro - Artifact02" Color="0,0,0,0" CameraTarget="81.1604,81.816">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
@@ -6399,6 +6399,17 @@
         <CameraValue Index="FalloffEnd" Value="8"/>
         <CameraValue Index="BokehFStop" Value="0.0178"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
+    </ObjectCamera>
+    <ObjectCamera Id="458" Position="81.0002,80.0202,0" Rotation="3.14" Scale="1,1,1" Name="Intro - ArtanisForces01" Color="0,0,0,0" CameraTarget="81.0002,80.0202">
+        <CameraValue Index="FieldOfView" Value="27.7998"/>
+        <CameraValue Index="NearClip" Value="0.0998"/>
+        <CameraValue Index="FarClip" Value="600"/>
+        <CameraValue Index="ShadowClip" Value="75"/>
+        <CameraValue Index="Distance" Value="28.099"/>
+        <CameraValue Index="Pitch" Value="56"/>
+        <CameraValue Index="Yaw" Value="179.9025"/>
+        <CameraValue Index="FocalDepth" Value="8"/>
+        <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
     <ObjectCamera Id="391" Position="80.8696,76.6606,0" Rotation="3.0705" Scale="1,1,1" Name="Victory - Camera02" Color="0,0,0,0" CameraTarget="80.8696,76.6606">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
@@ -6415,17 +6426,6 @@
         <CameraValue Index="FalloffEndNear" Value="0.0002"/>
         <CameraValue Index="BokehFStop" Value="0.0187"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
-    </ObjectCamera>
-    <ObjectCamera Id="458" Position="81.0002,80.0202,0" Rotation="3.14" Scale="1,1,1" Name="Intro - ArtanisForces01" Color="0,0,0,0" CameraTarget="81.0002,80.0202">
-        <CameraValue Index="FieldOfView" Value="27.7998"/>
-        <CameraValue Index="NearClip" Value="0.0998"/>
-        <CameraValue Index="FarClip" Value="600"/>
-        <CameraValue Index="ShadowClip" Value="75"/>
-        <CameraValue Index="Distance" Value="28.099"/>
-        <CameraValue Index="Pitch" Value="56"/>
-        <CameraValue Index="Yaw" Value="179.9025"/>
-        <CameraValue Index="FocalDepth" Value="8"/>
-        <CameraValue Index="FalloffEnd" Value="8"/>
     </ObjectCamera>
     <ObjectCamera Id="110" Position="54.6821,97.3925,0" Rotation="2.9492" Scale="1,1,1" Name="Intro - NerazimForces02" Color="0,0,0,0" CameraTarget="54.6821,97.3925">
         <Flag Index="ForcePlacement" Value="1"/>
@@ -6512,19 +6512,6 @@
         <CameraValue Index="BokehFStop" Value="0.0178"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
-    <ObjectCamera Id="251" Position="81.0002,80.0202,0" Rotation="3.14" Scale="1,1,1" Name="Intro - ArtanisForces02" Color="0,0,0,0" CameraTarget="81.0002,80.0202">
-        <CameraValue Index="FieldOfView" Value="27.7998"/>
-        <CameraValue Index="NearClip" Value="0.0998"/>
-        <CameraValue Index="FarClip" Value="600"/>
-        <CameraValue Index="ShadowClip" Value="75"/>
-        <CameraValue Index="Distance" Value="30.909"/>
-        <CameraValue Index="Pitch" Value="56"/>
-        <CameraValue Index="Yaw" Value="179.9025"/>
-        <CameraValue Index="FocalDepth" Value="8"/>
-        <CameraValue Index="FalloffEnd" Value="8"/>
-        <CameraValue Index="BokehFStop" Value="0.0097"/>
-        <CameraValue Index="BokehMaxCoC" Value="1"/>
-    </ObjectCamera>
     <ObjectCamera Id="1733" Position="90.1235,88.6523,0" Rotation="3.097" Scale="1,1,1" Name="Intro - StartCamera02" Color="0,0,0,0" CameraTarget="90.1235,88.6523">
         <CameraValue Index="FieldOfView" Value="27.7998"/>
         <CameraValue Index="NearClip" Value="0.0998"/>
@@ -6536,6 +6523,19 @@
         <CameraValue Index="FocalDepth" Value="8"/>
         <CameraValue Index="FalloffEnd" Value="8"/>
         <CameraValue Index="BokehFStop" Value="0.0178"/>
+        <CameraValue Index="BokehMaxCoC" Value="1"/>
+    </ObjectCamera>
+    <ObjectCamera Id="251" Position="81.0002,80.0202,0" Rotation="3.14" Scale="1,1,1" Name="Intro - ArtanisForces02" Color="0,0,0,0" CameraTarget="81.0002,80.0202">
+        <CameraValue Index="FieldOfView" Value="27.7998"/>
+        <CameraValue Index="NearClip" Value="0.0998"/>
+        <CameraValue Index="FarClip" Value="600"/>
+        <CameraValue Index="ShadowClip" Value="75"/>
+        <CameraValue Index="Distance" Value="30.909"/>
+        <CameraValue Index="Pitch" Value="56"/>
+        <CameraValue Index="Yaw" Value="179.9025"/>
+        <CameraValue Index="FocalDepth" Value="8"/>
+        <CameraValue Index="FalloffEnd" Value="8"/>
+        <CameraValue Index="BokehFStop" Value="0.0097"/>
         <CameraValue Index="BokehMaxCoC" Value="1"/>
     </ObjectCamera>
     <ObjectCamera Id="319" Position="56.7673,57.2077,0" Rotation="3.149" Scale="1,1,1" Name="Intro - TaldarimForces02" Color="0,0,0,0" CameraTarget="56.7673,57.2077">
@@ -6597,18 +6597,18 @@
     <ObjectUnit Id="1968658667" Position="87.9472,91.5573,0" Rotation="1.5993" Scale="1,1,1" UnitType="AP_Ultralisk" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
+    <ObjectUnit Id="566" Position="128.307,13.4965,0" Rotation="3.4675" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1941" Position="12.8447,47.904,0" Rotation="2.3867" Scale="1,1,1" UnitType="Mutalisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="566" Position="128.307,13.4965,0" Rotation="3.4675" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="37" Position="111.5,74.5,0" Rotation="2.6816" Scale="1,1,1" UnitType="Nexus" Player="9">
         <AIRebuild Index="1" Value="0"/>
@@ -6705,6 +6705,13 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="516" Position="61.3674,17.5922,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
     <ObjectUnit Id="1959" Position="106.5,150.5,0" Scale="1,1,1" UnitType="SpawningPool" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -6712,13 +6719,6 @@
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="516" Position="61.3674,17.5922,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2183" Position="99.4401,55.855,0" Rotation="0.8171" Scale="1,1,1" UnitType="SentryPurifier" Player="9">
@@ -6734,18 +6734,18 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="554" Position="132.1362,21.631,0" Rotation="4.1494" Scale="1,1,1" UnitType="Hydralisk" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="1929" Position="16.6994,58.2844,0" Rotation="0.9592" Scale="1,1,1" UnitType="QueenClassic" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="554" Position="132.1362,21.631,0" Rotation="4.1494" Scale="1,1,1" UnitType="Hydralisk" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="577" Position="133.6091,25.4128,0" Rotation="3.883" Scale="1,1,1" UnitType="Ultralisk" Player="4">
         <AIRebuild Index="1" Value="14"/>
@@ -6797,6 +6797,7 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="124" Position="93.5,94.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Stargate" Player="1"/>
+    <ObjectUnit Id="1612619748" Variation="5" Position="38,78.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="12000"/>
     <ObjectUnit Id="466" Position="28.6376,24.0297,0" Rotation="3.8481" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6804,9 +6805,14 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1612619748" Variation="5" Position="38,78.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="12000"/>
     <ObjectUnit Id="23" Position="51.5332,91.051,0" Rotation="3.7761" Scale="1,1,1" UnitType="StalkerShakuras" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="563" Position="127.7968,15.3073,0" Rotation="3.883" Scale="1,1,1" UnitType="Ultralisk" Player="4">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -6819,11 +6825,12 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="563" Position="127.7968,15.3073,0" Rotation="3.883" Scale="1,1,1" UnitType="Ultralisk" Player="4">
+    <ObjectUnit Id="526" Position="50.0771,23.0244,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1965" Position="101,150,0" Rotation="5.9338" Scale="1,1,1" UnitType="GreaterSpire" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
@@ -6832,13 +6839,6 @@
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="526" Position="50.0771,23.0244,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="613" Position="16.139,132.9145,0" Rotation="0.7458" Scale="1,1,1" UnitType="Zergling" Player="2">
@@ -6912,9 +6912,15 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="454280464" Position="108,96,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_SupplyDepot" Player="1"/>
     <ObjectUnit Id="636" Position="94.5,63.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="4">
         <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="454280464" Position="108,96,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_SupplyDepot" Player="1"/>
+    <ObjectUnit Id="569" Position="131.1052,19.0637,0" Rotation="4.0151" Scale="1,1,1" UnitType="Zergling" Player="4">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -6926,12 +6932,6 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="569" Position="131.1052,19.0637,0" Rotation="4.0151" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="472" Position="32.4401,21.38,0" Rotation="4.6166" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -6983,15 +6983,6 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="958146934" Position="100.5,87.5,0" Scale="1,1,1" UnitType="AP_SpawningPool" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
-    <ObjectUnit Id="530" Position="15.5,40.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="1969" Position="15,51,0" Rotation="0.4243" Scale="1,1,1" UnitType="SporeCrawler" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -6999,7 +6990,22 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="530" Position="15.5,40.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="958146934" Position="100.5,87.5,0" Scale="1,1,1" UnitType="AP_SpawningPool" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectUnit>
     <ObjectUnit Id="599" Position="130.1464,17.1442,0" Rotation="3.962" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="572" Position="133.4553,13.0097,0" Rotation="3.6335" Scale="1,1,1" UnitType="Zergling" Player="4">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -7013,12 +7019,6 @@
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="572" Position="133.4553,13.0097,0" Rotation="3.6335" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="24" Position="54.2495,90.5944,0" Rotation="3.7761" Scale="1,1,1" UnitType="StalkerShakuras" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
@@ -7035,9 +7035,6 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="115" Position="102.8977,92.601,0" Rotation="0.223" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
-    <ObjectUnit Id="220925461" Position="90.12,92.912,0" Rotation="4.387" Scale="1,1,1" UnitType="AP_Queen" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
     <ObjectUnit Id="477" Position="53.8332,21.0175,0" Rotation="5.5781" Scale="1,1,1" UnitType="Hydralisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7045,7 +7042,7 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1385369751" Position="103.4301,105.4768,0" Rotation="0.9531" Scale="1,1,1" UnitType="AP_Overlord" Player="1">
+    <ObjectUnit Id="220925461" Position="90.12,92.912,0" Rotation="4.387" Scale="1,1,1" UnitType="AP_Queen" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="2184" Position="96.528,53.6264,0" Rotation="1.0026" Scale="1,1,1" UnitType="SentryPurifier" Player="9">
@@ -7055,11 +7052,21 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="1385369751" Position="103.4301,105.4768,0" Rotation="0.9531" Scale="1,1,1" UnitType="AP_Overlord" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectUnit>
     <ObjectUnit Id="608" Position="21,137,0" Rotation="0.017" Scale="1,1,1" UnitType="SpineCrawler" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="523" Position="50.749,18.6018,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1960" Position="106.5,147.5,0" Rotation="5.707" Scale="1,1,1" UnitType="RoachWarren" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
@@ -7068,13 +7075,6 @@
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="523" Position="50.749,18.6018,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="47" Position="48,79,0" Scale="1,1,1" UnitType="Pylon" Player="8">
@@ -7092,18 +7092,18 @@
     </ObjectUnit>
     <ObjectUnit Id="1" Variation="4" Position="105,100.5,0" Scale="1,1,1" UnitType="MineralField" Resources="6000"/>
     <ObjectUnit Id="106" Position="69,51,0" Scale="1,1,1" UnitType="AP_Pylon" Player="1"/>
-    <ObjectUnit Id="549" Position="52.5,26.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="1926" Position="21.26,53.3488,0" Rotation="1.433" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="549" Position="52.5,26.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="469" Position="24.2751,20.3591,0" Rotation="2.067" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -7113,18 +7113,18 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="16" Variation="1" Position="76,113.5,0" Scale="1,1,1" UnitType="MineralField" Resources="6000"/>
+    <ObjectUnit Id="564" Position="130.9916,20.3796,0" Rotation="4.2402" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1943" Position="15.5576,53.3803,0" Rotation="1.282" Scale="1,1,1" UnitType="Mutalisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="564" Position="130.9916,20.3796,0" Rotation="4.2402" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="85" Position="106,99.5,0" Scale="1,1,1" UnitType="MineralField" Resources="6000"/>
     <ObjectUnit Id="507" Position="61.0612,15.5656,0" Rotation="1.4694" Scale="1,1,1" UnitType="Baneling" Player="3">
@@ -7135,14 +7135,14 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="62" Variation="8" Position="101,104.5,0" Scale="1,1,1" UnitType="MineralField" Resources="6000"/>
-    <ObjectUnit Id="1934" Position="48.8833,15.9594,0" Rotation="2.8242" Scale="1,1,1" UnitType="Mutalisk" Player="3">
+    <ObjectUnit Id="557" Position="40.7014,17.8867,0" Rotation="2.8242" Scale="1,1,1" UnitType="Roach" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="557" Position="40.7014,17.8867,0" Rotation="2.8242" Scale="1,1,1" UnitType="Roach" Player="3">
+    <ObjectUnit Id="1934" Position="48.8833,15.9594,0" Rotation="2.8242" Scale="1,1,1" UnitType="Mutalisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -7194,13 +7194,6 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="515" Position="63,18.5,0" Rotation="1.1225" Scale="1,1,1" UnitType="Hydralisk" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
     <ObjectUnit Id="1952" Position="120.5,144.5,0" Rotation="0.5234" Scale="1,1,1" UnitType="UltraliskCavern" Player="4">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -7210,14 +7203,15 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1746458528" Position="84.5,101.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_ZergMercenaryCompound" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
-    <ObjectUnit Id="552" Position="127.1057,18.599,0" Rotation="3.8374" Scale="1,1,1" UnitType="Hydralisk" Player="4">
+    <ObjectUnit Id="515" Position="63,18.5,0" Rotation="1.1225" Scale="1,1,1" UnitType="Hydralisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1746458528" Position="84.5,101.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_ZergMercenaryCompound" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="1931" Position="20.3676,133.8872,0" Rotation="1.1545" Scale="1,1,1" UnitType="Hydralisk" Player="2">
         <AIRebuild Index="1" Value="14"/>
@@ -7225,11 +7219,17 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="552" Position="127.1057,18.599,0" Rotation="3.8374" Scale="1,1,1" UnitType="Hydralisk" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="12" Position="105.5,93.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Assimilator" Player="1" Resources="6000"/>
-    <ObjectUnit Id="181530085" Position="65,51,0" Rotation="0.2761" Scale="1,1,1" UnitType="AP_SporeCrawler" Player="1">
+    <ObjectUnit Id="418" Position="81.2695,81.272,0" Scale="1,1,1" UnitType="ArtifactAiur06" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="418" Position="81.2695,81.272,0" Scale="1,1,1" UnitType="ArtifactAiur06" Player="1">
+    <ObjectUnit Id="181530085" Position="65,51,0" Rotation="0.2761" Scale="1,1,1" UnitType="AP_SporeCrawler" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="103" Position="63,74,0" Rotation="0.2658" Scale="1,1,1" UnitType="PhotonCannon" Player="7">
@@ -7253,17 +7253,17 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="263261768" Position="72,47,0" Rotation="4.9187" Scale="1,1,1" UnitType="AP_MissileTurret" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
-    <ObjectUnit Id="684065384" Position="93.5,94.5,0" Scale="1,1,1" UnitType="AP_Armory" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
     <ObjectUnit Id="621" Position="16.553,137.2722,0" Rotation="4.7207" Scale="1,1,1" UnitType="Zergling" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="684065384" Position="93.5,94.5,0" Scale="1,1,1" UnitType="AP_Armory" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectUnit>
+    <ObjectUnit Id="263261768" Position="72,47,0" Rotation="4.9187" Scale="1,1,1" UnitType="AP_MissileTurret" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="2181" Position="62.1901,93.6694,0" Rotation="3.6882" Scale="1,1,1" UnitType="VoidRayShakuras" Player="8">
         <Flag Index="UnitNoCreate" Value="1"/>
@@ -7273,6 +7273,13 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="518" Position="59.4797,21.744,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
     <ObjectUnit Id="1957" Position="112.5,144.5,0" Rotation="0.5234" Scale="1,1,1" UnitType="UltraliskCavern" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -7280,13 +7287,6 @@
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="518" Position="59.4797,21.744,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="21" Position="55.7932,96.3063,0" Scale="1,1,1" UnitType="VorazunChampion" Player="8">
@@ -7327,15 +7327,15 @@
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="6" Position="88,100,0" Scale="1,1,1" UnitType="AP_Pylon" Player="1"/>
-    <ObjectUnit Id="628136060" Position="88.5,99.5,0" Scale="1,1,1" UnitType="AP_CreepTumorUsed" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
     <ObjectUnit Id="424" Position="20.2617,48.077,0" Rotation="0.4604" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="628136060" Position="88.5,99.5,0" Scale="1,1,1" UnitType="AP_CreepTumorUsed" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="109" Position="51,70,0" Scale="1,1,1" UnitType="AP_Pylon" Player="1"/>
     <ObjectUnit Id="585" Position="18.0881,131.835,0" Rotation="1.1547" Scale="1,1,1" UnitType="Hydralisk" Player="2">
@@ -7369,18 +7369,18 @@
     <ObjectUnit Id="319939777" Position="47,69,0" Rotation="4.3208" Scale="1,1,1" UnitType="AP_MissileTurret" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
+    <ObjectUnit Id="571" Position="131.803,12.9626,0" Rotation="3.7231" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1944" Position="18.037,42.9594,0" Rotation="5.4416" Scale="1,1,1" UnitType="Mutalisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="571" Position="131.803,12.9626,0" Rotation="3.7231" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="433" Position="21.903,39.6503,0" Rotation="5.053" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -7423,6 +7423,12 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="574" Position="129.138,19.7336,0" Rotation="3.9621" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1949" Position="120.5,150.5,0" Rotation="5.7595" Scale="1,1,1" UnitType="EvolutionChamber" Player="4">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -7431,12 +7437,6 @@
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="574" Position="129.138,19.7336,0" Rotation="3.9621" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="597" Position="122.1748,11.3837,0" Rotation="3.6335" Scale="1,1,1" UnitType="Zergling" Player="4">
         <AIRebuild Index="1" Value="14"/>
@@ -7479,13 +7479,13 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="1407506605" Variation="6" Position="110,81.5,0" Scale="1,1,1" UnitType="PurifierRichMineralField" Resources="12000"/>
     <ObjectUnit Id="52" Position="112.0273,68.2888,0" Rotation="5.6665" Scale="1,1,1" UnitType="Adept" Player="9">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1407506605" Variation="6" Position="110,81.5,0" Scale="1,1,1" UnitType="PurifierRichMineralField" Resources="12000"/>
     <ObjectUnit Id="528" Position="9.5,9.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7516,18 +7516,18 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="905596590" Position="51.5,82.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="12000"/>
-    <ObjectUnit Id="551" Position="130.5,14.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="1924" Position="20.9611,51.0625,0" Rotation="1.433" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="551" Position="130.5,14.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1119430228" Position="90.8471,89.3293,0" Rotation="2.4824" Scale="1,1,1" UnitType="AP_Ultralisk" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
@@ -7599,7 +7599,7 @@
     <ObjectUnit Id="1772326547" Position="89.6137,86.6357,0" Rotation="5.151" Scale="1,1,1" UnitType="AP_Hydralisk" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="824" Position="74.9301,67.7868,0" Rotation="5.165" Scale="1,1,1" UnitType="Probe" Player="7">
+    <ObjectUnit Id="824" Position="75.5,70,0" Rotation="5.165" Scale="1,1,1" UnitType="Probe" Player="7">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -7629,7 +7629,6 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1604139383" Position="87.683,85.0068,0" Rotation="3.6086" Scale="1,1,1" UnitType="AP_Hellion" Player="1"/>
     <ObjectUnit Id="299" Position="21.3361,37.179,0" Rotation="2.3273" Scale="1,1,1" UnitType="Hydralisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7637,6 +7636,7 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="1604139383" Position="87.683,85.0068,0" Rotation="3.6086" Scale="1,1,1" UnitType="AP_Hellion" Player="1"/>
     <ObjectUnit Id="320" Position="54.459,22.8466,0" Rotation="3.706" Scale="1,1,1" UnitType="QueenClassic" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -7644,13 +7644,13 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1059811320" Position="87.9367,92.5908,0" Rotation="4.5263" Scale="1,1,1" UnitType="AP_SiegeBreaker" Player="1"/>
     <ObjectUnit Id="740" Position="29.5,32.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="1059811320" Position="87.9367,92.5908,0" Rotation="4.5263" Scale="1,1,1" UnitType="AP_SiegeBreaker" Player="1"/>
     <ObjectUnit Id="655" Position="102.9931,100.8596,0" Rotation="4.79" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
     <ObjectUnit Id="1705" Position="33.7932,7.5278,0" Rotation="0.7521" Scale="1,1,1" UnitType="Overlord" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -7707,14 +7707,14 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="708725183" Position="91.7805,91.4934,0" Rotation="1.087" Scale="1,1,1" UnitType="AP_Queen" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
     <ObjectUnit Id="1712" Position="83.3374,27.1325,0" Rotation="2.7045" Scale="1,1,1" UnitType="Overlord" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="708725183" Position="91.7805,91.4934,0" Rotation="1.087" Scale="1,1,1" UnitType="AP_Queen" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="1909" Position="19.1884,58.873,0" Rotation="0.324" Scale="1,1,1" UnitType="Hydralisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -7722,6 +7722,13 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1694" Position="69.298,59.5656,0" Rotation="5.168" Scale="1,1,1" UnitType="VoidRayTaldarim" Player="7">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="829" Position="126.5,144.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="CyberneticsCore" Player="7">
         <Flag Index="UnitHidden" Value="1"/>
@@ -7731,13 +7738,6 @@
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1694" Position="69.298,59.5656,0" Rotation="5.168" Scale="1,1,1" UnitType="VoidRayTaldarim" Player="7">
-        <Flag Index="UnitNoCreate" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="854" Position="61.5,87.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
@@ -7797,13 +7797,6 @@
     <ObjectUnit Id="169639837" Position="88.5,95.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Starport" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="1722" Position="15.9792,126.8444,0" Rotation="0.7521" Scale="1,1,1" UnitType="Overlord" Player="2">
-        <Flag Index="ForcePlacement" Value="1"/>
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="793" Position="120,36,0" Rotation="4.5197" Scale="1,1,1" UnitType="SpineCrawler" Player="4">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -7812,8 +7805,8 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="732" Position="30.5,118.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="2">
-        <Flag Index="UnitNoCreate" Value="1"/>
+    <ObjectUnit Id="1722" Position="15.9792,126.8444,0" Rotation="0.7521" Scale="1,1,1" UnitType="Overlord" Player="2">
+        <Flag Index="ForcePlacement" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -7825,6 +7818,13 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="732" Position="30.5,118.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="2">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="248" Position="30,22,0" Rotation="0.4245" Scale="1,1,1" UnitType="SporeCrawler" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -7843,7 +7843,7 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="214" Position="87.5446,86.2148,0" Rotation="5.583" Scale="1,1,1" UnitType="AP_ZealotAiur" Player="1"/>
-    <ObjectUnit Id="823" Position="68.0834,72.9345,0" Rotation="6.1296" Scale="1,1,1" UnitType="Probe" Player="7">
+    <ObjectUnit Id="823" Position="70.5,75,0" Rotation="6.1296" Scale="1,1,1" UnitType="Probe" Player="7">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -7899,10 +7899,10 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="210888796" Variation="7" Position="106,79.5,0" Scale="1,1,1" UnitType="PurifierRichMineralField" Resources="12000"/>
     <ObjectUnit Id="1258847968" Position="51,65,0" Rotation="0.5683" Scale="1,1,1" UnitType="AP_SporeCrawler" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
-    <ObjectUnit Id="210888796" Variation="7" Position="106,79.5,0" Scale="1,1,1" UnitType="PurifierRichMineralField" Resources="12000"/>
     <ObjectUnit Id="818" Position="66.7045,58.449,0" Rotation="5.364" Scale="1,1,1" UnitType="HighTemplarTaldarim" Player="7">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -7930,15 +7930,15 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1812473395" Position="88.2531,90.0744,0" Rotation="0.739" Scale="1,1,1" UnitType="AP_Hydralisk" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
     <ObjectUnit Id="811" Position="56.5,54.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1812473395" Position="88.2531,90.0744,0" Rotation="0.739" Scale="1,1,1" UnitType="AP_Hydralisk" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="645" Position="14.6826,131.5202,0" Rotation="5.571" Scale="1,1,1" UnitType="Zergling" Player="2">
         <AIRebuild Index="1" Value="14"/>
@@ -8053,21 +8053,14 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="845" Position="42,80,0" Rotation="2.2216" Scale="1,1,1" UnitType="Probe" Player="8">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="288300037" Position="107.3754,102.3337,0" Rotation="5.8425" Scale="1,1,1" UnitType="AP_Overlord" Player="1"/>
-    <ObjectUnit Id="845" Position="48.5866,81.974,0" Rotation="2.2216" Scale="1,1,1" UnitType="Probe" Player="8">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="648" Position="9.8361,137.6337,0" Rotation="2.0502" Scale="1,1,1" UnitType="Zergling" Player="2">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="867" Position="100.5,70.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="4">
-        <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -8080,7 +8073,7 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="776" Position="39.5,41.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
+    <ObjectUnit Id="867" Position="100.5,70.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="4">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8088,6 +8081,13 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1707" Position="46.5773,27.1035,0" Rotation="3.9416" Scale="1,1,1" UnitType="Overlord" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="776" Position="39.5,41.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
+        <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -8167,15 +8167,15 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1233055766" Position="104.5,89.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_EngineeringBay" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
     <ObjectUnit Id="812" Position="64.5,70.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1233055766" Position="104.5,89.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_EngineeringBay" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="136" Position="47,69,0" Rotation="1.6142" Scale="1,1,1" UnitType="AP_PhotonCannon" Player="1"/>
     <ObjectUnit Id="227" Position="31,28,0" Rotation="2.6008" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
@@ -8223,13 +8223,6 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="70615561" Position="78.5,70.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="12000"/>
-    <ObjectUnit Id="1917" Position="31.0544,24.8161,0" Rotation="2.7705" Scale="1,1,1" UnitType="Baneling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
     <ObjectUnit Id="734" Position="38.5,109.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -8237,13 +8230,20 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="1917" Position="31.0544,24.8161,0" Rotation="2.7705" Scale="1,1,1" UnitType="Baneling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="981249773" Position="70.5,78.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="12000"/>
     <ObjectUnit Id="1720" Position="22.5004,78.5141,0" Rotation="2.4504" Scale="1,1,1" UnitType="Overlord" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="981249773" Position="70.5,78.5,0" Scale="1,1,1" UnitType="RichVespeneGeyser" Resources="12000"/>
     <ObjectUnit Id="1579533311" Position="108,98,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_SupplyDepot" Player="1"/>
     <ObjectUnit Id="859" Position="90,54,0" Rotation="4.5192" Scale="1,1,1" UnitType="SpineCrawler" Player="4">
         <Flag Index="UnitNoCreate" Value="1"/>
@@ -8260,19 +8260,19 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1912" Position="30.7031,16.996,0" Rotation="2.7705" Scale="1,1,1" UnitType="Baneling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
     <ObjectUnit Id="731" Position="23.5,123.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1912" Position="30.7031,16.996,0" Rotation="2.7705" Scale="1,1,1" UnitType="Baneling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="255" Position="52.5786,94.988,0" Rotation="3.9177" Scale="1,1,1" UnitType="ZealotShakuras" Player="8">
         <AIRebuild Index="1" Value="14"/>
@@ -8287,7 +8287,6 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1608578731" Position="107,101,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_SupplyDepot" Player="1"/>
     <ObjectUnit Id="834" Position="137.5,149.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="FleetBeacon" Player="8">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -8297,6 +8296,7 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="1608578731" Position="107,101,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_SupplyDepot" Player="1"/>
     <ObjectUnit Id="230" Position="61.8994,61.8435,0" Scale="1,1,1" UnitType="AlarakChampion" Player="7"/>
     <ObjectUnit Id="328" Position="125.6218,10.4497,0" Rotation="3.422" Scale="1,1,1" UnitType="Queen" Player="4">
         <AIRebuild Index="1" Value="14"/>
@@ -8367,13 +8367,13 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="210" Position="90.8981,87.19,0" Rotation="5.5554" Scale="1,1,1" UnitType="AP_ImmortalAiur" Player="1"/>
+    <ObjectUnit Id="16985737" Variation="3" Position="111,80.5,0" Scale="1,1,1" UnitType="PurifierRichMineralField" Resources="12000"/>
     <ObjectUnit Id="1703" Position="20.7746,30.2268,0" Rotation="0.7521" Scale="1,1,1" UnitType="Overlord" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="16985737" Variation="3" Position="111,80.5,0" Scale="1,1,1" UnitType="PurifierRichMineralField" Resources="12000"/>
     <ObjectUnit Id="229" Position="98.6584,57.8215,0" Rotation="1.1872" Scale="1,1,1" UnitType="ColossusPurifier" Player="9">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -8409,6 +8409,7 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="798832274" Variation="2" Position="40,78.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="12000"/>
     <ObjectUnit Id="810" Position="68.4777,63.438,0" Rotation="5.4963" Scale="1,1,1" UnitType="ColossusTaldarim" Player="7">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -8416,7 +8417,6 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="798832274" Variation="2" Position="40,78.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="12000"/>
     <ObjectUnit Id="1698" Position="65.91,62.9155,0" Rotation="5.322" Scale="1,1,1" UnitType="Monitor" Player="7">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
@@ -8446,12 +8446,6 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1723" Position="25.64,133.42,0" Rotation="0.7521" Scale="1,1,1" UnitType="Overlord" Player="2">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="792" Position="114,31,0" Rotation="4.5197" Scale="1,1,1" UnitType="SpineCrawler" Player="4">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -8460,8 +8454,7 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="733" Position="37.5,118.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="2">
-        <Flag Index="UnitNoCreate" Value="1"/>
+    <ObjectUnit Id="1723" Position="25.64,133.42,0" Rotation="0.7521" Scale="1,1,1" UnitType="Overlord" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -8473,6 +8466,13 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="733" Position="37.5,118.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="2">
+        <Flag Index="UnitNoCreate" Value="1"/>
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="883741650" Position="111.3645,95.3034,0" Rotation="4.6606" Scale="1,1,1" UnitType="AP_Overlord" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
@@ -8516,7 +8516,7 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="846" Position="43.198,88.2641,0" Rotation="3.005" Scale="1,1,1" UnitType="Probe" Player="8">
+    <ObjectUnit Id="846" Position="40.5,86.5,0" Rotation="3.005" Scale="1,1,1" UnitType="Probe" Player="8">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -8584,15 +8584,6 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="701129424" Position="100.5,87.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Barracks" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1716" Position="131.1018,30.544,0" Rotation="4.126" Scale="1,1,1" UnitType="Overlord" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="791" Position="60,105,0" Rotation="0.7312" Scale="1,1,1" UnitType="SpineCrawler" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -8600,6 +8591,15 @@
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1716" Position="131.1018,30.544,0" Rotation="4.126" Scale="1,1,1" UnitType="Overlord" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="701129424" Position="100.5,87.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Barracks" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="216" Position="86.4523,91.011,0" Rotation="5.5554" Scale="1,1,1" UnitType="AP_ImmortalAiur" Player="1"/>
     <ObjectUnit Id="374" Position="56.6445,28.5378,0" Rotation="5.9453" Scale="1,1,1" UnitType="Baneling" Player="3">
@@ -8623,8 +8623,8 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1042482097" Position="85,102,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_MercCompound" Player="1"/>
     <ObjectUnit Id="132" Position="92.5,103.5,0" Scale="1,1,1" UnitType="VespeneGeyser" Resources="6000"/>
+    <ObjectUnit Id="1042482097" Position="85,102,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_MercCompound" Player="1"/>
     <ObjectUnit Id="298" Position="14.4821,46.2993,0" Rotation="5.8" Scale="1,1,1" UnitType="Hydralisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -8716,9 +8716,6 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="305386014" Position="94.5,89.5,0" Rotation="5.8117" Scale="1,1,1" UnitType="AP_HydraliskDen" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
     <ObjectUnit Id="835" Position="139.5,149.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="FleetBeacon" Player="9">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -8727,6 +8724,9 @@
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="305386014" Position="94.5,89.5,0" Rotation="5.8117" Scale="1,1,1" UnitType="AP_HydraliskDen" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="1701" Position="100.5,87.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_CyberneticsCore" Player="1"/>
     <ObjectUnit Id="329" Position="133.0214,10.5021,0" Rotation="2.6083" Scale="1,1,1" UnitType="Drone" Player="4">
@@ -8785,19 +8785,19 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="213" Position="87.1264,88.808,0" Rotation="5.6235" Scale="1,1,1" UnitType="AP_StalkerShakuras" Player="1"/>
-    <ObjectUnit Id="1916" Position="25.2231,28.4941,0" Rotation="2.7705" Scale="1,1,1" UnitType="Baneling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
     <ObjectUnit Id="735" Position="45.5,107.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="2">
         <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1916" Position="25.2231,28.4941,0" Rotation="2.7705" Scale="1,1,1" UnitType="Baneling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1721" Position="15.7697,86.6987,0" Rotation="0.7521" Scale="1,1,1" UnitType="Overlord" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -8836,14 +8836,14 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="866" Position="86.5,59.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="4">
-        <Flag Index="UnitNoCreate" Value="1"/>
+    <ObjectUnit Id="1729" Position="33.72,138.8598,0" Rotation="0.7521" Scale="1,1,1" UnitType="Overlord" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1729" Position="33.72,138.8598,0" Rotation="0.7521" Scale="1,1,1" UnitType="Overlord" Player="2">
+    <ObjectUnit Id="866" Position="86.5,59.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="4">
+        <Flag Index="UnitNoCreate" Value="1"/>
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -8918,8 +8918,8 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="218" Position="85.8444,87.7797,0" Rotation="5.7187" Scale="1,1,1" UnitType="AP_ZealotAiur" Player="1"/>
     <ObjectUnit Id="860369463" Position="105,77.5,0" Scale="1,1,1" UnitType="PurifierRichMineralField" Resources="12000"/>
+    <ObjectUnit Id="218" Position="85.8444,87.7797,0" Rotation="5.7187" Scale="1,1,1" UnitType="AP_ZealotAiur" Player="1"/>
     <ObjectUnit Id="177" Position="99.777,101.658,0" Rotation="0.2221" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
     <ObjectUnit Id="827" Position="132.5,147.5,0" Scale="1,1,1" UnitType="RoboticsBay" Player="9">
         <Flag Index="UnitHidden" Value="1"/>
@@ -8938,7 +8938,7 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="848" Position="114.6855,71.1591,0" Rotation="5.1647" Scale="1,1,1" UnitType="Probe" Player="9">
+    <ObjectUnit Id="848" Position="110.5,78.5,0" Rotation="5.1647" Scale="1,1,1" UnitType="Probe" Player="9">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -9029,6 +9029,12 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="531" Position="45.5,13.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1968" Position="100.5,147.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="BanelingNest" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -9037,12 +9043,6 @@
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="531" Position="45.5,13.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="55" Position="98.1796,54.3957,0" Scale="1,1,1" UnitType="KaraxChampion" Player="9">
         <AIRebuild Index="1" Value="14"/>
@@ -9088,8 +9088,15 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="114" Position="102.8884,94.1474,0" Rotation="0.5107" Scale="1,1,1" UnitType="AP_Probe" Player="1"/>
-    <ObjectUnit Id="1860756712" Position="84.3928,88.7807,0" Rotation="0.8356" Scale="1,1,1" UnitType="AP_Hellion" Player="1"/>
     <ObjectUnit Id="598" Position="131.372,17.625,0" Rotation="4.0744" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1860756712" Position="84.3928,88.7807,0" Rotation="0.8356" Scale="1,1,1" UnitType="AP_Hellion" Player="1"/>
+    <ObjectUnit Id="1304639765" Variation="7" Position="38,81.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="12000"/>
+    <ObjectUnit Id="573" Position="128.0952,22.0944,0" Rotation="4.0747" Scale="1,1,1" UnitType="Zergling" Player="4">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -9104,20 +9111,13 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="573" Position="128.0952,22.0944,0" Rotation="4.0747" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1304639765" Variation="7" Position="38,81.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="12000"/>
-    <ObjectUnit Id="1663963066" Position="105.0627,104.2907,0" Rotation="5.3095" Scale="1,1,1" UnitType="AP_Overlord" Player="1"/>
     <ObjectUnit Id="46" Position="67.5,67.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="Gateway" Player="7">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="1663963066" Position="105.0627,104.2907,0" Rotation="5.3095" Scale="1,1,1" UnitType="AP_Overlord" Player="1"/>
     <ObjectUnit Id="69" Position="60,70,0" Rotation="4.519" Scale="1,1,1" UnitType="SpineCrawler" Player="3">
         <Flag Index="UnitNoCreate" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -9140,6 +9140,13 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="522" Position="59.225,15.8681,0" Rotation="5.7478" Scale="1,1,1" UnitType="Zergling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
     <ObjectUnit Id="1961" Position="103.5,150.5,0" Rotation="5.7595" Scale="1,1,1" UnitType="EvolutionChamber" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -9149,7 +9156,7 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="522" Position="59.225,15.8681,0" Rotation="5.7478" Scale="1,1,1" UnitType="Zergling" Player="3">
+    <ObjectUnit Id="1927" Position="22.172,57.146,0" Rotation="1.433" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -9161,13 +9168,6 @@
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1927" Position="22.172,57.146,0" Rotation="1.433" Scale="1,1,1" UnitType="Zergling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="107" Position="72,47,0" Rotation="0.0463" Scale="1,1,1" UnitType="AP_PhotonCannon" Player="1"/>
     <ObjectUnit Id="453" Position="21.5688,25.9658,0" Rotation="0.4733" Scale="1,1,1" UnitType="Zergling" Player="3">
@@ -9183,6 +9183,13 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="527" Position="51.5788,24.767,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
     <ObjectUnit Id="1964" Position="103.5,144.5,0" Rotation="0.5234" Scale="1,1,1" UnitType="UltraliskCavern" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -9190,13 +9197,6 @@
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="527" Position="51.5788,24.767,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="612" Position="11.817,133.0024,0" Rotation="1.195" Scale="1,1,1" UnitType="Ultralisk" Player="2">
@@ -9259,6 +9259,12 @@
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="28" Position="68.5,115.5,0" Scale="1,1,1" UnitType="VespeneGeyser" Resources="6000"/>
+    <ObjectUnit Id="568" Position="130.2302,18.3666,0" Rotation="4.03" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1947" Position="21,63,0" Rotation="0.4243" Scale="1,1,1" UnitType="SporeCrawler" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9266,13 +9272,8 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="568" Position="130.2302,18.3666,0" Rotation="4.03" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="151062614" Position="89.7868,88.9023,0" Rotation="4.5297" Scale="1,1,1" UnitType="AP_SpartanCompany" Player="1"/>
+    <ObjectUnit Id="517" Position="128.521,13.3344,0" Rotation="3.7614" Scale="1,1,1" UnitType="QueenClassic" Player="4"/>
     <ObjectUnit Id="1958" Position="110,150,0" Rotation="5.9338" Scale="1,1,1" UnitType="GreaterSpire" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -9282,7 +9283,6 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="517" Position="128.521,13.3344,0" Rotation="3.7614" Scale="1,1,1" UnitType="QueenClassic" Player="4"/>
     <ObjectUnit Id="622" Position="18.9616,133.6027,0" Rotation="0.4401" Scale="1,1,1" UnitType="Zergling" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9328,18 +9328,18 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="555" Position="131.4753,23.9104,0" Rotation="4.3632" Scale="1,1,1" UnitType="Hydralisk" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="1928" Position="23.782,55.518,0" Rotation="2.3276" Scale="1,1,1" UnitType="Roach" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="555" Position="131.4753,23.9104,0" Rotation="4.3632" Scale="1,1,1" UnitType="Hydralisk" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="576" Position="129.1496,24.6103,0" Rotation="4.2968" Scale="1,1,1" UnitType="Zergling" Player="4">
         <AIRebuild Index="1" Value="14"/>
@@ -9362,18 +9362,18 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="562" Position="130,16,0" Rotation="3.7563" Scale="1,1,1" UnitType="SporeCrawler" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1937" Position="52.304,21.239,0" Rotation="2.8242" Scale="1,1,1" UnitType="Mutalisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="562" Position="130,16,0" Rotation="3.7563" Scale="1,1,1" UnitType="SporeCrawler" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="601" Position="14.821,133.3662,0" Rotation="1.1547" Scale="1,1,1" UnitType="Hydralisk" Player="2">
         <AIRebuild Index="1" Value="14"/>
@@ -9395,9 +9395,6 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="22" Position="98.5,97.5,0" Rotation="4.0742" Scale="1,1,1" Name="P1 Nexus" UnitType="AP_Nexus" Player="1"/>
-    <ObjectUnit Id="857746106" Position="89.4892,88.5417,0" Rotation="6.1652" Scale="1,1,1" UnitType="AP_Hydralisk" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
-    </ObjectUnit>
     <ObjectUnit Id="61" Position="47,10,0" Rotation="0.4243" Scale="1,1,1" UnitType="SporeCrawler" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9405,24 +9402,20 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1203886901" Position="83.278,90.3488,0" Rotation="5.8447" Scale="1,1,1" UnitType="AP_Hellion" Player="1"/>
+    <ObjectUnit Id="857746106" Position="89.4892,88.5417,0" Rotation="6.1652" Scale="1,1,1" UnitType="AP_Hydralisk" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
+    </ObjectUnit>
     <ObjectUnit Id="86" Position="107,73,0" Scale="1,1,1" UnitType="Pylon" Player="9">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="1203886901" Position="83.278,90.3488,0" Rotation="5.8447" Scale="1,1,1" UnitType="AP_Hellion" Player="1"/>
     <ObjectUnit Id="180403918" Position="51,65,0" Rotation="4.8693" Scale="1,1,1" UnitType="AP_MissileTurret" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="626" Position="34.1567,6.4113,0" Rotation="5.648" Scale="1,1,1" UnitType="Roach" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="1940" Position="21.3505,49.2087,0" Rotation="1.5273" Scale="1,1,1" UnitType="Mutalisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -9434,6 +9427,13 @@
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1940" Position="21.3505,49.2087,0" Rotation="1.5273" Scale="1,1,1" UnitType="Mutalisk" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="470" Position="27.4565,23.1154,0" Rotation="1.9455" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -9487,7 +9487,6 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1911856166" Position="101.3627,106.8864,0" Rotation="5.6896" Scale="1,1,1" UnitType="AP_Overlord" Player="1"/>
     <ObjectUnit Id="420" Position="22.47,46.3723,0" Rotation="1.894" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9495,6 +9494,7 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="1911856166" Position="101.3627,106.8864,0" Rotation="5.6896" Scale="1,1,1" UnitType="AP_Overlord" Player="1"/>
     <ObjectUnit Id="97" Position="66,71,0" Scale="1,1,1" UnitType="Pylon" Player="7">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9514,18 +9514,18 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1933" Position="10.658,135.6176,0" Rotation="1.1545" Scale="1,1,1" UnitType="Hydralisk" Player="2">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="558" Position="34.9372,15.203,0" Rotation="4.0087" Scale="1,1,1" UnitType="Roach" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="1933" Position="10.658,135.6176,0" Rotation="1.1545" Scale="1,1,1" UnitType="Hydralisk" Player="2">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="478" Position="52.3928,27.8977,0" Rotation="1.05" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -9535,6 +9535,12 @@
     </ObjectUnit>
     <ObjectUnit Id="27" Position="77.5,106.5,0" Scale="1,1,1" UnitType="VespeneGeyser" Resources="6000"/>
     <ObjectUnit Id="814802560" Position="88.1335,90.2631,0" Rotation="6.2048" Scale="1,1,1" UnitType="AP_SpartanCompany" Player="1"/>
+    <ObjectUnit Id="575" Position="128.9323,22.49,0" Rotation="4.1354" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1948" Position="123.5,147.5,0" Rotation="5.707" Scale="1,1,1" UnitType="RoachWarren" Player="4">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -9543,12 +9549,6 @@
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="575" Position="128.9323,22.49,0" Rotation="4.1354" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="529" Position="15.5,17.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -9619,6 +9619,13 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="520" Position="62.576,20.152,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
     <ObjectUnit Id="1963" Position="103.5,147.5,0" Rotation="5.7595" Scale="1,1,1" UnitType="InfestationPit" Player="2">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -9626,13 +9633,6 @@
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="520" Position="62.576,20.152,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="2187" Position="101.0986,58.2631,0" Rotation="0.8171" Scale="1,1,1" UnitType="SentryPurifier" Player="9">
@@ -9654,18 +9654,18 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="547" Position="37.5,6.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-    </ObjectUnit>
     <ObjectUnit Id="1920" Position="32.0383,26.3754,0" Rotation="1.433" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
+    <ObjectUnit Id="547" Position="37.5,6.5,0" Scale="1,1,1" UnitType="CreepTumorBurrowed" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="425" Position="13.5268,39.818,0" Rotation="2.0502" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -9694,6 +9694,13 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="525" Position="49.116,19.6713,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
+    </ObjectUnit>
     <ObjectUnit Id="1966" Position="109.5,147.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="BanelingNest" Player="3">
         <Flag Index="UnitHidden" Value="1"/>
         <Flag Index="ForcePlacement" Value="1"/>
@@ -9701,13 +9708,6 @@
         <AIRebuild Index="2" Value="0"/>
         <AIRebuild Index="3" Value="0"/>
         <AIRebuild Index="4" Value="0"/>
-        <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="525" Position="49.116,19.6713,0" Rotation="0.385" Scale="1,1,1" UnitType="Zergling" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="30" Position="58.698,92.7985,0" Rotation="3.6884" Scale="1,1,1" UnitType="VoidRayShakuras" Player="8">
@@ -9733,18 +9733,18 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
+    <ObjectUnit Id="570" Position="128.6003,18.1218,0" Rotation="3.871" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1945" Position="26.2724,51.9565,0" Rotation="2.3276" Scale="1,1,1" UnitType="Roach" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="570" Position="128.6003,18.1218,0" Rotation="3.871" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="1601761379" Position="94.5,89.5,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_Factory" Player="1">
         <Flag Index="ForcePlacement" Value="1"/>
@@ -9790,13 +9790,13 @@
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="781702172" Position="71.5,44.5,0" Scale="1,1,1" UnitType="AP_CreepTumorUsed" Player="1"/>
-    <ObjectUnit Id="553" Position="129.8994,16.2895,0" Rotation="3.5083" Scale="1,1,1" UnitType="Hydralisk" Player="4">
+    <ObjectUnit Id="1930" Position="11.0041,130.8796,0" Rotation="1.1545" Scale="1,1,1" UnitType="Hydralisk" Player="2">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1930" Position="11.0041,130.8796,0" Rotation="1.1545" Scale="1,1,1" UnitType="Hydralisk" Player="2">
+    <ObjectUnit Id="553" Position="129.8994,16.2895,0" Rotation="3.5083" Scale="1,1,1" UnitType="Hydralisk" Player="4">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
@@ -9845,18 +9845,18 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="560" Position="125,17,0" Rotation="4.0214" Scale="1,1,1" UnitType="SpineCrawler" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1939" Position="17.0158,39.3608,0" Rotation="3.8386" Scale="1,1,1" UnitType="Mutalisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="560" Position="125,17,0" Rotation="4.0214" Scale="1,1,1" UnitType="SpineCrawler" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="20" Position="75,114.5,0" Scale="1,1,1" UnitType="MineralField" Resources="6000"/>
     <ObjectUnit Id="127" Position="60.1713,64.5981,0" Rotation="5.463" Scale="1,1,1" UnitType="ImmortalTaldarim" Player="7">
@@ -9896,18 +9896,18 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="565" Position="124.0786,12.477,0" Rotation="3.6083" Scale="1,1,1" UnitType="Zergling" Player="4">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+    </ObjectUnit>
     <ObjectUnit Id="1942" Position="18.0512,48.3854,0" Rotation="3.7734" Scale="1,1,1" UnitType="Mutalisk" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
-    </ObjectUnit>
-    <ObjectUnit Id="565" Position="124.0786,12.477,0" Rotation="3.6083" Scale="1,1,1" UnitType="Zergling" Player="4">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
     <ObjectUnit Id="468" Position="22.6633,17.99,0" Rotation="4.146" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
@@ -9922,13 +9922,13 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
-    <ObjectUnit Id="1415771595" Position="89.9301,84.4846,0" Rotation="1.902" Scale="1,1,1" UnitType="AP_Hellion" Player="1"/>
     <ObjectUnit Id="506" Position="52.2998,11.3198,0" Rotation="0.3395" Scale="1,1,1" UnitType="Queen" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="1415771595" Position="89.9301,84.4846,0" Rotation="1.902" Scale="1,1,1" UnitType="AP_Hellion" Player="1"/>
     <ObjectUnit Id="401" Position="18.4296,47.4611,0" Rotation="2.7614" Scale="1,1,1" UnitType="Zergling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9965,7 +9965,6 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1706350176" Position="108,94,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_SupplyDepot" Player="1"/>
     <ObjectUnit Id="583" Position="31.9858,19.1816,0" Rotation="2.8242" Scale="1,1,1" UnitType="Roach" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>
@@ -9973,8 +9972,13 @@
         <AIRebuild Index="4" Value="14"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="2024870255" Position="88.5,95.5,0" Rotation="5.707" Scale="1,1,1" UnitType="AP_RoachWarren" Player="1">
-        <Flag Index="ForcePlacement" Value="1"/>
+    <ObjectUnit Id="1706350176" Position="108,94,0" Rotation="5.4975" Scale="1,1,1" UnitType="AP_SupplyDepot" Player="1"/>
+    <ObjectUnit Id="514" Position="59.9243,19.2575,0" Rotation="3.5397" Scale="1,1,1" UnitType="Hydralisk" Player="3">
+        <AIRebuild Index="1" Value="14"/>
+        <AIRebuild Index="2" Value="14"/>
+        <AIRebuild Index="3" Value="14"/>
+        <AIRebuild Index="4" Value="14"/>
+        <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
     <ObjectUnit Id="1953" Position="118,150,0" Rotation="5.9338" Scale="1,1,1" UnitType="GreaterSpire" Player="4">
         <Flag Index="UnitHidden" Value="1"/>
@@ -9985,12 +9989,8 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="514" Position="59.9243,19.2575,0" Rotation="3.5397" Scale="1,1,1" UnitType="Hydralisk" Player="3">
-        <AIRebuild Index="1" Value="14"/>
-        <AIRebuild Index="2" Value="14"/>
-        <AIRebuild Index="3" Value="14"/>
-        <AIRebuild Index="4" Value="14"/>
-        <AIFlag Index="IsUseable" Value="0"/>
+    <ObjectUnit Id="2024870255" Position="88.5,95.5,0" Rotation="5.707" Scale="1,1,1" UnitType="AP_RoachWarren" Player="1">
+        <Flag Index="ForcePlacement" Value="1"/>
     </ObjectUnit>
     <ObjectUnit Id="617" Position="12.0158,135.228,0" Rotation="0.852" Scale="1,1,1" UnitType="Zergling" Player="2">
         <AIRebuild Index="1" Value="14"/>
@@ -9998,6 +9998,7 @@
         <AIRebuild Index="3" Value="14"/>
         <AIRebuild Index="4" Value="14"/>
     </ObjectUnit>
+    <ObjectUnit Id="1103122487" Variation="8" Position="37,82.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="12000"/>
     <ObjectUnit Id="77" Position="12.822,42.6975,0" Rotation="1.953" Scale="1,1,1" UnitType="Brutalisk" Player="3">
         <AIRebuild Index="1" Value="0"/>
         <AIRebuild Index="2" Value="0"/>
@@ -10005,7 +10006,6 @@
         <AIRebuild Index="4" Value="0"/>
         <AIFlag Index="IsUseable" Value="0"/>
     </ObjectUnit>
-    <ObjectUnit Id="1103122487" Variation="8" Position="37,82.5,0" Scale="1,1,1" UnitType="RichMineralField" Resources="12000"/>
     <ObjectUnit Id="483" Position="55.462,22.4848,0" Rotation="2.7705" Scale="1,1,1" UnitType="Baneling" Player="3">
         <AIRebuild Index="1" Value="14"/>
         <AIRebuild Index="2" Value="14"/>

--- a/Maps/ArchipelagoCampaign/LotV/ap_salvation.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/LotV/ap_salvation.SC2Map/Triggers
@@ -572,6 +572,8 @@
         <FunctionCall Type="FunctionCall" Id="BCCFAFCC"/>
         <FunctionCall Type="FunctionCall" Id="9B7513CD"/>
         <FunctionCall Type="FunctionCall" Id="0EFA0BC8"/>
+        <FunctionCall Type="FunctionCall" Id="69D27F79"/>
+        <FunctionCall Type="FunctionCall" Id="DA089AF7"/>
         <FunctionCall Type="FunctionCall" Id="9C5FAAB6"/>
         <FunctionCall Type="FunctionCall" Id="07D5E9EE"/>
         <FunctionCall Type="FunctionCall" Id="79D4FC0B"/>
@@ -1183,26 +1185,57 @@
         <Variable Type="Variable" Id="F1CB27ED"/>
     </Element>
     <Element Type="FunctionCall" Id="0EFA0BC8">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="84565F53"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+        <Parameter Type="Param" Id="38A25740"/>
+    </Element>
+    <Element Type="Param" Id="38A25740">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="CF70F2A6"/>
+        <Variable Type="Variable" Id="34A58E06"/>
+    </Element>
+    <Element Type="FunctionCall" Id="69D27F79">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="024DE4CC"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+        <Parameter Type="Param" Id="A7DF8A80"/>
+        <Parameter Type="Param" Id="E73F383F"/>
+        <Parameter Type="Param" Id="A607E633"/>
+    </Element>
+    <Element Type="Param" Id="A7DF8A80">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="8845BF3B"/>
+        <Variable Type="Variable" Id="34A58E06"/>
+    </Element>
+    <Element Type="Param" Id="E73F383F">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="C30A359C"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="F5E3F3AD"/>
+    </Element>
+    <Element Type="Param" Id="A607E633">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="0BE79C23"/>
+        <FunctionCall Type="FunctionCall" Id="9ACBF6D9"/>
+    </Element>
+    <Element Type="FunctionCall" Id="9ACBF6D9">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000356"/>
+    </Element>
+    <Element Type="FunctionCall" Id="DA089AF7">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="943DF2F7"/>
         <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
-        <Parameter Type="Param" Id="DE460D5A"/>
-        <Parameter Type="Param" Id="B1D71381"/>
-        <Parameter Type="Param" Id="A48AEBD1"/>
-        <Parameter Type="Param" Id="120EE1FC"/>
+        <Parameter Type="Param" Id="B901B84A"/>
+        <Parameter Type="Param" Id="793F8FDB"/>
+        <Parameter Type="Param" Id="D5EB8BF7"/>
+        <Parameter Type="Param" Id="9EADA09D"/>
     </Element>
-    <Element Type="Param" Id="DE460D5A">
+    <Element Type="Param" Id="B901B84A">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="75FC31CB"/>
         <Variable Type="Variable" Id="34A58E06"/>
     </Element>
-    <Element Type="Param" Id="B1D71381">
+    <Element Type="Param" Id="793F8FDB">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="4AA9487D"/>
         <Preset Type="PresetValue" Library="Ntve" Id="74DE5DFF"/>
     </Element>
-    <Element Type="Param" Id="A48AEBD1">
+    <Element Type="Param" Id="D5EB8BF7">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="C93A9DCB"/>
         <Preset Type="PresetValue" Library="Ntve" Id="A9A13ADB"/>
     </Element>
-    <Element Type="Param" Id="120EE1FC">
+    <Element Type="Param" Id="9EADA09D">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="EEF303AC"/>
         <Value>600</Value>
         <ValueType Type="int"/>
@@ -6178,6 +6211,7 @@
         <Action Type="FunctionCall" Id="614071D3"/>
         <Action Type="Comment" Id="37EA4E38"/>
         <Action Type="FunctionCall" Id="5BFC940A"/>
+        <Action Type="FunctionCall" Id="30B06543"/>
         <Action Type="Comment" Id="78196C9C"/>
         <Action Type="FunctionCall" Id="D7ACD644"/>
         <Action Type="Comment" Id="B14550C1"/>
@@ -6465,6 +6499,14 @@
     </Element>
     <Element Type="Param" Id="A7109B2A">
         <ParameterDef Type="ParamDef" Library="Lbty" Id="3F42FBCD"/>
+        <Variable Type="Variable" Id="34A58E06"/>
+    </Element>
+    <Element Type="FunctionCall" Id="30B06543">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="84565F53"/>
+        <Parameter Type="Param" Id="D4F7E38D"/>
+    </Element>
+    <Element Type="Param" Id="D4F7E38D">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="CF70F2A6"/>
         <Variable Type="Variable" Id="34A58E06"/>
     </Element>
     <Element Type="Comment" Id="78196C9C">

--- a/Maps/ArchipelagoCampaign/LotV/ap_sky_shield.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/LotV/ap_sky_shield.SC2Map/MapScript.galaxy
@@ -2069,6 +2069,10 @@ bool gt_TransferFirstBaseToPlayer_Func (bool testConds, bool runActions) {
         if ((UnitGetType(lv_unit) == "AP_ZerglingRespawnControllerUnit")) {
             UnitRemove(lv_unit);
         }
+        else if ((UnitGetType(lv_unit) == "OrbitalCommand")) {
+            libNtve_gf_ReplaceUnit(lv_unit, "AP_CommandCenter", libNtve_ge_ReplaceUnitOptions_OldUnitsRelative);
+            lv_unit = libNtve_gf_LastReplacedUnit();
+        }
         else if (true) {
             lv_unitType = UnitGetType(lv_unit);
             libNtve_gf_ReplaceUnit(lv_unit, "AP_" + lv_unitType, libNtve_ge_ReplaceUnitOptions_OldUnitsRelative);
@@ -2077,6 +2081,7 @@ bool gt_TransferFirstBaseToPlayer_Func (bool testConds, bool runActions) {
         libNtve_gf_RescueUnit(lv_unit, gv_pLAYER_01_USER, true);
         lib15EF4C78_gf_AP_Player_ReapplyDefaultBehaviorsToUnit(lv_unit);
     }
+    lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_pLAYER_01_USER);
     TriggerExecute(gt_IncreaseSupplyCap, true, false);
     return true;
 }
@@ -2127,6 +2132,10 @@ bool gt_TransferSecondBaseToPlayer_Func (bool testConds, bool runActions) {
         if ((UnitGetType(lv_unit) == "AP_ZerglingRespawnControllerUnit")) {
             UnitRemove(lv_unit);
         }
+        else if ((UnitGetType(lv_unit) == "OrbitalCommand")) {
+            libNtve_gf_ReplaceUnit(lv_unit, "AP_CommandCenter", libNtve_ge_ReplaceUnitOptions_OldUnitsRelative);
+            lv_unit = libNtve_gf_LastReplacedUnit();
+        }
         else if (true) {
             lv_unitType = UnitGetType(lv_unit);
             libNtve_gf_ReplaceUnit(lv_unit, "AP_" + lv_unitType, libNtve_ge_ReplaceUnitOptions_OldUnitsRelative);
@@ -2135,6 +2144,7 @@ bool gt_TransferSecondBaseToPlayer_Func (bool testConds, bool runActions) {
         libNtve_gf_RescueUnit(lv_unit, gv_pLAYER_01_USER, true);
         lib15EF4C78_gf_AP_Player_ReapplyDefaultBehaviorsToUnit(lv_unit);
     }
+    lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_pLAYER_01_USER);
     TriggerExecute(gt_IncreaseSupplyCap, true, false);
     return true;
 }

--- a/Maps/ArchipelagoCampaign/LotV/ap_sky_shield.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/LotV/ap_sky_shield.SC2Map/Triggers
@@ -1671,6 +1671,7 @@
         <Action Type="FunctionCall" Id="FC0CEFB6"/>
         <Action Type="FunctionCall" Id="E9C90B87"/>
         <Action Type="FunctionCall" Id="661A9CA1"/>
+        <Action Type="FunctionCall" Id="8C1CD840"/>
         <Action Type="FunctionCall" Id="A6B6AAC9"/>
     </Element>
     <Element Type="Variable" Id="3601A8FE">
@@ -1933,6 +1934,7 @@
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="C0083258"/>
         <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000007"/>
         <FunctionCall Type="FunctionCall" Id="7FA31DE1"/>
+        <FunctionCall Type="FunctionCall" Id="0955C61F"/>
         <FunctionCall Type="FunctionCall" Id="3F20DBE0"/>
     </Element>
     <Element Type="FunctionCall" Id="7FA31DE1">
@@ -1976,6 +1978,80 @@
     <Element Type="Param" Id="6DD45400">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
         <Value>AP_ZerglingRespawnControllerUnit</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Unit"/>
+    </Element>
+    <Element Type="FunctionCall" Id="0955C61F">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="BB1891ED"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="C7699CD9"/>
+        <FunctionCall Type="FunctionCall" Id="8F5BF511"/>
+        <FunctionCall Type="FunctionCall" Id="17E8DBD9"/>
+        <FunctionCall Type="FunctionCall" Id="8D0B8F94"/>
+    </Element>
+    <Element Type="FunctionCall" Id="8F5BF511">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="F5662180"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="BF750C3C"/>
+        <Parameter Type="Param" Id="4D104620"/>
+        <Parameter Type="Param" Id="6C7A535D"/>
+        <Parameter Type="Param" Id="7EA354E0"/>
+    </Element>
+    <Element Type="Param" Id="4D104620">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4C513242"/>
+        <Variable Type="Variable" Id="3601A8FE"/>
+    </Element>
+    <Element Type="Param" Id="6C7A535D">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="C9FA4297"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="AC8DD36D"/>
+    </Element>
+    <Element Type="Param" Id="7EA354E0">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="C0271FCD"/>
+        <Value>AP_CommandCenter</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Unit"/>
+    </Element>
+    <Element Type="FunctionCall" Id="17E8DBD9">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000136"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="BF750C3C"/>
+        <Parameter Type="Param" Id="E9F261F9"/>
+        <Parameter Type="Param" Id="D4225416"/>
+    </Element>
+    <Element Type="Param" Id="E9F261F9">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000219"/>
+        <Variable Type="Variable" Id="3601A8FE"/>
+    </Element>
+    <Element Type="Param" Id="D4225416">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000220"/>
+        <FunctionCall Type="FunctionCall" Id="CFD3E8E8"/>
+    </Element>
+    <Element Type="FunctionCall" Id="CFD3E8E8">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="10EBC0A6"/>
+    </Element>
+    <Element Type="FunctionCall" Id="8D0B8F94">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="C60B9062"/>
+        <Parameter Type="Param" Id="66C42CC8"/>
+        <Parameter Type="Param" Id="01A73365"/>
+        <Parameter Type="Param" Id="3D41B5C3"/>
+    </Element>
+    <Element Type="Param" Id="66C42CC8">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <FunctionCall Type="FunctionCall" Id="5E45351C"/>
+    </Element>
+    <Element Type="FunctionCall" Id="5E45351C">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000079"/>
+        <Parameter Type="Param" Id="7E413B7A"/>
+    </Element>
+    <Element Type="Param" Id="7E413B7A">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000138"/>
+        <Variable Type="Variable" Id="3601A8FE"/>
+    </Element>
+    <Element Type="Param" Id="01A73365">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="3D41B5C3">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>OrbitalCommand</Value>
         <ValueType Type="gamelink"/>
         <ValueGameType Type="Unit"/>
     </Element>
@@ -2075,6 +2151,14 @@
         <ParameterDef Type="ParamDef" Library="15EF4C78" Id="FD281233"/>
         <Variable Type="Variable" Id="3601A8FE"/>
     </Element>
+    <Element Type="FunctionCall" Id="8C1CD840">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="84565F53"/>
+        <Parameter Type="Param" Id="8CF51970"/>
+    </Element>
+    <Element Type="Param" Id="8CF51970">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="CF70F2A6"/>
+        <Variable Type="Variable" Id="C1691D64"/>
+    </Element>
     <Element Type="FunctionCall" Id="A6B6AAC9">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000116"/>
         <Parameter Type="Param" Id="B811CB2A"/>
@@ -2101,6 +2185,7 @@
         <Action Type="FunctionCall" Id="79A907CE"/>
         <Action Type="FunctionCall" Id="CA4A4940"/>
         <Action Type="FunctionCall" Id="FFE5113C"/>
+        <Action Type="FunctionCall" Id="23FCECD6"/>
         <Action Type="FunctionCall" Id="E8B48652"/>
     </Element>
     <Element Type="Variable" Id="27DCC5E9">
@@ -2322,6 +2407,7 @@
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="C0083258"/>
         <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000007"/>
         <FunctionCall Type="FunctionCall" Id="64B54A75"/>
+        <FunctionCall Type="FunctionCall" Id="3C51B107"/>
         <FunctionCall Type="FunctionCall" Id="9870DAFE"/>
     </Element>
     <Element Type="FunctionCall" Id="64B54A75">
@@ -2365,6 +2451,80 @@
     <Element Type="Param" Id="CF4020E2">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
         <Value>AP_ZerglingRespawnControllerUnit</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Unit"/>
+    </Element>
+    <Element Type="FunctionCall" Id="3C51B107">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="BB1891ED"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="C7699CD9"/>
+        <FunctionCall Type="FunctionCall" Id="D86A9A6D"/>
+        <FunctionCall Type="FunctionCall" Id="13962F7E"/>
+        <FunctionCall Type="FunctionCall" Id="63584E51"/>
+    </Element>
+    <Element Type="FunctionCall" Id="D86A9A6D">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="F5662180"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="BF750C3C"/>
+        <Parameter Type="Param" Id="2F680DC9"/>
+        <Parameter Type="Param" Id="F4F37116"/>
+        <Parameter Type="Param" Id="98372FD0"/>
+    </Element>
+    <Element Type="Param" Id="2F680DC9">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4C513242"/>
+        <Variable Type="Variable" Id="27DCC5E9"/>
+    </Element>
+    <Element Type="Param" Id="F4F37116">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="C9FA4297"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="AC8DD36D"/>
+    </Element>
+    <Element Type="Param" Id="98372FD0">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="C0271FCD"/>
+        <Value>AP_CommandCenter</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Unit"/>
+    </Element>
+    <Element Type="FunctionCall" Id="13962F7E">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000136"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="BF750C3C"/>
+        <Parameter Type="Param" Id="E54ACA44"/>
+        <Parameter Type="Param" Id="C93CD0E5"/>
+    </Element>
+    <Element Type="Param" Id="E54ACA44">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000219"/>
+        <Variable Type="Variable" Id="27DCC5E9"/>
+    </Element>
+    <Element Type="Param" Id="C93CD0E5">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000220"/>
+        <FunctionCall Type="FunctionCall" Id="52F4B0C7"/>
+    </Element>
+    <Element Type="FunctionCall" Id="52F4B0C7">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="10EBC0A6"/>
+    </Element>
+    <Element Type="FunctionCall" Id="63584E51">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="C60B9062"/>
+        <Parameter Type="Param" Id="E600CCC8"/>
+        <Parameter Type="Param" Id="8E3AFC32"/>
+        <Parameter Type="Param" Id="01C4A9B3"/>
+    </Element>
+    <Element Type="Param" Id="E600CCC8">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <FunctionCall Type="FunctionCall" Id="C97FF453"/>
+    </Element>
+    <Element Type="FunctionCall" Id="C97FF453">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000079"/>
+        <Parameter Type="Param" Id="A8D22BC5"/>
+    </Element>
+    <Element Type="Param" Id="A8D22BC5">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000138"/>
+        <Variable Type="Variable" Id="27DCC5E9"/>
+    </Element>
+    <Element Type="Param" Id="8E3AFC32">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="01C4A9B3">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>OrbitalCommand</Value>
         <ValueType Type="gamelink"/>
         <ValueGameType Type="Unit"/>
     </Element>
@@ -2463,6 +2623,14 @@
     <Element Type="Param" Id="82B57D62">
         <ParameterDef Type="ParamDef" Library="15EF4C78" Id="FD281233"/>
         <Variable Type="Variable" Id="27DCC5E9"/>
+    </Element>
+    <Element Type="FunctionCall" Id="23FCECD6">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="84565F53"/>
+        <Parameter Type="Param" Id="9E5ED1B2"/>
+    </Element>
+    <Element Type="Param" Id="9E5ED1B2">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="CF70F2A6"/>
+        <Variable Type="Variable" Id="C1691D64"/>
     </Element>
     <Element Type="FunctionCall" Id="E8B48652">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000116"/>

--- a/Maps/ArchipelagoCampaign/LotV/ap_the_host.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/LotV/ap_the_host.SC2Map/MapScript.galaxy
@@ -1973,6 +1973,7 @@ bool gt_StartGameQ_Func (bool testConds, bool runActions) {
 
     TimerStart(gv_mastery_SpeedRunTimer, 1440.0, false, c_timeAI);
     UIAlertPoint("Trigger", gv_pLAYER_01_USER, StringExternal("Param/Value/976F43A0"), null, PointFromId(70));
+    lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_pLAYER_01_USER);
     libVCMI_gf_StartingWorkersAutoHarvest(RegionFromId(17), null);
     lv_i = 1;
     for ( ; ( (auto07AA8B2B_ai >= 0 && lv_i <= auto07AA8B2B_ae) || (auto07AA8B2B_ai < 0 && lv_i >= auto07AA8B2B_ae) ) ; lv_i += auto07AA8B2B_ai ) {

--- a/Maps/ArchipelagoCampaign/LotV/ap_the_host.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/LotV/ap_the_host.SC2Map/Triggers
@@ -7423,6 +7423,7 @@
         <Action Type="FunctionCall" Id="415FCE9F"/>
         <Action Type="Comment" Id="5D61BFF2"/>
         <Action Type="FunctionCall" Id="5D9EB5AD"/>
+        <Action Type="FunctionCall" Id="24B013D3"/>
         <Action Type="Comment" Id="1CAD5436"/>
         <Action Type="Comment" Id="43DB489C"/>
         <Action Type="FunctionCall" Id="07AA8B2B"/>
@@ -7515,16 +7516,24 @@
         </Comment>
     </Element>
     <Element Type="FunctionCall" Id="5D9EB5AD">
-        <FunctionDef Type="FunctionDef" Library="VCMI" Id="11A7316F"/>
-        <Parameter Type="Param" Id="A9B20BB8"/>
-        <Parameter Type="Param" Id="26448E8E"/>
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="84565F53"/>
+        <Parameter Type="Param" Id="1FC08407"/>
     </Element>
-    <Element Type="Param" Id="A9B20BB8">
+    <Element Type="Param" Id="1FC08407">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="CF70F2A6"/>
+        <Variable Type="Variable" Id="80B901F8"/>
+    </Element>
+    <Element Type="FunctionCall" Id="24B013D3">
+        <FunctionDef Type="FunctionDef" Library="VCMI" Id="11A7316F"/>
+        <Parameter Type="Param" Id="AC456806"/>
+        <Parameter Type="Param" Id="A5D9E056"/>
+    </Element>
+    <Element Type="Param" Id="AC456806">
         <ParameterDef Type="ParamDef" Library="VCMI" Id="70E22E41"/>
         <ValueType Type="region"/>
         <ValueId Id="17"/>
     </Element>
-    <Element Type="Param" Id="26448E8E">
+    <Element Type="Param" Id="A5D9E056">
         <ParameterDef Type="ParamDef" Library="VCMI" Id="E1353A15"/>
         <Preset Type="PresetValue" Library="Ntve" Id="F5E3F3AD"/>
     </Element>

--- a/Maps/ArchipelagoCampaign/WoL/ap_safe_haven.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/WoL/ap_safe_haven.SC2Map/MapScript.galaxy
@@ -693,6 +693,9 @@ bool gt_FactionSwapInit_Func (bool testConds, bool runActions) {
     unitgroup autoEBB3F6E8_g;
     int autoEBB3F6E8_u;
     unit autoEBB3F6E8_var;
+    unitgroup auto5972562D_g;
+    int auto5972562D_u;
+    unit auto5972562D_var;
     unitgroup auto871775BC_g;
     int auto871775BC_u;
     unit auto871775BC_var;
@@ -716,14 +719,20 @@ bool gt_FactionSwapInit_Func (bool testConds, bool runActions) {
                 auto25A9036C_var = UnitGroupUnitFromEnd(auto25A9036C_g, auto25A9036C_u);
                 if (auto25A9036C_var == null) { break; }
                 libNtve_gf_ReplaceUnit(auto25A9036C_var, "AP_Hive", libNtve_ge_ReplaceUnitOptions_OldUnitsRelative);
-                autoEBB3F6E8_g = UnitGroup("AP_Larva", gv_pLAYER01_USER, RegionCircle(UnitGetPosition(libNtve_gf_LastReplacedUnit()), 5.0), UnitFilter(0, 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0);
-                autoEBB3F6E8_u = UnitGroupCount(autoEBB3F6E8_g, c_unitCountAll);
-                for (;; autoEBB3F6E8_u -= 1) {
-                    autoEBB3F6E8_var = UnitGroupUnitFromEnd(autoEBB3F6E8_g, autoEBB3F6E8_u);
-                    if (autoEBB3F6E8_var == null) { break; }
-                    UnitRemove(autoEBB3F6E8_var);
-                }
-                lib15EF4C78_gf_AP_Player_SpawnLarvaForHatchery(libNtve_gf_LastReplacedUnit(), 3);
+            }
+            autoEBB3F6E8_g = UnitGroup("AP_Larva", gv_pLAYER01_USER, RegionEntireMap(), UnitFilter(0, 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0);
+            autoEBB3F6E8_u = UnitGroupCount(autoEBB3F6E8_g, c_unitCountAll);
+            for (;; autoEBB3F6E8_u -= 1) {
+                autoEBB3F6E8_var = UnitGroupUnitFromEnd(autoEBB3F6E8_g, autoEBB3F6E8_u);
+                if (autoEBB3F6E8_var == null) { break; }
+                UnitRemove(autoEBB3F6E8_var);
+            }
+            auto5972562D_g = UnitGroup("AP_Hive", gv_pLAYER01_USER, RegionEntireMap(), UnitFilter(0, 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0);
+            auto5972562D_u = UnitGroupCount(auto5972562D_g, c_unitCountAll);
+            for (;; auto5972562D_u -= 1) {
+                auto5972562D_var = UnitGroupUnitFromEnd(auto5972562D_g, auto5972562D_u);
+                if (auto5972562D_var == null) { break; }
+                lib15EF4C78_gf_AP_Player_SpawnLarvaForHatchery(auto5972562D_var, 3);
             }
             PlayerSetRace(1, "Zerg");
             lib5BD4895D_gf_AP_Core_MapConfig_setPlayerFaction(gv_pLAYER01_USER, lib5BD4895D_gv_aP_Core_Faction_KERRIGAN_SWARM);
@@ -1281,6 +1290,13 @@ void gt_DEBUGMalignantCreep_Init () {
 //--------------------------------------------------------------------------------------------------
 bool gt_IntroSequence_Func (bool testConds, bool runActions) {
     // Automatic Variable Declarations
+    unitgroup autoC84C2E97_g;
+    int autoC84C2E97_u;
+    unit autoC84C2E97_var;
+    unitgroup auto08A51CCE_g;
+    int auto08A51CCE_u;
+    unit auto08A51CCE_var;
+
     // Actions
     if (!runActions) {
         return true;
@@ -1291,6 +1307,20 @@ bool gt_IntroSequence_Func (bool testConds, bool runActions) {
     libNtve_gf_GlobalCinematicSetting(true);
     TriggerExecute(gt_StartAI, true, false);
     Wait(0.1, c_timeReal);
+    autoC84C2E97_g = UnitGroup("AP_Larva", gv_pLAYER01_USER, RegionEntireMap(), UnitFilter(0, 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0);
+    autoC84C2E97_u = UnitGroupCount(autoC84C2E97_g, c_unitCountAll);
+    for (;; autoC84C2E97_u -= 1) {
+        autoC84C2E97_var = UnitGroupUnitFromEnd(autoC84C2E97_g, autoC84C2E97_u);
+        if (autoC84C2E97_var == null) { break; }
+        UnitRemove(autoC84C2E97_var);
+    }
+    auto08A51CCE_g = UnitGroup("AP_Hive", gv_pLAYER01_USER, RegionEntireMap(), UnitFilter(0, 0, (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32))), 0);
+    auto08A51CCE_u = UnitGroupCount(auto08A51CCE_g, c_unitCountAll);
+    for (;; auto08A51CCE_u -= 1) {
+        auto08A51CCE_var = UnitGroupUnitFromEnd(auto08A51CCE_g, auto08A51CCE_u);
+        if (auto08A51CCE_var == null) { break; }
+        lib15EF4C78_gf_AP_Player_SpawnLarvaForHatchery(auto08A51CCE_var, 3);
+    }
     libNtve_gf_CinematicMode(false, PlayerGroupAll(), 1.5);
     libNtve_gf_GlobalCinematicSetting(false);
     libNtve_gf_SwooshCamera(gv_pLAYER01_USER, ((CameraInfoGetValue(CameraInfoDefault(), c_cameraValueDistance)) + 8.0), CameraInfoGetValue(CameraInfoDefault(), c_cameraValueDistance), PlayerStartLocation(gv_pLAYER01_USER), 1.5);

--- a/Maps/ArchipelagoCampaign/WoL/ap_safe_haven.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/WoL/ap_safe_haven.SC2Map/Triggers
@@ -553,6 +553,8 @@
         <FunctionCall Type="FunctionCall" Id="9B41D67F"/>
         <FunctionCall Type="FunctionCall" Id="BBC64C58"/>
         <FunctionCall Type="FunctionCall" Id="25A9036C"/>
+        <FunctionCall Type="FunctionCall" Id="EBB3F6E8"/>
+        <FunctionCall Type="FunctionCall" Id="5972562D"/>
         <FunctionCall Type="FunctionCall" Id="6AB3E2CC"/>
         <FunctionCall Type="FunctionCall" Id="A4425F2D"/>
         <FunctionCall Type="FunctionCall" Id="871775BC"/>
@@ -643,8 +645,6 @@
         <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
         <Parameter Type="Param" Id="1773A611"/>
         <FunctionCall Type="FunctionCall" Id="FE41DA15"/>
-        <FunctionCall Type="FunctionCall" Id="EBB3F6E8"/>
-        <FunctionCall Type="FunctionCall" Id="FC6DAEBC"/>
     </Element>
     <Element Type="Param" Id="1773A611">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="F96B466D"/>
@@ -710,7 +710,7 @@
     </Element>
     <Element Type="FunctionCall" Id="EBB3F6E8">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="C4DC760C"/>
-        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="9441B8B5"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
         <Parameter Type="Param" Id="81ADA976"/>
         <FunctionCall Type="FunctionCall" Id="81545641"/>
     </Element>
@@ -741,29 +741,7 @@
         <FunctionCall Type="FunctionCall" Id="360720F6"/>
     </Element>
     <Element Type="FunctionCall" Id="360720F6">
-        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000030"/>
-        <Parameter Type="Param" Id="1D33BC47"/>
-        <Parameter Type="Param" Id="ADC5B44C"/>
-    </Element>
-    <Element Type="Param" Id="1D33BC47">
-        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000049"/>
-        <FunctionCall Type="FunctionCall" Id="EF7B0C34"/>
-    </Element>
-    <Element Type="FunctionCall" Id="EF7B0C34">
-        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000083"/>
-        <Parameter Type="Param" Id="CA61442A"/>
-    </Element>
-    <Element Type="Param" Id="CA61442A">
-        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000144"/>
-        <FunctionCall Type="FunctionCall" Id="0E667DB3"/>
-    </Element>
-    <Element Type="FunctionCall" Id="0E667DB3">
-        <FunctionDef Type="FunctionDef" Library="Ntve" Id="10EBC0A6"/>
-    </Element>
-    <Element Type="Param" Id="ADC5B44C">
-        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000050"/>
-        <Value>5.0</Value>
-        <ValueType Type="fixed"/>
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000356"/>
     </Element>
     <Element Type="Param" Id="9EAE1C2A">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="00000695"/>
@@ -786,6 +764,50 @@
     <Element Type="FunctionCall" Id="06673EB8">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="19CE733E"/>
     </Element>
+    <Element Type="FunctionCall" Id="5972562D">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C4DC760C"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+        <Parameter Type="Param" Id="B1D897A6"/>
+        <FunctionCall Type="FunctionCall" Id="FC6DAEBC"/>
+    </Element>
+    <Element Type="Param" Id="B1D897A6">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="F96B466D"/>
+        <FunctionCall Type="FunctionCall" Id="9823DF07"/>
+    </Element>
+    <Element Type="FunctionCall" Id="9823DF07">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000359"/>
+        <Parameter Type="Param" Id="30929481"/>
+        <Parameter Type="Param" Id="F5041692"/>
+        <Parameter Type="Param" Id="EBA55DE7"/>
+        <Parameter Type="Param" Id="2E785CF6"/>
+        <Parameter Type="Param" Id="FD01AA56"/>
+    </Element>
+    <Element Type="Param" Id="30929481">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000691"/>
+        <Value>AP_Hive</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Unit"/>
+    </Element>
+    <Element Type="Param" Id="F5041692">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000692"/>
+        <Variable Type="Variable" Id="41340C67"/>
+    </Element>
+    <Element Type="Param" Id="EBA55DE7">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000693"/>
+        <FunctionCall Type="FunctionCall" Id="8D9E5887"/>
+    </Element>
+    <Element Type="FunctionCall" Id="8D9E5887">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000356"/>
+    </Element>
+    <Element Type="Param" Id="2E785CF6">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000695"/>
+        <Value>-;Missile,Dead,Hidden</Value>
+        <ValueType Type="unitfilter"/>
+    </Element>
+    <Element Type="Param" Id="FD01AA56">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000694"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1468BD55"/>
+    </Element>
     <Element Type="FunctionCall" Id="FC6DAEBC">
         <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="B0D3DDB6"/>
         <SubFunctionType Type="SubFuncType" Library="Ntve" Id="9441B8B5"/>
@@ -794,10 +816,10 @@
     </Element>
     <Element Type="Param" Id="453767C8">
         <ParameterDef Type="ParamDef" Library="15EF4C78" Id="DA7B34AA"/>
-        <FunctionCall Type="FunctionCall" Id="80E0185A"/>
+        <FunctionCall Type="FunctionCall" Id="329D1D38"/>
     </Element>
-    <Element Type="FunctionCall" Id="80E0185A">
-        <FunctionDef Type="FunctionDef" Library="Ntve" Id="10EBC0A6"/>
+    <Element Type="FunctionCall" Id="329D1D38">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="19CE733E"/>
     </Element>
     <Element Type="Param" Id="9C93D636">
         <ParameterDef Type="ParamDef" Library="15EF4C78" Id="A2D03B12"/>
@@ -6262,6 +6284,9 @@
         <Action Type="Comment" Id="99F5F575"/>
         <Action Type="FunctionCall" Id="9621317A"/>
         <Action Type="FunctionCall" Id="D03220FA"/>
+        <Action Type="Comment" Id="EF746E61"/>
+        <Action Type="FunctionCall" Id="C84C2E97"/>
+        <Action Type="FunctionCall" Id="08A51CCE"/>
         <Action Type="Comment" Id="7D093750"/>
         <Action Type="FunctionCall" Id="05E60A97"/>
         <Action Type="FunctionCall" Id="7437A1CC"/>
@@ -6378,6 +6403,127 @@
     <Element Type="Param" Id="222A6421">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="00000420"/>
         <Preset Type="PresetValue" Library="Ntve" Id="00000012"/>
+    </Element>
+    <Element Type="Comment" Id="EF746E61">
+        <Comment>
+            Fix disconnected larvae before they become visible
+        </Comment>
+    </Element>
+    <Element Type="FunctionCall" Id="C84C2E97">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C4DC760C"/>
+        <Parameter Type="Param" Id="17053924"/>
+        <FunctionCall Type="FunctionCall" Id="52CE667F"/>
+    </Element>
+    <Element Type="Param" Id="17053924">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="F96B466D"/>
+        <FunctionCall Type="FunctionCall" Id="5A599081"/>
+    </Element>
+    <Element Type="FunctionCall" Id="5A599081">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000359"/>
+        <Parameter Type="Param" Id="42503375"/>
+        <Parameter Type="Param" Id="DD7915FF"/>
+        <Parameter Type="Param" Id="1F7DFF8E"/>
+        <Parameter Type="Param" Id="9CE7EF06"/>
+        <Parameter Type="Param" Id="97090AB7"/>
+    </Element>
+    <Element Type="Param" Id="42503375">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000691"/>
+        <Value>AP_Larva</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Unit"/>
+    </Element>
+    <Element Type="Param" Id="DD7915FF">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000692"/>
+        <Variable Type="Variable" Id="41340C67"/>
+    </Element>
+    <Element Type="Param" Id="1F7DFF8E">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000693"/>
+        <FunctionCall Type="FunctionCall" Id="B79425FE"/>
+    </Element>
+    <Element Type="FunctionCall" Id="B79425FE">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000356"/>
+    </Element>
+    <Element Type="Param" Id="9CE7EF06">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000695"/>
+        <Value>-;Missile,Dead,Hidden</Value>
+        <ValueType Type="unitfilter"/>
+    </Element>
+    <Element Type="Param" Id="97090AB7">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000694"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1468BD55"/>
+    </Element>
+    <Element Type="FunctionCall" Id="52CE667F">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000078"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="9441B8B5"/>
+        <Parameter Type="Param" Id="6A0A0618"/>
+    </Element>
+    <Element Type="Param" Id="6A0A0618">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000137"/>
+        <FunctionCall Type="FunctionCall" Id="E8386108"/>
+    </Element>
+    <Element Type="FunctionCall" Id="E8386108">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="19CE733E"/>
+    </Element>
+    <Element Type="FunctionCall" Id="08A51CCE">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C4DC760C"/>
+        <Parameter Type="Param" Id="D6966953"/>
+        <FunctionCall Type="FunctionCall" Id="7BB9F888"/>
+    </Element>
+    <Element Type="Param" Id="D6966953">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="F96B466D"/>
+        <FunctionCall Type="FunctionCall" Id="D9E90987"/>
+    </Element>
+    <Element Type="FunctionCall" Id="D9E90987">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000359"/>
+        <Parameter Type="Param" Id="7C3E9587"/>
+        <Parameter Type="Param" Id="932E7991"/>
+        <Parameter Type="Param" Id="3FF58CDD"/>
+        <Parameter Type="Param" Id="64A014DC"/>
+        <Parameter Type="Param" Id="A49203B2"/>
+    </Element>
+    <Element Type="Param" Id="7C3E9587">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000691"/>
+        <Value>AP_Hive</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Unit"/>
+    </Element>
+    <Element Type="Param" Id="932E7991">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000692"/>
+        <Variable Type="Variable" Id="41340C67"/>
+    </Element>
+    <Element Type="Param" Id="3FF58CDD">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000693"/>
+        <FunctionCall Type="FunctionCall" Id="749F0137"/>
+    </Element>
+    <Element Type="FunctionCall" Id="749F0137">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000356"/>
+    </Element>
+    <Element Type="Param" Id="64A014DC">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000695"/>
+        <Value>-;Missile,Dead,Hidden</Value>
+        <ValueType Type="unitfilter"/>
+    </Element>
+    <Element Type="Param" Id="A49203B2">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000694"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1468BD55"/>
+    </Element>
+    <Element Type="FunctionCall" Id="7BB9F888">
+        <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="B0D3DDB6"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="9441B8B5"/>
+        <Parameter Type="Param" Id="C6FD1A8C"/>
+        <Parameter Type="Param" Id="EFBF2FF8"/>
+    </Element>
+    <Element Type="Param" Id="C6FD1A8C">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="DA7B34AA"/>
+        <FunctionCall Type="FunctionCall" Id="C39B31D5"/>
+    </Element>
+    <Element Type="FunctionCall" Id="C39B31D5">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="19CE733E"/>
+    </Element>
+    <Element Type="Param" Id="EFBF2FF8">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="A2D03B12"/>
+        <Value>3</Value>
+        <ValueType Type="int"/>
     </Element>
     <Element Type="Comment" Id="7D093750">
         <Comment>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
@@ -4111,7 +4111,7 @@
     </CRequirement>
     <CRequirement id="AP_HaveStalwartArcInducers">
         <EditorCategories value="Race:Protoss,TechType:Upgrade"/>
-        <NodeArray index="Show" Link="AP_CountUpgradeStalwartArcInducersCompleteOnly"/>
+        <NodeArray index="Use" Link="AP_CountUpgradeStalwartArcInducersCompleteOnly"/>
     </CRequirement>
     <CRequirement id="AP_HaveStalwartStabilizedElectrodes">
         <EditorCategories value="Race:Protoss,TechType:Upgrade"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/Lib15EF4C78.galaxy
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/Lib15EF4C78.galaxy
@@ -3915,7 +3915,7 @@ void lib15EF4C78_gf_AP_Player_SpawnLarvaForHatchery (unit lp_hatchery, int lp_la
 bool lib15EF4C78_gf_AP_Player_IsMineralField (unit lp_unit) {
     // Automatic Variable Declarations
     // Implementation
-    if (((UnitGetType(lp_unit) == "MineralField") || (UnitGetType(lp_unit) == "RichMineralField") || (UnitGetType(lp_unit) == ("UmojanLabMineralField")) || (UnitGetType(lp_unit) == ("BattleStationMineralField")))) {
+    if (((UnitGetType(lp_unit) == "MineralField") || (UnitGetType(lp_unit) == "RichMineralField") || (UnitGetType(lp_unit) == ("UmojanLabMineralField")) || (UnitGetType(lp_unit) == ("BattleStationMineralField")) || (UnitGetType(lp_unit) == ("PurifierRichMineralField")))) {
         return true;
     }
     else {


### PR DESCRIPTION
Fixed issues with auto-rally and auto-mining (in particular with ally control option) in following missions:
- Sky Shield
- Last Stand
- The Host
- Salvation
- Into the Void
- Amon's Fall

----

- Fixed disconnected Drones in Safe Haven (Zerg)
- Fixed Stalwart War Council item not displaying if you haven't found the item