### PR TITLE
sc2: Pygalisk and Observer adjustments

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/AbilData.xml
@@ -7359,12 +7359,12 @@
         <Cost>
             <Cooldown TimeUse="2"/>
         </Cost>
-        <AutoCastFilters value="Visible,Enemy;Self,Player,Ally,Neutral,Missile,Structure"/>
+        <AutoCastFilters value="Visible,Enemy;Self,Player,Ally,Neutral,Missile,Structure,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
         <AutoCastRange value="11"/>
         <AutoCastValidatorArray value="AP_NotHaveScopophobia"/>
         <AutoCastValidatorArray value="IsNotEgg"/>
         <AutoCastValidatorArray value="AP_IsNotLarva"/>
-        <TargetFilters value="Enemy;Self,Player,Ally,Neutral,Structure,Missile,Stasis,Dead,Hidden"/>
+        <TargetFilters value="Enemy;Self,Player,Ally,Neutral,Structure,Missile,Structure,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
         <Range value="11"/>
         <Arc value="360"/>
         <CmdButtonArray index="Execute" DefaultButtonFace="AP_Scopophobia" Requirements="AP_HaveObserverScopophobia"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -23704,8 +23704,8 @@
         <FlagArray index="UseLineOfSight" value="1"/>
         <FlagArray index="AIThreatGround" value="1"/>
         <FlagArray index="ArmySelect" value="1"/>
-        <LifeStart value="75"/>
-        <LifeMax value="75"/>
+        <LifeStart value="100"/>
+        <LifeMax value="100"/>
         <LifeArmor value="2"/>
         <LifeRegenRate value="0.2734"/>
         <LifeArmorName value="Unit/LifeArmorName/ZergGroundArmor"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/WeaponData.xml
@@ -1328,7 +1328,7 @@
         <TargetFilters value="Ground,Visible;Structure,Missile,Stasis,Dead,Hidden,Invulnerable"/>
         <AcquirePrioritization value="ByAngle"/>
         <Range value="0.1"/>
-        <Period value="0.861"/>
+        <Period value="0.95"/>
         <DamagePoint value="0.3332"/>
         <Options index="Melee" value="1"/>
         <Effect value="AP_PygaliskSet"/>


### PR DESCRIPTION
Pygalisk: Increased HP 75 -> 100, decreased attack speed by about 10% (this following discussion in the discord, see [here](https://discord.com/channels/731205301247803413/1370202172868006040/1371559575118942339) ).

Observer: Fixed scopophobia targeting destructables, reported by Sraw [here](https://discord.com/channels/731205301247803413/1154164338769268859/1370480529085960272)

I also investigated Tommygun's report of the cooldown display on scopophobia disappearing. It turns out that the counting-down cooldown disappears at <2s, and as the cooldown is 2s it disappears instantly. I could observe this effect by temporarily setting it to 4s.