### PR TITLE
Fix A Sinister Turn raceswaps

### DIFF
--- a/Maps/ArchipelagoCampaign/WoL/ap_a_sinister_turn.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/WoL/ap_a_sinister_turn.SC2Map/MapScript.galaxy
@@ -541,7 +541,6 @@ bool gt_FactionSwapInit_Func (bool testConds, bool runActions) {
         lib5BD4895D_gf_AP_Core_Util_FixPlayerMaxSupplyAfterRaceSwap(gv_p1_USER);
         libLbty_gf_OrderWorkerstoGatherNearbyResources(RegionEntireMap(), gv_p1_USER);
         lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_p1_USER);
-        TriggerExecute(gt_ObjectiveDestroyPrisonsCreateQ, true, false);
     }
     return true;
 }
@@ -2971,6 +2970,10 @@ bool gt_PlayerBuildingArmyActivatesMidCin_Func (bool testConds, bool runActions)
             return false;
         }
 
+        if (!((libNtve_gf_TriggeringProgressUnitType() != "AP_SICocoonInfestedSCV"))) {
+            return false;
+        }
+
         if (!((UnitGetOwner(EventUnitProgressUnit()) == 1))) {
             return false;
         }
@@ -3074,6 +3077,10 @@ bool gt_PlayerBuildingUnitActivatesActivatesStalker_Func (bool testConds, bool r
         }
 
         if (!((UnitFilterMatch(EventUnitProgressUnit(), gv_p1_USER, UnitFilter(0, 0, (1 << c_targetFilterStructure) | (1 << c_targetFilterWorker) | (1 << c_targetFilterMissile), (1 << (c_targetFilterDead - 32)) | (1 << (c_targetFilterHidden - 32)))) == true))) {
+            return false;
+        }
+
+        if (!((libNtve_gf_TriggeringProgressUnitType() != "AP_SICocoonInfestedSCV"))) {
             return false;
         }
 

--- a/Maps/ArchipelagoCampaign/WoL/ap_a_sinister_turn.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/WoL/ap_a_sinister_turn.SC2Map/Triggers
@@ -223,6 +223,7 @@
         <Variable Type="Variable" Id="93FA6C04"/>
     </Element>
     <Element Type="FunctionCall" Id="AFB32A0E">
+        <Disabled/>
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000116"/>
         <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000005"/>
         <Parameter Type="Param" Id="F599CA97"/>
@@ -22114,6 +22115,7 @@
     <Element Type="Trigger" Id="912517AD">
         <Event Type="FunctionCall" Id="64FECE81"/>
         <Condition Type="FunctionCall" Id="FABA254A"/>
+        <Condition Type="FunctionCall" Id="D264336F"/>
         <Condition Type="FunctionCall" Id="E709B653"/>
         <Action Type="FunctionCall" Id="0D8DB009"/>
     </Element>
@@ -22170,6 +22172,29 @@
         <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
         <Value>true</Value>
         <ValueType Type="bool"/>
+    </Element>
+    <Element Type="FunctionCall" Id="D264336F">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <Parameter Type="Param" Id="B873446A"/>
+        <Parameter Type="Param" Id="45661A89"/>
+        <Parameter Type="Param" Id="8DEA3432"/>
+    </Element>
+    <Element Type="Param" Id="B873446A">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <FunctionCall Type="FunctionCall" Id="ECF0252F"/>
+    </Element>
+    <Element Type="FunctionCall" Id="ECF0252F">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000271"/>
+    </Element>
+    <Element Type="Param" Id="45661A89">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="500677B2"/>
+    </Element>
+    <Element Type="Param" Id="8DEA3432">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>AP_SICocoonInfestedSCV</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Unit"/>
     </Element>
     <Element Type="FunctionCall" Id="E709B653">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
@@ -22607,6 +22632,7 @@
         <Event Type="FunctionCall" Id="E77608F8"/>
         <Condition Type="FunctionCall" Id="3A7DE5E7"/>
         <Condition Type="FunctionCall" Id="A139C36A"/>
+        <Condition Type="FunctionCall" Id="7836EDA4"/>
         <Condition Type="FunctionCall" Id="F926C087"/>
         <Action Type="FunctionCall" Id="EC3F3854"/>
     </Element>
@@ -22693,6 +22719,29 @@
         <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
         <Value>true</Value>
         <ValueType Type="bool"/>
+    </Element>
+    <Element Type="FunctionCall" Id="7836EDA4">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <Parameter Type="Param" Id="B0C2573A"/>
+        <Parameter Type="Param" Id="56102DB2"/>
+        <Parameter Type="Param" Id="977422DE"/>
+    </Element>
+    <Element Type="Param" Id="B0C2573A">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <FunctionCall Type="FunctionCall" Id="3A81E22B"/>
+    </Element>
+    <Element Type="FunctionCall" Id="3A81E22B">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000271"/>
+    </Element>
+    <Element Type="Param" Id="56102DB2">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="500677B2"/>
+    </Element>
+    <Element Type="Param" Id="977422DE">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>AP_SICocoonInfestedSCV</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Unit"/>
     </Element>
     <Element Type="FunctionCall" Id="F926C087">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>


### PR DESCRIPTION
- Fixed an issue where race-swapped versions of A Sinister Turn would get a 2nd blackout screen and fade-in graphics 3 seconds into the mission
- Fixed an issue where infested SCV eggs would count towards producing a "non-military unit", triggering attack waves too early