### PR TITLE
Misc Fixes

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -45091,4 +45091,28 @@
         <On Terms="ActorCreation" Send="SetOpacity"/>
         <Model value="AP_Reaver"/>
     </CActorModel>
+    <CActorSound id="AP_InfBullfrogLoadSound" parent="SoundOneShot">
+        <On Terms="AbilTransport.AP_InfBullfrogTransport.TransportLoad" Send="Create"/>
+        <Host Subject="_Selectable"/>
+        <HostSiteOps Ops="SOpAttachOriginStationary"/>
+        <Sound value="Overlord_Load"/>
+    </CActorSound>
+    <CActorSound id="AP_InfBullfrogUnloadSound" parent="SoundOneShot">
+        <On Terms="AbilTransport.AP_InfBullfrogTransport.TransportUnload" Send="Create"/>
+        <Host Subject="_Selectable"/>
+        <HostSiteOps Ops="SOpAttachOriginStationary"/>
+        <Sound value="Overlord_Unload"/>
+    </CActorSound>
+    <CActorSound id="AP_InfBullfrogLoadSound2" parent="SoundOneShot">
+        <On Terms="AbilTransport.AP_InfBullfrogTransport.TransportLoad" Send="Create"/>
+        <Host Subject="_Selectable"/>
+        <HostSiteOps Ops="SOpAttachOriginStationary"/>
+        <Sound value="Medivac_Load"/>
+    </CActorSound>
+    <CActorSound id="AP_InfBullfrogUnloadSound2" parent="SoundOneShot">
+        <On Terms="AbilTransport.AP_InfBullfrogTransport.TransportUnload" Send="Create"/>
+        <Host Subject="_Selectable"/>
+        <HostSiteOps Ops="SOpAttachOriginStationary"/>
+        <Sound value="Medivac_Unload"/>
+    </CActorSound>
 </Catalog>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -30319,7 +30319,7 @@
             <LayoutButtons index="13" removed="1"/>
             <LayoutButtons index="14" removed="1"/>
         </CardLayouts>
-        <Radius value="0.625"/>
+        <Radius value="0.5625"/>
         <LeaderAlias value="AP_Roach"/>
         <SubgroupAlias value="AP_MercRoach"/>
         <AIEvaluateAlias value="AP_MercRoach"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -22863,6 +22863,7 @@
         <Collide index="ForceField" value="1"/>
         <Collide index="Locust" value="1"/>
         <Collide index="Small" value="1"/>
+        <Collide index="Colossus" value="1"/>
         <Attributes index="Armored" value="1"/>
         <Attributes index="Biological" value="1"/>
         <Attributes index="Mechanical" value="1"/>
@@ -22938,6 +22939,7 @@
         <Collide index="ForceField" value="1"/>
         <Collide index="Locust" value="1"/>
         <Collide index="Small" value="1"/>
+        <Collide index="Colossus" value="1"/>
         <Attributes index="Armored" value="1"/>
         <Attributes index="Biological" value="1"/>
         <Attributes index="Mechanical" value="1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -17094,6 +17094,8 @@
         <EffectArray Operation="Set" Reference="Unit,AP_Archon,Collide[15]" Value="0"/>
         <EffectArray Operation="Set" Reference="Unit,AP_Archon,Collide[12]" Value="1"/>
         <EffectArray Operation="Set" Reference="Unit,AP_Archon,VisionHeight" Value="4"/>
+        <EffectArray Reference="Weapon,AP_PsionicShockwave,Range" Value="1"/>
+        <EffectArray Reference="Weapon,AP_PsionicShockwaveUpgrade,Range" Value="1"/>
         <EditorCategories value="Race:Protoss,UpgradeType:Talents"/>
     </CUpgrade>
     <CUpgrade id="AP_ArchonSiphon">

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameHotkeys.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameHotkeys.txt
@@ -437,7 +437,6 @@ Button/Hotkey/AP_Scourge=S
 Button/Hotkey/AP_ScourgeDetonate=X
 Button/Hotkey/AP_Scout=S
 Button/Hotkey/AP_ScoutNerazimCloak=C
-Button/Hotkey/AP_ScoutNerazimCloakUpgrade=C
 Button/Hotkey/AP_ScoutNerazimDecloak=D
 Button/Hotkey/AP_ScoutNerazimPhantomDash=T
 Button/Hotkey/AP_ScoutNerazimPilot=L


### PR DESCRIPTION
- fixed Mist Wing cloak hotkey with Null Shroud item
- changed Infested Bunker to collide with Colossus/Aberration
- changed Merc Roach radius so it can barely fit 1x1 building holes 
- added Bullfrog load/unload sounds
- changed Archon Transcendence (floating movement) to also grant +1 range (2 -> 3)
  - 2 range Archons are only in WoL. In HotS and LotV they get 3 range.