### PR TITLE
Misc Fixes

### DIFF
--- a/Maps/ArchipelagoCampaign/HotS/ap_harvest_of_screams.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/HotS/ap_harvest_of_screams.SC2Map/MapScript.galaxy
@@ -2735,7 +2735,7 @@ bool gt_StartFirstFlashFreezeQ_Func (bool testConds, bool runActions) {
     for (;; autoB8CFF056_u -= 1) {
         autoB8CFF056_var = UnitGroupUnitFromEnd(autoB8CFF056_g, autoB8CFF056_u);
         if (autoB8CFF056_var == null) { break; }
-        if ((autoB8CFF056_var != gv_kerrigan) && (UnitGetType(autoB8CFF056_var) != "AutomatedExtractor") && (UnitGetType(autoB8CFF056_var) != "AP_RavagerCocoon") && (UnitGetType(autoB8CFF056_var) != "AP_MedicMengsk")) {
+        if ((autoB8CFF056_var != gv_kerrigan) && (UnitGetType(autoB8CFF056_var) != "AutomatedExtractor") && (UnitGetType(autoB8CFF056_var) != "AP_RavagerCocoon") && (UnitGetType(autoB8CFF056_var) != "AP_MedicMengsk") && (UnitHasBehavior2(autoB8CFF056_var, "AP_HallucinationTimedLife") == false)) {
             gf_ReplaceUnit(autoB8CFF056_var);
         }
         else {

--- a/Maps/ArchipelagoCampaign/HotS/ap_harvest_of_screams.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/HotS/ap_harvest_of_screams.SC2Map/Triggers
@@ -17346,6 +17346,7 @@
         <FunctionCall Type="FunctionCall" Id="7FD7116A"/>
         <FunctionCall Type="FunctionCall" Id="F621E8F0"/>
         <FunctionCall Type="FunctionCall" Id="F6041F66"/>
+        <FunctionCall Type="FunctionCall" Id="C7993915"/>
     </Element>
     <Element Type="FunctionCall" Id="EE050117">
         <FunctionDef Type="FunctionDef" Id="614A336A"/>
@@ -17538,6 +17539,44 @@
         <Value>AP_MedicMengsk</Value>
         <ValueType Type="gamelink"/>
         <ValueGameType Type="Unit"/>
+    </Element>
+    <Element Type="FunctionCall" Id="C7993915">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000003"/>
+        <Parameter Type="Param" Id="8A6085C4"/>
+        <Parameter Type="Param" Id="AF6AFD71"/>
+        <Parameter Type="Param" Id="96577966"/>
+    </Element>
+    <Element Type="Param" Id="8A6085C4">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <FunctionCall Type="FunctionCall" Id="10FE8170"/>
+    </Element>
+    <Element Type="FunctionCall" Id="10FE8170">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="142FF15A"/>
+        <Parameter Type="Param" Id="DC314357"/>
+        <Parameter Type="Param" Id="C464F12D"/>
+    </Element>
+    <Element Type="Param" Id="DC314357">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="033DFD05"/>
+        <FunctionCall Type="FunctionCall" Id="B6BE062B"/>
+    </Element>
+    <Element Type="FunctionCall" Id="B6BE062B">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="19CE733E"/>
+    </Element>
+    <Element Type="Param" Id="C464F12D">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="B29EDD13"/>
+        <Value>AP_HallucinationTimedLife</Value>
+        <ValueType Type="gamelink"/>
+        <ValueGameType Type="Behavior"/>
+    </Element>
+    <Element Type="Param" Id="AF6AFD71">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="96577966">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>false</Value>
+        <ValueType Type="bool"/>
     </Element>
     <Element Type="FunctionCall" Id="9E014DF2">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000116"/>

--- a/Maps/ArchipelagoCampaign/WoL/ap_a_sinister_turn.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/WoL/ap_a_sinister_turn.SC2Map/MapScript.galaxy
@@ -542,6 +542,7 @@ bool gt_FactionSwapInit_Func (bool testConds, bool runActions) {
         libLbty_gf_OrderWorkerstoGatherNearbyResources(RegionEntireMap(), gv_p1_USER);
         lib15EF4C78_gf_AP_Player_UtilTownHallAutoRally(gv_p1_USER);
     }
+    VisRevealArea(gv_p1_USER, RegionFromId(34), 0.0625, true);
     return true;
 }
 

--- a/Maps/ArchipelagoCampaign/WoL/ap_a_sinister_turn.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/WoL/ap_a_sinister_turn.SC2Map/Triggers
@@ -21,6 +21,7 @@
     </Element>
     <Element Type="Trigger" Id="2CF54025">
         <Action Type="FunctionCall" Id="B3FAB1C2"/>
+        <Action Type="FunctionCall" Id="7FBF3537"/>
     </Element>
     <Element Type="FunctionCall" Id="B3FAB1C2">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000137"/>
@@ -286,6 +287,31 @@
         <Value>Neut</Value>
         <ValueType Type="gamelink"/>
         <ValueGameType Type="Race"/>
+    </Element>
+    <Element Type="FunctionCall" Id="7FBF3537">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="685AF92D"/>
+        <Parameter Type="Param" Id="8EC0B67F"/>
+        <Parameter Type="Param" Id="354CFAFA"/>
+        <Parameter Type="Param" Id="29DD0E70"/>
+        <Parameter Type="Param" Id="272B02D3"/>
+    </Element>
+    <Element Type="Param" Id="8EC0B67F">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="654EA30A"/>
+        <Variable Type="Variable" Id="93FA6C04"/>
+    </Element>
+    <Element Type="Param" Id="354CFAFA">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="9EE40FDE"/>
+        <Value>0.0625</Value>
+        <ValueType Type="fixed"/>
+    </Element>
+    <Element Type="Param" Id="29DD0E70">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="415394EA"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="00000071"/>
+    </Element>
+    <Element Type="Param" Id="272B02D3">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="A8FE7C12"/>
+        <ValueType Type="region"/>
+        <ValueId Id="34"/>
     </Element>
     <Element Type="Category" Id="121282A3">
         <Item Type="Variable" Id="F143006D"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -7200,7 +7200,7 @@
         <AbilArray Link="AP_ArmoryResearch"/>
         <AbilArray Link="AP_ArmoryResearch2"/>
         <BehaviorArray Link="TerranBuildingBurnDown"/>
-        <BehaviorArray Link="FireSuppressionSystem"/>
+        <BehaviorArray Link="AP_FireSuppressionSystem"/>
         <CardLayouts>
             <LayoutButtons Face="Cancel" Type="AbilCmd" AbilCmd="que5,CancelLast" Row="2" Column="4"/>
             <LayoutButtons Face="CancelBuilding" Type="AbilCmd" AbilCmd="BuildInProgress,Cancel" Row="2" Column="4"/>


### PR DESCRIPTION
Harvest of Screams
- fixed Hallucinations becoming real units during the first Flash Freeze

A Sinister Turn:
- fixed visible creep near main base in Fog of War

Armory
- fixed incorrect Fire Suppression behavior