### PR TITLE
fix Elder Probe charges

### DIFF
--- a/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
+++ b/Mods/ArchipelagoTriggers.SC2Mod/Base.SC2Data/LibABFE498B.galaxy
@@ -10010,6 +10010,7 @@ bool auto_libABFE498B_gf_AP_Triggers_resetBase_TriggerFunc (bool testConds, bool
     libNtve_gf_PlayerRemoveCooldown(lp_player, "Abil/AP_ElderProbeWarpin");
     PlayerAddCooldown(lp_player, "Abil/AP_ElderProbeWarpin", 60.0);
     lib15EF4C78_gf_AP_Player_clearZerglingRespawnChargesFromPlayer(lp_player);
+    PlayerAddChargeUsed(lp_player, "Abil/AP_ElderProbeReconstruction", 5.0);
     return true;
 }
 


### PR DESCRIPTION
Elder Probes:
- fixed getting too many Reconstruction charges in missions with no-build sections