### PR TITLE
Bugs and Balance

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/BehaviorData.xml
@@ -4369,7 +4369,7 @@
     </CBehaviorBuff>
     <CBehaviorBuff id="AP_AdeptPsionicTransferDamageBuff">
         <Alignment value="Positive"/>
-        <Requirements value="AP_HaveAdeptDisruptiveTransfer"/>
+        <Requirements value="AP_HaveAdeptDisruptiveTransferEffect"/>
         <InfoIcon value="Assets\Textures\btn-ability-protoss-psionictransfer.dds"/>
         <EditorCategories value="Race:Protoss,AbilityorEffectType:Units"/>
         <Period value="0.2"/>
@@ -7587,13 +7587,10 @@
         <Requirements value="AP_NotHaveK5CreepBonuses"/>
     </CBehaviorCreepSource>
     <CBehaviorBuff id="AP_ImpalingStrike">
-        <DamageResponse Handled="AP_ImpalingStrikeAB" Location="Attacker">
-            <RequireEffectArray value="AP_HotSUltraliskKaiserBladesDamage"/>
-            <RequireEffectArray value="AP_HotSUltraliskKaiserBladesSecondaryDamage"/>
-            <RequireEffectArray value="AP_HotSUltraliskKaiserBladesSecondaryUpgradeDamage"/>
+        <DamageResponse Handled="AP_ImpalingStrikeSet" Location="Attacker">
             <RequireEffectArray value="AP_TyrannozorKaiserBladesDamage"/>
             <RequireEffectArray value="AP_TyrannozorKaiserBladesSecondaryDamage"/>
-            <Chance value="0.2"/>
+            <Chance value="0.3"/>
         </DamageResponse>
         <InfoFlags index="Hidden" value="1"/>
         <DisableValidatorArray value="AP_HaveImpalingStrike"/>
@@ -7605,10 +7602,16 @@
         <Alignment value="Negative"/>
         <BehaviorCategories index="Stun" value="1"/>
         <EditorCategories value="AbilityorEffectType:Units"/>
-        <Duration value="2"/>
+        <Duration value="1.5"/>
         <Modification>
             <StateFlags index="Stun" value="1"/>
         </Modification>
+    </CBehaviorBuff>
+    <CBehaviorBuff id="AP_ImpalingStrikeResist">
+        <InfoFlags index="Hidden" value="1"/>
+        <InfoIcon value="Assets\Textures\btn-ability-zerg-dehaka-ultralisk-impalingstrike.dds"/>
+        <EditorCategories value="AbilityorEffectType:Units"/>
+        <Duration value="4.5"/>
     </CBehaviorBuff>
     <CBehaviorBuff id="AP_TyrannozorTyrantsProtectionCaster">
         <InfoFlags index="Hidden" value="1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -18567,7 +18567,7 @@
         <AmmoUnit value="AP_TyrannozorAAWeapon"/>
     </CEffectLaunchMissile>
     <CEffectDamage id="AP_TyrannozorMissileLaunchersDamage" parent="DU_WEAP">
-        <Amount value="15"/>
+        <Amount value="16"/>
         <EditorCategories value="Race:Zerg"/>
         <Death value="Eviscerate"/>
     </CEffectDamage>
@@ -18586,7 +18586,7 @@
     </CEffectEnumArea>
     <CEffectDamage id="AP_TyrannozorKaiserBladesDamage" parent="DU_WEAP">
         <EditorCategories value="Race:Zerg"/>
-        <Amount value="35"/>
+        <Amount value="40"/>
         <Death value="Eviscerate"/>
     </CEffectDamage>
     <CEffectDamage id="AP_TyrannozorKaiserBladesSecondaryDamage" parent="DU_WEAP">
@@ -18594,10 +18594,22 @@
         <Amount value="5"/>
         <Death value="Eviscerate"/>
     </CEffectDamage>
+    <CEffectSet id="AP_ImpalingStrikeSet">
+        <EditorCategories value="Race:Terran"/>
+        <EffectArray value="AP_ImpalingStrikeAB"/>
+        <EffectArray value="AP_ImpalingStrikeResistAB"/>
+    </CEffectSet>
     <CEffectApplyBehavior id="AP_ImpalingStrikeAB">
         <Behavior value="AP_ImpalingStrikeStun"/>
         <ValidatorArray index="0" value="AP_NotHeroic"/>
         <ValidatorArray value="NotStructure"/>
+        <ValidatorArray value="AP_NotHaveImpalingStrikeResist"/>
+    </CEffectApplyBehavior>
+    <CEffectApplyBehavior id="AP_ImpalingStrikeResistAB">
+        <Behavior value="AP_ImpalingStrikeResist"/>
+        <ValidatorArray index="0" value="AP_NotHeroic"/>
+        <ValidatorArray value="NotStructure"/>
+        <ValidatorArray value="AP_NotHaveImpalingStrikeResist"/>
     </CEffectApplyBehavior>
     <CEffectApplyBehavior id="AP_PredatorCloakAB">
         <Behavior value="AP_PredatorCloak"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/RequirementData.xml
@@ -2824,6 +2824,10 @@
         <EditorCategories value="Race:Protoss,TechType:Ability"/>
         <NodeArray index="Show" Link="AP_CountUpgradeAdeptShieldUpgradeCompleteOnly"/>
     </CRequirement>
+    <CRequirement id="AP_HaveAdeptDisruptiveTransferEffect">
+        <EditorCategories value="Race:Protoss,TechType:Ability"/>
+        <NodeArray index="Use" Link="AP_CountUpgradeAdeptDisruptiveTransferCompleteOnly"/>
+    </CRequirement>
     <CRequirement id="AP_HaveAdeptDisruptiveTransfer">
         <EditorCategories value="Race:Protoss,TechType:Ability"/>
         <NodeArray index="Use" Link="AP_CountUpgradeAdeptDisruptiveTransferCompleteOnly"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -23421,12 +23421,8 @@
         <BehaviorArray Link="AP_TorrasqueDontDie"/>
         <BehaviorArray Link="AP_NoxiousDamageAura"/>
         <BehaviorArray Link="AP_CreepFrenzy13Crawler"/>
-        <BehaviorArray Link="AP_ImpalingStrike"/>
         <BehaviorArray Link="AP_UltraliskOrganicCarapaceIndicator"/>
-        <BehaviorArray Link="AP_AnabolicSynthesisIndicator"/>
-        <BehaviorArray Link="AP_ChitinousPlatingIndicator"/>
         <BehaviorArray Link="AP_MonarchBladesIndicator"/>
-        <BehaviorArray Link="AP_HealingAdaption"/>
         <BehaviorArray Link="AP_MorphUltraliskResourceEfficiency"/>
         <WeaponArray Link="AP_KaiserBlades"/>
         <WeaponArray/>
@@ -23457,10 +23453,8 @@
             </LayoutButtons>
             <LayoutButtons Face="AP_TissueAssimilation" Type="Passive" Requirements="AP_HaveHotSTissueAssimilation" Row="1" Column="1"/>
             <!-- moved to behaivors LayoutButtons Face="AP_MonarchBlades" Type="Passive" Requirements="AP_HaveHotSMonarchBlades" Row="1" Column="2"/-->
-            <!-- moved to behaivors LayoutButtons Face="AP_AnabolicSynthesis" Type="Passive" Requirements="AP_HaveAnabolicSynthesis" Row="1" Column="3"/-->
-            <!-- moved to behaivors LayoutButtons Face="AP_ChitinousPlating" Type="Passive" Requirements="AP_HaveChitinousPlating" Row="1" Column="4"/-->
-            <LayoutButtons Face="AP_ImpalingStrike" Type="Passive" Requirements="AP_HaveImpalingStrike" Row="1" Column="3"/>
-            <LayoutButtons Face="AP_HealingAdaptation" Type="Passive" Requirements="AP_HaveHealingAdaptation" Row="1" Column="4"/>
+            <LayoutButtons Face="AP_AnabolicSynthesis" Type="Passive" Requirements="AP_HaveAnabolicSynthesis" Row="1" Column="3"/>
+            <LayoutButtons Face="AP_ChitinousPlating" Type="Passive" Requirements="AP_HaveChitinousPlating" Row="1" Column="4"/>
             <LayoutButtons Face="AP_NoxiousCloud" Type="Passive" Requirements="AP_HaveHotSNoxious" Row="1" Column="0"/>
             <LayoutButtons Face="AP_PoisonNova" Type="AbilCmd" AbilCmd="AP_PoisonNova,Execute" Row="2" Column="1"/>
             <LayoutButtons Face="AP_TyrannozorMerge" Type="AbilCmd" AbilCmd="AP_TyrannozorMerge,0" Row="2" Column="2"/>
@@ -23541,10 +23535,7 @@
         <BehaviorArray Link="Frenzy"/>
         <BehaviorArray Link="AP_TorrasqueDontDie"/>
         <BehaviorArray Link="AP_CreepFrenzy13Crawler"/>
-        <BehaviorArray Link="AP_HealingAdaption"/>
         <BehaviorArray Link="AP_UltraliskOrganicCarapaceIndicator"/>
-        <BehaviorArray Link="AP_AnabolicSynthesisIndicator"/>
-        <BehaviorArray Link="AP_ChitinousPlatingIndicator"/>
         <BehaviorArray Link="AP_MonarchBladesIndicator"/>
         <CardLayouts>
             <LayoutButtons Face="Attack" Type="AbilCmd" AbilCmd="attack,Execute" Row="0" Column="4"/>
@@ -23567,8 +23558,8 @@
                 <Column value="2"/>
             </LayoutButtons>
             <!-- moved to behaivors LayoutButtons Face="AP_MonarchBlades" Type="Passive" Requirements="AP_HaveHotSMonarchBlades" Row="1" Column="2"/-->
-            <!-- moved to behaivors LayoutButtons Face="AP_AnabolicSynthesis" Type="Passive" Requirements="AP_HaveAnabolicSynthesis" Row="1" Column="3"/-->
-            <!-- moved to behaivors LayoutButtons Face="AP_ChitinousPlating" Type="Passive" Requirements="AP_HaveChitinousPlating" Row="1" Column="4"/-->
+            <LayoutButtons Face="AP_AnabolicSynthesis" Type="Passive" Requirements="AP_HaveAnabolicSynthesis" Row="1" Column="3"/>
+            <LayoutButtons Face="AP_ChitinousPlating" Type="Passive" Requirements="AP_HaveChitinousPlating" Row="1" Column="4"/>
             <LayoutButtons Face="AP_ImpalingStrike" Type="Passive" Requirements="AP_HaveImpalingStrike" Row="1" Column="3"/>
             <LayoutButtons Face="AP_HealingAdaptation" Type="Passive" Requirements="AP_HaveHealingAdaptation" Row="1" Column="4"/>
             <LayoutButtons Face="AP_TissueAssimilation" Type="Passive" Requirements="AP_HaveHotSTissueAssimilation" Row="1" Column="1"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UpgradeData.xml
@@ -16566,16 +16566,10 @@
         <Icon value="Assets\Textures\btn-ability-zerg-dehaka-tyrannozor-barrageofspikes.dds"/>
     </CUpgrade>
     <CUpgrade id="AP_ImpalingStrike">
-        <AffectedUnitArray value="AP_Ultralisk"/>
-        <AffectedUnitArray value="AP_MercUltralisk"/>
         <AffectedUnitArray value="AP_Tyrannozor"/>
         <Icon value="Assets\Textures\btn-ability-zerg-dehaka-ultralisk-impalingstrike.dds"/>
     </CUpgrade>
     <CUpgrade id="AP_HealingAdaptation">
-        <AffectedUnitArray value="AP_Ultralisk"/>
-        <AffectedUnitArray value="AP_UltraliskBurrowed"/>
-        <AffectedUnitArray value="AP_MercUltralisk"/>
-        <AffectedUnitArray value="AP_MercUltraliskBurrowed"/>
         <AffectedUnitArray value="AP_Tyrannozor"/>
         <AffectedUnitArray value="AP_TyrannozorBurrowed"/>
         <Icon value="Assets\Textures\btn-ability-zerg-dehaka-ultralisk-healingadaptation.dds"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ValidatorData.xml
@@ -135,6 +135,9 @@
         <CombineArray value="AP_SourceIsNotAPHellion"/>
         <Type value="And"/>
     </CValidatorCombine>
+    <CValidatorUnitCompareBehaviorCount id="AP_NotHaveImpalingStrikeResist">
+        <Behavior value="AP_ImpalingStrikeResist"/>
+    </CValidatorUnitCompareBehaviorCount>
     <CValidatorUnitCompareBehaviorCount id="AP_AtLeastOneHealBeamBusy">
         <WhichUnit Value="Caster"/>
         <Compare value="GE"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -2774,7 +2774,7 @@ Button/Tooltip/AP_HealMengskHealL2=<c val="f078ff">Heals <d ref="Effect,AP_Medic
 Button/Tooltip/AP_HealMengskHealL3=<c val="f078ff">Heals <d ref="Effect,AP_MedicMengskHealL3,RechargeVitalRate" precision="2"/> life per <d ref="Effect,AP_MedicMengskHealL3,RechargeVitalRate * Effect,AP_MedicMengskHealL3,DrainVitalCostFactor"  precision="2"/> energy.</c>
 Button/Tooltip/AP_HealMengskHealL4=<c val="f078ff">Heals <d ref="Effect,AP_MedicMengskHealModifyTargetLife,VitalArray[Life].Change / Effect,AP_MedicMengskHealTargetPersistent,PeriodicPeriodArray[0]" precision="2"/> life per <d ref="-Effect,AP_MedicMengskHealModifyCasterEnergy,VitalArray[Energy].Change / Effect,AP_MedicMengskHealTargetPersistent,PeriodicPeriodArray[0]" precision="2"/> energy.</c>
 Button/Tooltip/AP_HealMengskPlusMech=Heals a friendly biological or mechanical target.<n/><n/>
-Button/Tooltip/AP_HealingAdaptation=Ultralisks and Tyrannozors regenerate life quickly when out of combat.
+Button/Tooltip/AP_HealingAdaptation=Tyrannozors regenerate life quickly when out of combat.
 Button/Tooltip/AP_HealingDrone=Heals nearby biological and mechanical units.<n/>Times out after <d ref="Behavior,AP_HealingDroneTimedLife,Duration"/> seconds.
 Button/Tooltip/AP_HealingPsionicStorm=Psionic Storm can be cast from +<d ref="Upgrade,AP_HighTemplarPlasmaSurge,EffectArray[3].Value"/> range, affects a larger area, and restores <d ref="((Effect,AP_HighArchonPsiStormPersistent,PeriodCount+1)*(Effect,AP_HighArchonPsiStormHeal,RechargeVitalRate))/2"/> shields to friendly units in the target area.<c/>
 Button/Tooltip/AP_HellArmor=Increases Hellion and Hellbat armor by 2.
@@ -2882,7 +2882,7 @@ Button/Tooltip/AP_ImpalerDen=<c val="ffff8a">Enables:</c><n/>- Impalers from Hyd
 Button/Tooltip/AP_ImpalerEgg=This cocoon contains a Hydralisk that is morphing into an Impaler.
 Button/Tooltip/AP_ImpalerGenerateCreep=Generates creep while standing still or burrowed.
 Button/Tooltip/AP_ImpalerPassive=Impaler Den enables you to morph Impalers from Hydralisks.
-Button/Tooltip/AP_ImpalingStrike=Ultralisk and Tyrannozor melee attacks have a 20% chance to stun for 2 seconds.
+Button/Tooltip/AP_ImpalingStrike=Tyrannozor melee attacks have a <d ref="Behavior,AP_ImpalingStrike,DamageResponse.Chance*100"/>% chance to stun for <d ref="Behavior,AP_ImpalingStrikeStun,Duration" precision="1"/> seconds.
 Button/Tooltip/AP_ImpalingStrikeStun=This unit is stunned due to Impaling Strike.
 Button/Tooltip/AP_ImprovedIonCannons=Improves Ion Cannon weapon damage by 2.
 Button/Tooltip/AP_ImprovedNanoRepair=Science Vessel's Nano-Repair no longer costs energy.


### PR DESCRIPTION
Fixed an issue with Adept Disruptive Transfer item not working properly under some conditions

Tyrannozor Re-adjustments:
Melee attack damage increased to 40 (from 35)
Anti-air attack damage increased to 16 (from 15)
Impaling Strike Rework:
- Now has a 30% chance to stun for 1.5 seconds (was a 20% chance to stun for 2 seconds).
- Units that are stunned cannot be stunned again for 3 seconds after the stun expires. Goal of this is to prevent enemies from getting stunlocked by high-rolling impaling strike, and to make the ability more consistent.

Removed Healing Adaptation and Impaling Strike from Ultralisks.
Reasoning:
- Devs generally want to stray away from abilities that buff an entire class of units instead of specific units.
- Want to give Tyrannozors a more distinct role from Ultralisks. While ultralisks have more cleave potential and self sustain, we want to focus on giving Tyrannozor's a different niche. Hence the buff's to their primary attacks and out-of-combat regeneration, niches that Ultralisks don't really fill.