### PR TITLE
sc2: Fix Bile Launcher description saying it can hit air

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoPlayer.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -2457,7 +2457,7 @@ Button/Tooltip/AP_BattlecruiserRangeAura=Grants nearby friendly ranged ground un
 Button/Tooltip/AP_BehemothPlating=Increases Battlecruiser armor by 2.
 Button/Tooltip/AP_BileLauncherArtilleryDucts=Increases the range of the Bile Launcher's Bombardment by <d ref="$UpgradeEffectArrayValue:AP_BileLauncherArtilleryDucts:Weapon,AP_BileLauncherBombardment,Range$"/>.
 Button/Tooltip/AP_BileLauncherBesideSpawningPool=The Bile Launcher deals +<d ref="Behavior,AP_BileLauncherBesideSpawningPool,Modification.DamageDealtScaled[Splash]"/> damage if placed beside a Spawning Pool.
-Button/Tooltip/AP_BileLauncherBombardment=Constantly blasts a target area, repeatedly dealing <d ref="Effect,AP_BileLauncherBombardmentDamage,Amount"/> damage to enemy ground and air units.
+Button/Tooltip/AP_BileLauncherBombardment=Constantly blasts a target area, repeatedly dealing <d ref="Effect,AP_BileLauncherBombardmentDamage,Amount"/> damage to enemy ground units.
 Button/Tooltip/AP_BileLauncherRapidBombardment=Reduces the cooldown of the Bile Launcher's Bombardment.
 Button/Tooltip/AP_BioMechanicalHeal=Heals a friendly biological or mechanical unit.<n/><n/><c val="f078ff">Heals <d ref="Effect,AP_HealingDroneHeal,RechargeVitalRate[0]"/> life per second.</c>
 Button/Tooltip/AP_BioMechanicalStockpiling=Infested Factories and Starports can store 3 additional unit charges.


### PR DESCRIPTION
Fixing an issue where the bile launcher bombardment tooltip would say it could hit air.

<img width="553" height="164" alt="image" src="https://github.com/user-attachments/assets/c6bc0a9e-175f-4c0d-b449-06eb67bcb0b8" />
