### PR TITLE
SC2: Allow testing missions from editor

### DIFF
--- a/Mods/ArchipelagoCore.SC2Mod/Base.SC2Data/Lib5BD4895D.galaxy
+++ b/Mods/ArchipelagoCore.SC2Mod/Base.SC2Data/Lib5BD4895D.galaxy
@@ -1657,6 +1657,11 @@ bool lib5BD4895D_gt_AP_Core_mapLoadStart_Func (bool testConds, bool runActions) 
     libNtve_gf_SetDialogItemImage(lib5BD4895D_gv_aP_Core_blackScreen, "Assets\\Textures\\ui_ingame_blackmask.dds", PlayerGroupAll());
     libNtve_gf_SetDialogItemBlendMode(lib5BD4895D_gv_aP_Core_blackScreen, c_triggerBlendModeAlpha, PlayerGroupAll());
     DialogSetVisible(lib5BD4895D_gv_aP_Core_blackScreen_dialog, PlayerGroupAll(), true);
+    if ((GameIsTestMap(false) == true)) {
+        Wait(0.0625, c_timeGame);
+        TriggerExecute(lib5BD4895D_gt_AP_Triggers_loadFinished, true, false);
+    }
+
     return true;
 }
 
@@ -1693,6 +1698,10 @@ bool lib5BD4895D_gt_AP_Core_mapLoadEnd_Func (bool testConds, bool runActions) {
     DialogControlFadeTransparency(lib5BD4895D_gv_aP_Core_blackScreen, PlayerGroupAll(), lv_duration, 0.0);
     Wait(lv_duration, c_timeReal);
     DialogDestroy(lib5BD4895D_gv_aP_Core_blackScreen_dialog);
+    if ((GameIsTestMap(false) == true)) {
+        TriggerDebugOutput(1, StringExternal("Param/Value/lib_5BD4895D_FD3A182F"), true);
+    }
+
     return true;
 }
 

--- a/Mods/ArchipelagoCore.SC2Mod/Triggers
+++ b/Mods/ArchipelagoCore.SC2Mod/Triggers
@@ -665,6 +665,7 @@
             <Action Type="FunctionCall" Library="5BD4895D" Id="5512C818"/>
             <Action Type="FunctionCall" Library="5BD4895D" Id="DBD20837"/>
             <Action Type="FunctionCall" Library="5BD4895D" Id="8D903C59"/>
+            <Action Type="FunctionCall" Library="5BD4895D" Id="1D4468AD"/>
         </Element>
         <Element Type="FunctionCall" Id="363E87A5">
             <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000120"/>
@@ -861,6 +862,89 @@
             <ParameterDef Type="ParamDef" Library="Ntve" Id="25A88BC6"/>
             <Preset Type="PresetValue" Library="Ntve" Id="00000120"/>
         </Element>
+        <Element Type="FunctionCall" Id="1D4468AD">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000137"/>
+            <FunctionCall Type="Comment" Library="5BD4895D" Id="ED04263B"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="1CB61433"/>
+            <FunctionCall Type="Comment" Library="5BD4895D" Id="DAB80810"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="06023349"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="5B6C03BA"/>
+        </Element>
+        <Element Type="Comment" Id="ED04263B">
+            <Comment>
+                Map is started with the &quot;Test Document&quot; button from Editor
+            </Comment>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+        </Element>
+        <Element Type="FunctionCall" Id="1CB61433">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000242"/>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="485378F7"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="D5093C8F"/>
+        </Element>
+        <Element Type="Param" Id="485378F7">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="00000419"/>
+            <Value>0.0625</Value>
+            <ValueType Type="fixed"/>
+        </Element>
+        <Element Type="Param" Id="D5093C8F">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="00000420"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000013"/>
+        </Element>
+        <Element Type="Comment" Id="DAB80810">
+            <Comment>
+                needs a wait
+            </Comment>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+        </Element>
+        <Element Type="FunctionCall" Id="06023349">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000116"/>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="ACEEC89E"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="5D75B1E3"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="DA97FAF5"/>
+        </Element>
+        <Element Type="Param" Id="ACEEC89E">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="00000183"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000065"/>
+        </Element>
+        <Element Type="Param" Id="5D75B1E3">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="00000184"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000068"/>
+        </Element>
+        <Element Type="Param" Id="DA97FAF5">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="00000182"/>
+            <ValueType Type="trigger"/>
+            <ValueElement Type="Trigger" Library="5BD4895D" Id="4863529C"/>
+        </Element>
+        <Element Type="FunctionCall" Id="5B6C03BA">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000003"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="723F2CB2"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="94FCA9D9"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="2E7A61FE"/>
+        </Element>
+        <Element Type="Param" Id="723F2CB2">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="CC8C6548"/>
+        </Element>
+        <Element Type="FunctionCall" Id="CC8C6548">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="40844EC3"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="8E77CC9F"/>
+        </Element>
+        <Element Type="Param" Id="8E77CC9F">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="51D3A7CE"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="BE13E79D"/>
+        </Element>
+        <Element Type="Param" Id="94FCA9D9">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+        </Element>
+        <Element Type="Param" Id="2E7A61FE">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+            <Value>true</Value>
+            <ValueType Type="bool"/>
+        </Element>
         <Element Type="Trigger" Id="CB983523">
             <Variable Type="Variable" Library="5BD4895D" Id="80482A34"/>
             <Event Type="FunctionCall" Library="5BD4895D" Id="DCF56985"/>
@@ -869,6 +953,7 @@
             <Action Type="FunctionCall" Library="5BD4895D" Id="6BA49D24"/>
             <Action Type="FunctionCall" Library="5BD4895D" Id="EA900063"/>
             <Action Type="FunctionCall" Library="5BD4895D" Id="F37902B2"/>
+            <Action Type="FunctionCall" Library="5BD4895D" Id="9057E13F"/>
         </Element>
         <Element Type="Variable" Id="80482A34">
             <VariableType>
@@ -976,6 +1061,65 @@
         <Element Type="Param" Id="85B043E3">
             <ParameterDef Type="ParamDef" Library="Ntve" Id="C5AA206D"/>
             <Variable Type="Variable" Library="5BD4895D" Id="7A01FE6A"/>
+        </Element>
+        <Element Type="FunctionCall" Id="9057E13F">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000137"/>
+            <FunctionCall Type="Comment" Library="5BD4895D" Id="BFC9B350"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="EF239598"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="23DCDAB4"/>
+        </Element>
+        <Element Type="Comment" Id="BFC9B350">
+            <Comment>
+                Map is started with the &quot;Test Document&quot; button from Editor
+            </Comment>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+        </Element>
+        <Element Type="FunctionCall" Id="EF239598">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000118"/>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000004"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="1FFAE581"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="14574554"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="FD3A182F"/>
+        </Element>
+        <Element Type="Param" Id="1FFAE581">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="C3CF50B0"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="AEB4446D"/>
+        </Element>
+        <Element Type="Param" Id="14574554">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="00000187"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="00000071"/>
+        </Element>
+        <Element Type="Param" Id="FD3A182F">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="00000186"/>
+            <ValueType Type="text"/>
+        </Element>
+        <Element Type="FunctionCall" Id="23DCDAB4">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+            <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000003"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="22F7EF81"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="C7465445"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="2FE91482"/>
+        </Element>
+        <Element Type="Param" Id="22F7EF81">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+            <FunctionCall Type="FunctionCall" Library="5BD4895D" Id="0A225374"/>
+        </Element>
+        <Element Type="FunctionCall" Id="0A225374">
+            <FunctionDef Type="FunctionDef" Library="Ntve" Id="40844EC3"/>
+            <Parameter Type="Param" Library="5BD4895D" Id="2F6413C9"/>
+        </Element>
+        <Element Type="Param" Id="2F6413C9">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="51D3A7CE"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="BE13E79D"/>
+        </Element>
+        <Element Type="Param" Id="C7465445">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+            <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+        </Element>
+        <Element Type="Param" Id="2FE91482">
+            <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+            <Value>true</Value>
+            <ValueType Type="bool"/>
         </Element>
         <Element Type="Category" Id="A6ED77DD">
             <Item Type="Comment" Library="5BD4895D" Id="E6E61AFB"/>

--- a/Mods/ArchipelagoCore.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
+++ b/Mods/ArchipelagoCore.SC2Mod/enUS.SC2Data/LocalizedData/GameStrings.txt
@@ -22,6 +22,7 @@ Param/Value/lib_5BD4895D_CF8E4FDB=)</s>
 Param/Value/lib_5BD4895D_D237E34D=)</s>
 Param/Value/lib_5BD4895D_E339DF85=1 check
 Param/Value/lib_5BD4895D_E71C1AAC= <s val="ObjectivePanelChecks">(
+Param/Value/lib_5BD4895D_FD3A182F=DEBUG: Mission was started from Editor, running with default settings
 UI/ChallengeObjectives=Challenge Objectives
 UI/MasteryObjectives=Mastery Objectives
 Unit/Name/AP_Core_Controller=Archipelago Controller


### PR DESCRIPTION
This is a fix/QoL change, which allows developers to load up an AP campaign mission into the editor and start it directly using the "Test Document" button. Previously, missions tested this way would just be softlocked in a blackscreen and wait for the communication with the AP bot indefinitely.

 It uses a native condition to check, if the map is started as a test document, and in that case just skips the communication with the client and finishes loading with default settings.

<img width="486" height="103" alt="grafik" src="https://github.com/user-attachments/assets/b1e76469-367e-407d-9b59-1340be8901cd" />

Displays a message ingame:

<img width="1097" height="551" alt="grafik" src="https://github.com/user-attachments/assets/ed995570-2969-41fc-b6c8-c9c8d843eafe" />

Having the ability to quickly test a change with 1 button press can be very useful. Also maps started as test documents do have unique properties, for example they display error messages and warnings, which are hidden when starting the mission regularly and can be useful for debugging or finding potential future issues.

Since it checks specifically for the test document state, there is no effect on any missions started from an actual campaign.