### PR TITLE
fix Gates of Hell broken trigger reference

### DIFF
--- a/Maps/ArchipelagoCampaign/WoL/ap_gates_of_hell.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/WoL/ap_gates_of_hell.SC2Map/MapScript.galaxy
@@ -1494,7 +1494,7 @@ bool gt_FactionSwapInit_Func (bool testConds, bool runActions) {
                     for (;; autoC3737AAA_u -= 1) {
                         lv_bunkerunit = UnitGroupUnitFromEnd(autoC3737AAA_g, autoC3737AAA_u);
                         if (lv_bunkerunit == null) { break; }
-                        lib15EF4C78_gf_Stukov_NewBunkerUnitProcess(lv_bunkerunit);
+                        lib15EF4C78_gf_Stukov_NewBunkerUnitProcess(lv_bunkerunit, lv_bunkerunit);
                     }
                 }
 

--- a/Maps/ArchipelagoCampaign/WoL/ap_gates_of_hell.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/WoL/ap_gates_of_hell.SC2Map/MapScript.galaxy
@@ -1494,7 +1494,7 @@ bool gt_FactionSwapInit_Func (bool testConds, bool runActions) {
                     for (;; autoC3737AAA_u -= 1) {
                         lv_bunkerunit = UnitGroupUnitFromEnd(autoC3737AAA_g, autoC3737AAA_u);
                         if (lv_bunkerunit == null) { break; }
-                        lib15EF4C78_gf_Stukov_NewBunkerUnitProcess(lv_bunkerunit, lv_bunkerunit);
+                        lib15EF4C78_gf_Stukov_NewBunkerUnitProcess(autoB60DE566_var, lv_bunkerunit);
                     }
                 }
 

--- a/Maps/ArchipelagoCampaign/WoL/ap_gates_of_hell.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/WoL/ap_gates_of_hell.SC2Map/Triggers
@@ -2800,7 +2800,10 @@
     </Element>
     <Element Type="Param" Id="5D332E63">
         <ParameterDef Type="ParamDef" Library="15EF4C78" Id="45A1C25F"/>
-        <Variable Type="Variable" Id="D9E2C278"/>
+        <FunctionCall Type="FunctionCall" Id="2690CEFC"/>
+    </Element>
+    <Element Type="FunctionCall" Id="2690CEFC">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="19CE733E"/>
     </Element>
     <Element Type="FunctionCall" Id="2DDF34E1">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>

--- a/Maps/ArchipelagoCampaign/WoL/ap_gates_of_hell.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/WoL/ap_gates_of_hell.SC2Map/Triggers
@@ -2792,9 +2792,14 @@
         <FunctionDef Type="FunctionDef" Library="15EF4C78" Id="EE97ED69"/>
         <SubFunctionType Type="SubFuncType" Library="Ntve" Id="00000007"/>
         <Parameter Type="Param" Id="7C47CDF9"/>
+        <Parameter Type="Param" Id="5D332E63"/>
     </Element>
     <Element Type="Param" Id="7C47CDF9">
         <ParameterDef Type="ParamDef" Library="15EF4C78" Id="09282B3A"/>
+        <Variable Type="Variable" Id="D9E2C278"/>
+    </Element>
+    <Element Type="Param" Id="5D332E63">
+        <ParameterDef Type="ParamDef" Library="15EF4C78" Id="45A1C25F"/>
         <Variable Type="Variable" Id="D9E2C278"/>
     </Element>
     <Element Type="FunctionCall" Id="2DDF34E1">

--- a/docs/debug commands.md
+++ b/docs/debug commands.md
@@ -1,0 +1,90 @@
+Debug commands in Archipelago SC2 are in-game chat commands, intended to be used by developers for testing and bug fixing purposes. They are similar to cheat codes, but usually provide benefits more specific to AP or the current mission. Since they are intended to be used by developers for testing, they often have shorthand variants, to prevent activating these commands by accident it is required to enable Debug Mode first with a separate command. Entering Debug Mode enables all other debug commands. Every Debug command starts with a dash/minus '-'
+
+Debug commmands can be divided into 3 categories:
+
+• Generic: These commands work in ANY Archipelago SC2 mission.
+• Semi Generic: These commands are not implemented in every single mission, but they are shared across many missions where they make sense. Example: Skip to the next section of a mission.
+• Map Specific: These commands test a specific feature of the mission you are currently playing. Example: Complete a bonus objective.
+
+Full list of Debug Commmands:
+
+
+Generic: These commands can be used in any Archipelago SC2 mission
+
+-debug, -d: Activate Debug Mode, required to use all the other debug commands
+
+
+-control x: Take one-sided control of player x
+-reapply: Reapplies default behaviors to all your units. Fixes certain bugs where units do not get all benefits from their items
+-resetbase, -reset: Resets many aspects of your main base, including Spear of Adun energy/cooldown and Merc cooldown
+-skip, -s: Skips all transmissions currently playing, and allows other triggers queued after these transmissions to progress the mission state
+-clear, -c: Clears the action queue, retaining the one action currently running. WARNING: This can soft-lock your game!
+
+-win: Ends the mission in victory, granting the victory location (intended to work in all missions, does not work for all missions at this time)
+-revive, -r: Revives your heroes instantly (currently only works with Kerrigan, intended to work with other heroes like Nova)
+
+
+Semi-generic: These commands are not implemented in every single mission, but they are shared across multiple missions where they make sense
+
+-sx: Skip to Section X. This command is implemented in most missions that have multiple sections. For example, typing '-s2' in the mission "The Dig" will skip Section 1, the Siege Tank introduction and proceed to Section 2, the defense of the Laser Drill.
+
+This is intended to be a prototype for the future implementation of a Checkpoint system.
+
+
+
+Map Specific: These commands only work for one (or a few) specific missions, usually to test a mechanic only used in that mission.
+
+Rendezvous:
+
+-fenix: Spawns Fenix in the enemy base (test for the final reinforcement wave for Protoss raceswap)
+
+With Friends like these:
+
+-FullPower: All Hyperion upgrades.
+
+Templar's Return:
+
+-openX: Open Door X
+
+The Infinite Cycle:
+
+-holdoutX, -hX: Skips to the specified "holdout" sections. The semi-generic -sX command skips to after the holdouts instead.
+
+The Escape:
+
+-s3: This skips to the Vulture freeway escape section, which is normally not accessible in Archipelago.
+
+Breakout:
+
+-freeX: Complete bonus objective X, freeing the prisoners.
+
+Gates of Hell
+
+-drop: Spawn the next drop pod. Currently only works for the very first drop pod.
+
+Piercing the Shroud:
+
+-ammo: Replenish your abilities.
+
+Zero Hour:
+
+-spawn: Make the next rescues appear on the Map.
+-flank: Trigger a flank attack.
+-drop: Trigger a Zerg drop pod.
+-color: Make the different zerg players use different colors.
+
+
+Into the Void:
+
+-fX: Establish Forward Bases. 1,2,3 for Raynor, Kerrigan or Artanis AI (only available if the respective AI controls one of the bases). Each use will make the AI progress 1 "step".
+-bX: Finish the 4 Bonus Objectives.
+-tX: Spawn Void Thrasher attacking Player X, 1,2,3 being Raynor, Kerrigan or Artanis.
+
+Amon's Fall:
+
+-eat: Trigger Amon to destroy the next base in the cycle.
+
+The Essence of Eternity
+
+-revive, -r: Instantly revives all heroes used by your allies (or yourself if playing with ally control enabled).
+


### PR DESCRIPTION
Fixes a bug reported on Discord. Gates of Hell lost a trigger reference for some reason, which lead to an invalid script file.

Also added the documentation for debug commands.