### PR TITLE
fix Greater Hydralisk Den morph animation

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -18450,6 +18450,8 @@
         <On Terms="AbilMorph.*.Cancel; MorphTo AP_ImpalerDen" Send="AnimPlay Rebirth Build,D,Start 0 0.000000 0.000000 0.300000 AsDuration"/>
         <On Terms="Effect.HydraliskDenMorphFinishDummy.Start" Send="StatusSet MorphAnim 1"/>
         <On Terms="Effect.HydraliskDenMorphFinishDummy.Start" Send="AnimClear Waiting"/>
+        <On Terms="AbilMorph.*.Finish; MorphTo AP_LurkerDen; AnimPlaying Morph" Send="Create AP_LurkerDen"/>
+        <On Terms="AbilMorph.*.Finish; MorphTo AP_LurkerDen; AnimPlaying Morph" Send="Destroy"/>
         <Model value="HydraliskDen"/>
         <BuildModel value="HydraliskDen"/>
         <DeathArray index="Normal" ModelLink="HydraliskDenDeath" SoundLink="HydraliskDen_Explode"/>

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/SoundData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/SoundData.xml
@@ -15756,4 +15756,14 @@
         <DupeDestroyCount value="10"/>
         <DupeMuteCount value="5"/>
     </CSound>
+    <CSound id="Uni_DeathFXRagdollFire" parent="Death">
+        <AssetArray File="Assets\Sounds\Uni\Deaths\Uni_DeathFXFire0.wav"/>
+        <AssetArray File="Assets\Sounds\Uni\Deaths\Uni_DeathFXFire1.wav"/>
+        <AssetArray File="Assets\Sounds\Uni\Deaths\Uni_DeathFXFire2.wav"/>
+        <AssetArray File="Assets\Sounds\Uni\Deaths\Uni_DeathFXFire3.wav"/>
+        <AssetArray File="Assets\Sounds\Uni\Deaths\Uni_DeathFXFire4.wav"/>
+        <AssetArray File="Assets\Sounds\Uni\Deaths\Uni_DeathFXFire5.wav"/>
+        <Pitch value="-2.000000,2.000000"/>
+        <Volume value="-6.000000,-6.000000"/>
+    </CSound>
 </Catalog>


### PR DESCRIPTION
Animation would break if build times get too fast. Added a fallback event.

also fixes a warning message from a missing sound object