### PR TITLE
fix Spear of Adun energy display

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/Lib15EF4C78.galaxy
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/Lib15EF4C78.galaxy
@@ -1418,6 +1418,7 @@ void lib15EF4C78_gf_PU_GPSetUnit (unit lp_casterUnit) {
     UnitGroupAdd(lib15EF4C78_gv_pU_GPCasterGroup, lp_casterUnit);
     libNtve_gf_SetDialogItemUnitGroup(lib15EF4C78_gv_pU_GPCmdPanel, lib15EF4C78_gv_pU_GPCasterGroup, PlayerGroupAll());
     lib15EF4C78_gf_PU_GPVitalsUpdate();
+    TriggerEnable(lib15EF4C78_gt_PU_GPVitalChanges, true);
 }
 
 void lib15EF4C78_gf_ShowSpearofAdunUI (bool lp_showHide, fixed lp_duration) {
@@ -6671,6 +6672,13 @@ void lib15EF4C78_gt_PU_GPInit_Init () {
 //--------------------------------------------------------------------------------------------------
 bool lib15EF4C78_gt_PU_GPVitalChanges_Func (bool testConds, bool runActions) {
     // Automatic Variable Declarations
+    // Conditions
+    if (testConds) {
+        if (!((UnitIsValid(lib15EF4C78_gv_pU_GPUnit) == true))) {
+            return false;
+        }
+    }
+
     // Actions
     if (!runActions) {
         return true;
@@ -6683,6 +6691,7 @@ bool lib15EF4C78_gt_PU_GPVitalChanges_Func (bool testConds, bool runActions) {
 //--------------------------------------------------------------------------------------------------
 void lib15EF4C78_gt_PU_GPVitalChanges_Init () {
     lib15EF4C78_gt_PU_GPVitalChanges = TriggerCreate("lib15EF4C78_gt_PU_GPVitalChanges_Func");
+    TriggerEnable(lib15EF4C78_gt_PU_GPVitalChanges, false);
     TriggerAddEventUnitProperty(lib15EF4C78_gt_PU_GPVitalChanges, UnitRefFromVariable("lib15EF4C78_gv_pU_GPUnit"), c_unitPropEnergy);
 }
 


### PR DESCRIPTION
If a mission does not have a Spear of Adun caster unit set up (disabled in settings, no SoA item yet, no LotV mission...), the trigger to update the energy for the SoA UI will not have a valid unit for the event. This causes it to fire for every single energy change for all units in the map. Depending on the map, this can easily be several thousand times per second.

This fix turns off the trigger by default, and only turns it on, once a valid unit is set. It also adds a condition to the trigger, so that even if it is turned on, it will check, if the SoA caster unit is valid.

Tested in local testmap, made sure it works in scenarios where you have no SoA, have SoA from the start, have a no-build section without SoA or get your first SoA item over the course of a mission.