### PR TITLE
SC2: Add debug commands to Evil Awoken

### DIFF
--- a/Maps/ArchipelagoCampaign/LotV/ap_evil_awoken.SC2Map/MapScript.galaxy
+++ b/Maps/ArchipelagoCampaign/LotV/ap_evil_awoken.SC2Map/MapScript.galaxy
@@ -220,6 +220,7 @@ trigger gt_Init06Difficulties;
 trigger gt_Init07Help;
 trigger gt_DEBUGS2;
 trigger gt_DEBUGS3;
+trigger gt_DEBUGVictory;
 trigger gt_StartAI;
 trigger gt_GeneralAttackAI;
 trigger gt_TaldarimResources;
@@ -1433,7 +1434,7 @@ bool gt_DEBUGS2_Func (bool testConds, bool runActions) {
     // Automatic Variable Declarations
     // Conditions
     if (testConds) {
-        if (!((GameCheatsEnabled(c_gameCheatCategoryDevelopment) == true))) {
+        if (!((libABFE498B_gv_aP_Triggers_DebugMode == true))) {
             return false;
         }
 
@@ -1498,8 +1499,8 @@ bool gt_DEBUGS2_Func (bool testConds, bool runActions) {
 //--------------------------------------------------------------------------------------------------
 void gt_DEBUGS2_Init () {
     gt_DEBUGS2 = TriggerCreate("gt_DEBUGS2_Func");
-    TriggerAddEventChatMessage(gt_DEBUGS2, c_playerAny, "s2", true);
-    TriggerAddEventChatMessage(gt_DEBUGS2, c_playerAny, "stage2", true);
+    TriggerAddEventChatMessage(gt_DEBUGS2, c_playerAny, "-s2", true);
+    TriggerAddEventChatMessage(gt_DEBUGS2, c_playerAny, "-stage2", true);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1509,7 +1510,7 @@ bool gt_DEBUGS3_Func (bool testConds, bool runActions) {
     // Automatic Variable Declarations
     // Conditions
     if (testConds) {
-        if (!((GameCheatsEnabled(c_gameCheatCategoryDevelopment) == true))) {
+        if (!((libABFE498B_gv_aP_Triggers_DebugMode == true))) {
             return false;
         }
 
@@ -1556,8 +1557,50 @@ bool gt_DEBUGS3_Func (bool testConds, bool runActions) {
 //--------------------------------------------------------------------------------------------------
 void gt_DEBUGS3_Init () {
     gt_DEBUGS3 = TriggerCreate("gt_DEBUGS3_Func");
-    TriggerAddEventChatMessage(gt_DEBUGS3, c_playerAny, "s3", true);
-    TriggerAddEventChatMessage(gt_DEBUGS3, c_playerAny, "stage3", true);
+    TriggerAddEventChatMessage(gt_DEBUGS3, c_playerAny, "-s3", true);
+    TriggerAddEventChatMessage(gt_DEBUGS3, c_playerAny, "-stage3", true);
+}
+
+//--------------------------------------------------------------------------------------------------
+// Trigger: DEBUG - Victory
+//--------------------------------------------------------------------------------------------------
+bool gt_DEBUGVictory_Func (bool testConds, bool runActions) {
+    // Automatic Variable Declarations
+    // Conditions
+    if (testConds) {
+        if (!((libABFE498B_gv_aP_Triggers_DebugMode == true))) {
+            return false;
+        }
+
+        if (!((gv_gameOver == false))) {
+            return false;
+        }
+
+        if (!((gv_inCinematic == false))) {
+            return false;
+        }
+
+        if (!((TriggerIsEnabled(TriggerGetCurrent()) == true))) {
+            return false;
+        }
+    }
+
+    // Actions
+    if (!runActions) {
+        return true;
+    }
+
+    TriggerEnable(TriggerGetCurrent(), false);
+    TriggerStop(gt_StartGameSection3Q);
+    TriggerStop(gt_StartGameSection3Q);
+    TriggerExecute(gt_VictoryEscapeComplete, true, false);
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+void gt_DEBUGVictory_Init () {
+    gt_DEBUGVictory = TriggerCreate("gt_DEBUGVictory_Func");
+    TriggerAddEventChatMessage(gt_DEBUGVictory, c_playerAny, "-win", true);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -10563,6 +10606,7 @@ void InitTriggers () {
     gt_Init07Help_Init();
     gt_DEBUGS2_Init();
     gt_DEBUGS3_Init();
+    gt_DEBUGVictory_Init();
     gt_StartAI_Init();
     gt_GeneralAttackAI_Init();
     gt_TaldarimResources_Init();

--- a/Maps/ArchipelagoCampaign/LotV/ap_evil_awoken.SC2Map/Triggers
+++ b/Maps/ArchipelagoCampaign/LotV/ap_evil_awoken.SC2Map/Triggers
@@ -4530,6 +4530,7 @@
     <Element Type="Category" Id="747B697E">
         <Item Type="Trigger" Id="3CEF7378"/>
         <Item Type="Trigger" Id="7179CA5C"/>
+        <Item Type="Trigger" Id="80DB4170"/>
     </Element>
     <Element Type="Trigger" Id="3CEF7378">
         <Event Type="FunctionCall" Id="AC73E5AF"/>
@@ -4580,7 +4581,7 @@
     </Element>
     <Element Type="Param" Id="54049B82">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="00000192"/>
-        <Value>s2</Value>
+        <Value>-s2</Value>
         <ValueType Type="string"/>
     </Element>
     <Element Type="FunctionCall" Id="0EE50113">
@@ -4599,7 +4600,7 @@
     </Element>
     <Element Type="Param" Id="DE131490">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="00000192"/>
-        <Value>stage2</Value>
+        <Value>-stage2</Value>
         <ValueType Type="string"/>
     </Element>
     <Element Type="FunctionCall" Id="1D0E37A6">
@@ -4610,15 +4611,7 @@
     </Element>
     <Element Type="Param" Id="36EBEBC0">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
-        <FunctionCall Type="FunctionCall" Id="56009902"/>
-    </Element>
-    <Element Type="FunctionCall" Id="56009902">
-        <FunctionDef Type="FunctionDef" Library="Ntve" Id="3CE0B2FC"/>
-        <Parameter Type="Param" Id="24578A7B"/>
-    </Element>
-    <Element Type="Param" Id="24578A7B">
-        <ParameterDef Type="ParamDef" Library="Ntve" Id="45211CA0"/>
-        <Preset Type="PresetValue" Library="Ntve" Id="A1D24908"/>
+        <Variable Type="Variable" Library="ABFE498B" Id="4644CBA9"/>
     </Element>
     <Element Type="Param" Id="46BB29D5">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
@@ -5305,7 +5298,7 @@
     <Element Type="Trigger" Id="7179CA5C">
         <Event Type="FunctionCall" Id="7D8B487E"/>
         <Event Type="FunctionCall" Id="08F60174"/>
-        <Condition Type="FunctionCall" Id="05A06957"/>
+        <Condition Type="FunctionCall" Id="24AAB345"/>
         <Condition Type="FunctionCall" Id="9341B470"/>
         <Condition Type="FunctionCall" Id="F9DD1E82"/>
         <Condition Type="FunctionCall" Id="1DC3BF1B"/>
@@ -5331,7 +5324,7 @@
     </Element>
     <Element Type="Param" Id="9BEA4E72">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="00000192"/>
-        <Value>s3</Value>
+        <Value>-s3</Value>
         <ValueType Type="string"/>
     </Element>
     <Element Type="FunctionCall" Id="08F60174">
@@ -5350,32 +5343,24 @@
     </Element>
     <Element Type="Param" Id="AA81AFC0">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="00000192"/>
-        <Value>stage3</Value>
+        <Value>-stage3</Value>
         <ValueType Type="string"/>
     </Element>
-    <Element Type="FunctionCall" Id="05A06957">
+    <Element Type="FunctionCall" Id="24AAB345">
         <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
-        <Parameter Type="Param" Id="8DFF168A"/>
-        <Parameter Type="Param" Id="BBF88885"/>
-        <Parameter Type="Param" Id="3C7FF3BA"/>
+        <Parameter Type="Param" Id="1FE9D990"/>
+        <Parameter Type="Param" Id="82175EA4"/>
+        <Parameter Type="Param" Id="033FA762"/>
     </Element>
-    <Element Type="Param" Id="8DFF168A">
+    <Element Type="Param" Id="1FE9D990">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
-        <FunctionCall Type="FunctionCall" Id="02BAF0C4"/>
+        <Variable Type="Variable" Library="ABFE498B" Id="4644CBA9"/>
     </Element>
-    <Element Type="FunctionCall" Id="02BAF0C4">
-        <FunctionDef Type="FunctionDef" Library="Ntve" Id="3CE0B2FC"/>
-        <Parameter Type="Param" Id="8F5549CD"/>
-    </Element>
-    <Element Type="Param" Id="8F5549CD">
-        <ParameterDef Type="ParamDef" Library="Ntve" Id="45211CA0"/>
-        <Preset Type="PresetValue" Library="Ntve" Id="A1D24908"/>
-    </Element>
-    <Element Type="Param" Id="BBF88885">
+    <Element Type="Param" Id="82175EA4">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
         <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
     </Element>
-    <Element Type="Param" Id="3C7FF3BA">
+    <Element Type="Param" Id="033FA762">
         <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
         <Value>true</Value>
         <ValueType Type="bool"/>
@@ -5670,6 +5655,176 @@
         <ParameterDef Type="ParamDef" Library="Ntve" Id="00000182"/>
         <ValueType Type="trigger"/>
         <ValueElement Type="Trigger" Id="52EE8CB0"/>
+    </Element>
+    <Element Type="Trigger" Id="80DB4170">
+        <Event Type="FunctionCall" Id="24D5C90F"/>
+        <Condition Type="FunctionCall" Id="737B98B9"/>
+        <Condition Type="FunctionCall" Id="C399BD2E"/>
+        <Condition Type="FunctionCall" Id="69A7E75F"/>
+        <Condition Type="FunctionCall" Id="477EB322"/>
+        <Action Type="FunctionCall" Id="3F0E3825"/>
+        <Action Type="FunctionCall" Id="E9AF68C8"/>
+        <Action Type="FunctionCall" Id="AF1A476E"/>
+        <Action Type="FunctionCall" Id="2E756754"/>
+    </Element>
+    <Element Type="FunctionCall" Id="24D5C90F">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000121"/>
+        <Parameter Type="Param" Id="8DE703D1"/>
+        <Parameter Type="Param" Id="F0DCA5A5"/>
+        <Parameter Type="Param" Id="CA9343A3"/>
+    </Element>
+    <Element Type="Param" Id="8DE703D1">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000191"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="2999701E"/>
+    </Element>
+    <Element Type="Param" Id="F0DCA5A5">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000193"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="00000073"/>
+    </Element>
+    <Element Type="Param" Id="CA9343A3">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000192"/>
+        <Value>-win</Value>
+        <ValueType Type="string"/>
+    </Element>
+    <Element Type="FunctionCall" Id="737B98B9">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <Parameter Type="Param" Id="D8F9D300"/>
+        <Parameter Type="Param" Id="A7327251"/>
+        <Parameter Type="Param" Id="E8195F32"/>
+    </Element>
+    <Element Type="Param" Id="D8F9D300">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <Variable Type="Variable" Library="ABFE498B" Id="4644CBA9"/>
+    </Element>
+    <Element Type="Param" Id="A7327251">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="E8195F32">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>true</Value>
+        <ValueType Type="bool"/>
+    </Element>
+    <Element Type="FunctionCall" Id="C399BD2E">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <Parameter Type="Param" Id="4701C568"/>
+        <Parameter Type="Param" Id="95E4F847"/>
+        <Parameter Type="Param" Id="F0130C0E"/>
+    </Element>
+    <Element Type="Param" Id="4701C568">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <Variable Type="Variable" Id="05B1C009"/>
+    </Element>
+    <Element Type="Param" Id="95E4F847">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="F0130C0E">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>false</Value>
+        <ValueType Type="bool"/>
+    </Element>
+    <Element Type="FunctionCall" Id="69A7E75F">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <Parameter Type="Param" Id="F8D49281"/>
+        <Parameter Type="Param" Id="52CB6A21"/>
+        <Parameter Type="Param" Id="A76DBFC3"/>
+    </Element>
+    <Element Type="Param" Id="F8D49281">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <Variable Type="Variable" Id="9565F0FC"/>
+    </Element>
+    <Element Type="Param" Id="52CB6A21">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="A76DBFC3">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>false</Value>
+        <ValueType Type="bool"/>
+    </Element>
+    <Element Type="FunctionCall" Id="477EB322">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="C439C375"/>
+        <Parameter Type="Param" Id="AC0215B9"/>
+        <Parameter Type="Param" Id="CEEC1878"/>
+        <Parameter Type="Param" Id="D38C61C7"/>
+    </Element>
+    <Element Type="Param" Id="AC0215B9">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="ABB380C4"/>
+        <FunctionCall Type="FunctionCall" Id="8F284889"/>
+    </Element>
+    <Element Type="FunctionCall" Id="8F284889">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000112"/>
+        <Parameter Type="Param" Id="1046D1AE"/>
+    </Element>
+    <Element Type="Param" Id="1046D1AE">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000178"/>
+        <FunctionCall Type="FunctionCall" Id="C757D964"/>
+    </Element>
+    <Element Type="FunctionCall" Id="C757D964">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000217"/>
+    </Element>
+    <Element Type="Param" Id="CEEC1878">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="51567265"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="1E7A4625"/>
+    </Element>
+    <Element Type="Param" Id="D38C61C7">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="4A15EC5F"/>
+        <Value>true</Value>
+        <ValueType Type="bool"/>
+    </Element>
+    <Element Type="FunctionCall" Id="3F0E3825">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000111"/>
+        <Parameter Type="Param" Id="934B9E2E"/>
+        <Parameter Type="Param" Id="CD342AEA"/>
+    </Element>
+    <Element Type="Param" Id="934B9E2E">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000176"/>
+        <FunctionCall Type="FunctionCall" Id="D5E7C688"/>
+    </Element>
+    <Element Type="FunctionCall" Id="D5E7C688">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000217"/>
+    </Element>
+    <Element Type="Param" Id="CD342AEA">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000177"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="00000545"/>
+    </Element>
+    <Element Type="FunctionCall" Id="E9AF68C8">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="698FE891"/>
+        <Parameter Type="Param" Id="2B3A51CE"/>
+    </Element>
+    <Element Type="Param" Id="2B3A51CE">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="13A87DA8"/>
+        <ValueType Type="trigger"/>
+        <ValueElement Type="Trigger" Id="014F6D7C"/>
+    </Element>
+    <Element Type="FunctionCall" Id="AF1A476E">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="698FE891"/>
+        <Parameter Type="Param" Id="C52A3D99"/>
+    </Element>
+    <Element Type="Param" Id="C52A3D99">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="13A87DA8"/>
+        <ValueType Type="trigger"/>
+        <ValueElement Type="Trigger" Id="014F6D7C"/>
+    </Element>
+    <Element Type="FunctionCall" Id="2E756754">
+        <FunctionDef Type="FunctionDef" Library="Ntve" Id="00000116"/>
+        <Parameter Type="Param" Id="67AA7807"/>
+        <Parameter Type="Param" Id="46CCA077"/>
+        <Parameter Type="Param" Id="DFE72D7B"/>
+    </Element>
+    <Element Type="Param" Id="67AA7807">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000183"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="00000065"/>
+    </Element>
+    <Element Type="Param" Id="46CCA077">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000184"/>
+        <Preset Type="PresetValue" Library="Ntve" Id="00000068"/>
+    </Element>
+    <Element Type="Param" Id="DFE72D7B">
+        <ParameterDef Type="ParamDef" Library="Ntve" Id="00000182"/>
+        <ValueType Type="trigger"/>
+        <ValueElement Type="Trigger" Id="1394A8A3"/>
     </Element>
     <Element Type="Category" Id="00D055C7">
         <Item Type="Category" Id="068E9D70"/>

--- a/Maps/ArchipelagoCampaign/LotV/ap_evil_awoken.SC2Map/enUS.SC2Data/LocalizedData/TriggerStrings.txt
+++ b/Maps/ArchipelagoCampaign/LotV/ap_evil_awoken.SC2Map/enUS.SC2Data/LocalizedData/TriggerStrings.txt
@@ -166,6 +166,7 @@ Trigger/Name/7AA0EA09=S2 - Amon Q
 Trigger/Name/7B27AFF3=S2 - Gauntlet Prep
 Trigger/Name/7CD31D2E=S3 - Final Stretch Escalation 2
 Trigger/Name/7D050986=S1 - Observer Room Warp Attack 02
+Trigger/Name/80DB4170=DEBUG - Victory
 Trigger/Name/82743864=S1 - Teach Blink Initial Attack Q
 Trigger/Name/835321BF=BO - Unit Warps In
 Trigger/Name/83E23CF4=Objective - Destroy Catalyst - Create

--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/UnitData.xml
@@ -1172,6 +1172,7 @@
             <LayoutButtons Face="Cancel" Type="AbilCmd" AbilCmd="AP_VultureQueue3,0" Row="2" Column="4"/>
         </CardLayouts>
         <Radius value="0.625"/>
+        <InnerRadius value="0.5"/>
         <SeparationRadius value="0.625"/>
         <CargoSize value="2"/>
         <ScoreMake value="75"/>
@@ -1261,6 +1262,7 @@
             <LayoutButtons Face="AP_GoliathShapedHull" Type="Passive" Requirements="AP_HaveGoliathShapedHull" Row="1" Column="2"/>
         </CardLayouts>
         <Radius value="0.6875"/>
+        <InnerRadius value="0.5"/>
         <SeparationRadius value="0.65"/>
         <CargoSize value="2"/>
         <ScoreMake value="200"/>
@@ -16252,7 +16254,7 @@
         </CardLayouts>
         <Radius value="1"/>
         <SeparationRadius value="0.75"/>
-        <InnerRadius value="0.75"/>
+        <InnerRadius value="0.5625"/>
         <CargoSize value="4"/>
         <ScoreKill value="450"/>
         <ScoreResult value="BuildOrder"/>


### PR DESCRIPTION
Fixed missing Inner Radius for following units
- Vulture
- Goliath
- Dark Archon (to match regular Archon)

Caused issues with unintuitive collision behavior against hard edges like buildings and cliffs. Vultures were considered a bigger collision size than Colossus for example.

Evil Awoken: Added Debug commands

- -s2 -> Skip to Section 2
- -s3 -> Skip to Section 3
- -win -> Victory