### PR TITLE
SC2: Fix Infested Medic Heal Sound

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/ActorData.xml
@@ -2834,7 +2834,7 @@
         <On Terms="Abil.AP_MengskMedicHealPlusMech.TargetChannelStart" Send="Create"/>
         <On Terms="Abil.AP_MengskMedicHealPlusMech.TargetChannelStop" Send="Destroy"/>
         <On Terms="Abil.AP_InfestedMedicMercHeal.TargetChannelStart" Send="Create"/>
-        <On Terms="Abil.AP_AP_InfestedMedicMercHeal.TargetChannelStop" Send="Destroy"/>
+        <On Terms="Abil.AP_InfestedMedicMercHeal.TargetChannelStop" Send="Destroy"/>
         <On Terms="Abil.AP_InfestedMedicMercHealPlusMech.TargetChannelStart" Send="Create"/>
         <On Terms="Abil.AP_InfestedMedicMercHealPlusMech.TargetChannelStop" Send="Destroy"/>
         <On Terms="ActorOrphan" Send="Destroy"/>


### PR DESCRIPTION
Fixed an issue where Infested Medic Heal would play the heal sound but never stop it.