### PR TITLE
sc2: Remove AI threat flags from baneling explode abilities to avoid AI jank

### DIFF
--- a/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
+++ b/Mods/ArchipelagoPlayer.SC2Mod/Base.SC2Data/GameData/EffectData.xml
@@ -4852,8 +4852,6 @@
         <EditorCategories value="Race:Zerg"/>
         <SearchFilters value="-;Missile,Stasis,Dead,Hidden"/>
         <AreaArray Radius="0.5" Effect="AP_RavagerCorrosiveBileSet"/>
-<!--        <AINotifyFlags index="HurtFriend" value="1"/>-->
-<!--        <AINotifyFlags index="HurtEnemy" value="1"/>-->
     </CEffectEnumArea>
     <CEffectEnumArea id="AP_RavagerCorrosiveBileWarningDummySearch">
         <EditorCategories value="Race:Zerg"/>
@@ -10541,7 +10539,6 @@
     </CEffectSet>
     <CEffectDamage id="AP_HotSBanelingExplodeLargeDirect" parent="DU_WEAP">
         <EditorCategories value="Race:Zerg"/>
-        <AINotifyFlags index="HurtEnemy" value="1"/>
         <AttributeBonus index="Structure" value="40"/>
         <Kind value="Splash"/>
         <Amount value="40"/>
@@ -10597,7 +10594,6 @@
     </CEffectEnumArea>
     <CEffectDamage id="AP_HotSBanelingExplodeLargeSearchDamage" parent="DU_WEAP">
         <EditorCategories value="Race:Zerg"/>
-        <AINotifyFlags index="HurtEnemy" value="1"/>
         <ImpactLocation Value="TargetUnit"/>
         <AttributeBonus index="Structure" value="40"/>
         <Kind value="Splash"/>
@@ -10621,7 +10617,6 @@
     </CEffectSwitch>
     <CEffectDamage id="AP_HotSBanelingExplodeSmallDirect" parent="DU_WEAP">
         <EditorCategories value="Race:Zerg"/>
-        <AINotifyFlags index="HurtEnemy" value="1"/>
         <AttributeBonus index="Structure" value="5"/>
         <Kind value="Splash"/>
         <Amount value="5"/>
@@ -10676,7 +10671,6 @@
     </CEffectEnumArea>
     <CEffectDamage id="AP_HotSBanelingExplodeSmallSearchDamage" parent="DU_WEAP">
         <EditorCategories value="Race:Zerg"/>
-        <AINotifyFlags index="HurtEnemy" value="1"/>
         <ImpactLocation Value="TargetUnit"/>
         <AttributeBonus index="Structure" value="5"/>
         <Kind value="Splash"/>
@@ -10784,7 +10778,6 @@
     </CEffectLaunchMissile>
     <CEffectDamage id="AP_VolatileBurstU" parent="DU_WEAP">
         <EditorCategories value="Race:Zerg"/>
-        <AINotifyFlags index="HurtEnemy" value="1"/>
         <ImpactLocation Value="CasterUnit"/>
         <Kind value="Splash"/>
         <KindSplash value="Splash"/>
@@ -11529,7 +11522,6 @@
     </CEffectEnumArea>
     <CEffectEnumArea id="AP_OracleStasisTrapActivate">
         <EditorCategories value="Race:Protoss"/>
-        <AINotifyFlags index="HurtEnemy" value="1"/>
         <ImpactLocation Value="CasterUnit"/>
         <SearchFilters value="Ground;Self,Player,Ally,Neutral,Structure,Missile,Destructible,Stasis,Dead,Hidden,Invulnerable"/>
         <AreaArray Radius="5" Effect="AP_OracleStasisTrapSearchSet"/>


### PR DESCRIPTION
This has been reported as a bug so many times and every time I run into it I get irritated by it.

I know it's a vanilla thing, but frankly I consider it a vanilla bug. That we should fix. And bug reports seem to indicate I'm not alone in thinking that. And the fact that e.g. Mutalisks would flee from banelings is clearly bug territory.

Removed the flag from Oracle Stasis Trap because it has all the same qualities that make banelings, ravagers, disruptors, and liberators feel buggy with this behaviour: the effect is persistent and may form walls before enemies approach. Left the flag on things like storms, as those appear instantaneously (though I think it's worth investigating what it's like if the flag is removed from storm).